### PR TITLE
feat: goto control

### DIFF
--- a/src/components/inputs/CoordinateNumberInput.vue
+++ b/src/components/inputs/CoordinateNumberInput.vue
@@ -1,9 +1,12 @@
 <style scoped>
-
+    .coordinate >>> .v-input__slot {
+        min-height: 36px !important;
+    }
 </style>
 
 <template>
     <v-text-field
+        class="coordinate"
         v-model="coordinate"
         :prefix="label"
         @change="changed"

--- a/src/components/inputs/CoordinateNumberInput.vue
+++ b/src/components/inputs/CoordinateNumberInput.vue
@@ -1,0 +1,50 @@
+<style scoped>
+
+</style>
+
+<template>
+    <v-text-field
+        v-model="coordinate"
+        :prefix="label"
+        @change="changed"
+        @keyup="changed"
+        outlined
+        hide-details
+        :rules="nameRules"
+        dense
+    ></v-text-field>
+</template>
+
+<script lang="ts">
+import {Component, Mixins, Prop, VModel} from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+
+@Component
+export default class CoordinateNumberInput extends Mixins(BaseMixin) {
+    @VModel({ type: String }) coordinate!: string
+
+    @Prop({ type: Number, required: true }) readonly maxValue!: number
+    @Prop({ type: Number, required: true }) readonly minValue!: number
+    @Prop({ type: String, required: true }) readonly label!: string
+
+    nameRules = [
+        (v: string) => v === '' || this.isInRange(parseFloat(v)) || 'Out of range',
+    ]
+
+    private isInRange(value: number): boolean {
+        return value <= this.maxValue && value >= this.minValue
+    }
+
+    changed() {
+        if (!this.coordinate.match(/^-?(\d+(\.|,)?\d*)?$/)) {
+            const parsed = parseFloat(this.coordinate)
+            if (!isNaN(parsed)) {
+                this.coordinate = parsed.toString()
+            } else {
+                this.coordinate = ''
+            }
+        }
+    }
+
+}
+</script>

--- a/src/components/panels/ControlPanel.vue
+++ b/src/components/panels/ControlPanel.vue
@@ -32,6 +32,7 @@
             <control-panel-cross-control v-if="controlStyle === 'cross'"></control-panel-cross-control>
             <control-panel-circle-control v-else-if="controlStyle === 'circle'"></control-panel-circle-control>
             <control-panel-bars-control v-else></control-panel-bars-control>
+            <control-panel-goto-control></control-panel-goto-control>
             <control-panel-extruder v-if="existsExtruder"></control-panel-extruder>
         </v-container>
     </panel>
@@ -44,11 +45,12 @@ import ControlPanelExtruder from '@/components/panels/ControlPanelExtruder.vue'
 import ControlPanelCrossControl from '@/components/panels/ControlPanelCrossControl.vue'
 import ControlPanelBarsControl from '@/components/panels/ControlPanelBarsControl.vue'
 import ControlPanelCircleControl from '@/components/panels/ControlPanelCircleControl.vue'
