### PR TITLE
fix: correct spelling of `max_accel_to_decel` input field (fixes #474)

### DIFF
--- a/src/components/panels/MachineSettings/MotionSettings.vue
+++ b/src/components/panels/MachineSettings/MotionSettings.vue
@@ -35,7 +35,7 @@
             </v-col>
             <v-col class="col-12 col-md-6">
                 <motion-settings-input
-                    :label="$t('Panels.MachineSettingsPanel.MotionSettings.Deceleration')"
+                    :label="$t('Panels.MachineSettingsPanel.MotionSettings.MaxAccelToDecel')"
                     :target="current_accel_to_decel"
                     :max="max_accel_to_decel"
                     :default-value="max_accel_to_decel"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -368,7 +368,7 @@
         "Motion": "Bewegung",
         "Velocity": "Geschwindigkeit",
         "Acceleration": "Beschleunigung",
-        "Deceleration": "Verlangsamung",
+        "MaxAccelToDecel": "Max. Beschl. zu Verz.",
         "SquareCornerVelocity": "Eck-Geschwindigkeit"
       },
       "PressureAdvanceSettings": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,7 +372,7 @@
         "Motion": "Motion",
         "Velocity": "Velocity",
         "Acceleration": "Acceleration",
-        "Deceleration": "Deceleration",
+        "MaxAccelToDecel": "Max Accel. to Decel.",
         "SquareCornerVelocity": "Square Corner Velocity"
       },
       "PressureAdvanceSettings": {


### PR DESCRIPTION
Signed-off-by: Dominik Willner <th33xitus@gmail.com>