### PR TITLE
fix: allow upper case sensor names

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -502,12 +502,13 @@ export const getters: GetterTree<PrinterState, RootState> = {
         const objects = getters.getPrinterConfigObjects(checkObjects)
         Object.keys(objects).forEach((key) => {
             const settings = objects[key]
+            const caseKey: string = Object.keys(state).find((state_key: string) => state_key.toLowerCase() === key.toLowerCase()) || ''
             if (
                 'sensor_type' in settings &&
 				sensorTypes.includes(settings.sensor_type) &&
-				key in state
+                caseKey in state 
             ) {
-                const value = state[key]
+                const value = state[caseKey]
 
                 output = {
                     temperature: value.temperature?.toFixed(0),

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -529,11 +529,13 @@ export const getters: GetterTree<PrinterState, RootState> = {
         const objects = getters.getPrinterConfigObjects(checkObjects)
         Object.keys(objects).forEach((key) => {
             const value = objects[key]
+            const caseKey: string = Object.keys(state).find((state_key: string) => state_key.toLowerCase() === key.toLowerCase()) || ''
+            
             if ('sensor_type' in value && value.sensor_type === 'temperature_mcu' && 'sensor_mcu' in value) {
                 output.push({
-                    key: key,
+                    key: caseKey,
                     settings: value,
-                    object: key in state ? state[key] : {}
+                    object: caseKey in state ? state[caseKey] : {}
                 })
             }
         })


### PR DESCRIPTION
when using sensor names like this

```
[temperature_sensor HAL]
sensor_type: temperature_host
sensor_path: /sys/devices/platform/coretemp.0/hwmon/hwmon0/temp3_input
```

it was causing the SystemLoads panel to break, mostly because they keys were being looked up were all lowercase. This correctly looks up the keys. 