+import ControlPanelGotoControl from '@/components/panels/ControlPanelGoToControl.vue'
 import Panel from '@/components/ui/Panel.vue'
 @Component({
     components: {
         Panel,
-        ControlPanelCircleControl, ControlPanelBarsControl, ControlPanelCrossControl, ControlPanelExtruder}
+        ControlPanelCircleControl, ControlPanelBarsControl, ControlPanelCrossControl, ControlPanelExtruder, ControlPanelGotoControl}
 })
 export default class ControlPanel extends Mixins(BaseMixin) {
     get controlStyle() {

--- a/src/components/panels/ControlPanelGoToControl.vue
+++ b/src/components/panels/ControlPanelGoToControl.vue
@@ -1,0 +1,162 @@
+<style lang="scss" scoped>
+.axis-input-group {
+    gap: 10px;
+    display: inline-flex;
+    align-items: center;
+}
+.goto-group {
+    display: inline-flex;
+    align-items: center;
+    padding-top: 5px;
+}
+</style>
+
+<template>
+    <div class="mt-3">
+        <v-form
+            v-model="valid"
+            lazy-validation
+            @submit.prevent="sendCmd"
+        >
+            <div class="goto-group">
+                <div background-color="blue" dark class="axis-input-group">
+                    <coordinate-number-input
+                        label="X"
+                        v-model="coordinate.x"
+                        :min-value="stepperXmin"
+                        :max-value="stepperXmax"></coordinate-number-input>
+                    <coordinate-number-input
+                        label="Y"
+                        v-model="coordinate.y"
+                        :min-value="stepperYmin"
+                        :max-value="stepperYmax"></coordinate-number-input>
+                    <coordinate-number-input
+                        label="Z"
+                        v-model="coordinate.z"
+                        :min-value="stepperZmin"
+                        :max-value="stepperZmax"></coordinate-number-input>
+                    <v-btn color="primary" type="submit" :disabled="!valid || !hasValues">
+                        <v-icon small class="mr-1">mdi-cursor-move</v-icon>
+                        {{ $t('Panels.ControlPanel.Goto') }}
+                    </v-btn>
+                </div>
+            </div>
+        </v-form>
+    </div>
+</template>
+
+<script lang="ts">
+import {Component, Mixins} from 'vue-property-decorator'
+import BaseMixin from '../mixins/base'
+import ControlMixin from '@/components/mixins/control'
+import CoordinateNumberInput from '@/components/inputs/CoordinateNumberInput.vue'
+
+@Component({
+    components: {CoordinateNumberInput}
+})
+export default class ControlPanelGotoControl extends Mixins(BaseMixin, ControlMixin) {
+    valid = true
+
+    coordinate = {
+        x: '',
+        y: '',
+        z: ''
+    }
+
+    get hasValues() {
+        return Object.values(this.coordinate).some(value => value !== '')
+    }
+
+    get absolute_coordinates() {
+        return this.$store.state.printer?.gcode_move?.absolute_coordinates ?? true
+    }
+
+    get stepperXmin() {
+        return this.$store.state.printer.configfile?.settings?.stepper_x?.position_min ?? Number.NEGATIVE_INFINITY
+    }
+
+    get stepperXmax() {
+        return this.$store.state.printer.configfile?.settings?.stepper_x?.position_max ?? Number.POSITIVE_INFINITY
+    }
+
+    get stepperYmin() {
+        return this.$store.state.printer.configfile?.settings?.stepper_y?.position_min ?? Number.NEGATIVE_INFINITY
+    }
+
+    get stepperYmax() {
+        return this.$store.state.printer.configfile?.settings?.stepper_y?.position_max ?? Number.POSITIVE_INFINITY
+    }
+
+    get stepperZmax() {
+        return this.$store.state.printer.configfile?.settings?.stepper_z?.position_max ?? Number.POSITIVE_INFINITY
+    }
+
+    get stepperZmin() {
+        return this.$store.state.printer.configfile?.settings?.stepper_z?.position_min ?? Number.NEGATIVE_INFINITY
+    }
+
+    get feedrateXY() {
+        return this.$store.state.gui.dashboard?.control?.feedrateXY ?? 100
+    }
+
+    get feedrateZ() {
+        return this.$store.state.gui.dashboard?.control?.feedrateZ ?? 10
+    }
+
+    private getZGcode() {
+        const parsedZ = parseFloat(this.coordinate.z)
+
+        if (!isNaN(parsedZ)) {
+            return [`G1 Z${parsedZ} F${this.feedrateZ*60}`]
+        }
+
+        return []
+    }
+
+    private getXYGcode() {
+        const parsedX = parseFloat(this.coordinate.x)
+        const parsedY = parseFloat(this.coordinate.y)
+
+        if (isNaN(parsedX) && isNaN(parsedY)) {
+            return []
+        }
+
+        const xCode = isNaN(parsedX) ? '' : `X${parsedX} `
+        const yCode = isNaN(parsedY) ? '' : `Y${parsedY} `
+
+        return [`G1 ${xCode}${yCode}F${this.feedrateXY*60}`]
+    }
+
+    private getGcode() {
+        if (this.absolute_coordinates) {
+            [
+                ...this.getZGcode(),
+                ...this.getXYGcode(),
+            ].join('\n').trim()
+        }
+
+        return [
+            'G90',
+            ...this.getZGcode(),
+            ...this.getXYGcode(),
+            'G91'
+        ].join('\n').trim()
+    }
+
+    sendCmd() {
+        const gcode = this.getGcode()
+        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
+        this.$socket.emit('printer.gcode.script', { script: gcode })
+        this.reset()
+    }
+
+    reset() {
+        this.coordinate = {
+            x: '',
+            y: '',
+            z: ''
+        }
+    }
+
+}
+</script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -250,7 +250,8 @@
 			"FeedAmountIn": "Feed amount in",
 			"FeedrateIn": "Feedrate in",
 			"Retract": "Retract",
-			"Extrude": "Extrude"
+			"Extrude": "Extrude",
+			"Goto": "GO"
 		},
 		"MacrosPanel": {
 			"Headline": "Macros"


### PR DESCRIPTION
This PR adds three text fields to the control panel to move directly to a coordinate.

- It checks if the values are within the printer limits.
- If Z and XY coordinates are entered it moves Z first.
- If the printer is in relative mode it switches to absolute mode and back.

closes(#218)

![Screenshot 2021-10-11 at 23 06 26](https://user-images.githubusercontent.com/1850271/136855642-f00f6a79-3228-4bc9-8355-134586b68b18.png)


