### PR TITLE
fix: support for printer farm in https mode

### DIFF
--- a/src/store/farm/printer/index.ts
+++ b/src/store/farm/printer/index.ts
@@ -13,7 +13,7 @@ export const getDefaultState = (): FarmPrinterState => {
             hostname: '',
             port: 7125,
             webPort: 80,
-            protocol: 'ws',
+            protocol: document.location.protocol === 'https:' ? 'wss' : 'ws',
             isConnected: false,
             isConnecting: false,
             reconnects: 0,


### PR DESCRIPTION
Fix #439 