### PR TITLE
fix: bug in dependency getter

### DIFF
--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -69,13 +69,7 @@ export const getters: GetterTree<RootState, any> = {
         const minMoonrakerVersionRelease = minMoonrakerVersionSplits[0] ?? ''
         const minMoonrakerVersionBuild = parseInt(minMoonrakerVersionSplits[1] ?? 0)
 
-        if (moonrakerVersion === '') {
-            dependencies.push({
-                serviceName: 'Moonraker',
-                installedVersion: '--',
-                neededVersion: minMoonrakerVersion
-            })
-        } else if (
+        if (
             semver.valid(moonrakerVersionRelease) && (
                 semver.gt(minMoonrakerVersionRelease, moonrakerVersionRelease) ||
                 (semver.eq(minMoonrakerVersionRelease, moonrakerVersionRelease) && moonrakerVersionBuild < minMoonrakerVersionBuild)


### PR DESCRIPTION
resolves an issue where the dependency panel pops up for a fraction of a second and falsely displays an outdated moonraker version detected on the users system.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>