### PR TITLE
fix: ignore maxTouchPoints === 256

### DIFF
--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -61,7 +61,8 @@ export default class BaseMixin extends Vue {
     }
 
     get isTouchDevice() {
-        return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0))
+        // ignore if browser reports maxTouchPoints === 256, can happen on Windows 10
+        return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0 && navigator.maxTouchPoints !== 256))
     }
 
     get moonrakerComponents() {


### PR DESCRIPTION
It can occur, that a browser on Windows 10 reports a maxTouchPoints count of 256, even though it is a desktop system without any touch functionality at all. See also: https://stackoverflow.com/a/67909182

Short codepen snippet to report maxTouchPoints count with an alert gave: 
![dfgdfg](http://puu.sh/IzhkD/10fb11ea5d.png)

Signed-off-by: Dominik Willner <th33xitus@gmail.com>