### PR TITLE
fix: check for null when running in docker or non pi

### DIFF
--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -89,7 +89,7 @@ export const getters: GetterTree<ServerState, any> = {
             let tempSensor = rootGetters['printer/getHostTempSensor']
             if (tempSensor === null) {
                 tempSensor = {
-                    temperature: state.cpu_temp.toFixed(0),
+                    temperature: state.cpu_temp?.toFixed(0),
                     measured_min_temp: null,
                     measured_max_temp: null
                 }


### PR DESCRIPTION
when not running on pi this should be checked for null, because of which the System Panel is prevented being loaded.