### PR TITLE
fix: dispatch with correct keyName

### DIFF
--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -110,7 +110,7 @@ export const actions: ActionTree<GuiState, RootState> = {
     setGcodefilesMetadata({ commit, dispatch, state }, data) {
         commit('setGcodefilesMetadata', data)
         dispatch('updateSettings', {
-            keyName: 'gcodefiles',
+            keyName: 'view.gcodefiles',
             newVal: state.view.gcodefiles
         })
     },
@@ -118,7 +118,7 @@ export const actions: ActionTree<GuiState, RootState> = {
     setGcodefilesShowHiddenFiles({ commit, dispatch, state }, data) {
         commit('setGcodefilesShowHiddenFiles', data)
         dispatch('updateSettings', {
-            keyName: 'gcodefiles',
+            keyName: 'view.gcodefiles',
             newVal: state.view.gcodefiles
         })
     },


### PR DESCRIPTION
Previously, data was stored in an outdated store.
Updating to the correct keyName to use the correct store.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>