### PR TITLE
fix: encodeURI for thumbnails and timelapse files

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -924,7 +924,9 @@ export default class GcodefilesPanel extends Mixins(BaseMixin) {
                 thumb.height >= thumbnailSmallMin && thumb.height <= thumbnailSmallMax
             )
 
-            if (thumbnail && 'relative_path' in thumbnail) return this.apiUrl+'/server/files/'+this.currentPath+'/'+encodeURI(thumbnail.relative_path)+'?timestamp='+item.modified.getTime()
+            if (thumbnail && 'relative_path' in thumbnail) {
+                return encodeURI(`${this.apiUrl}/server/files/${this.currentPath}/${thumbnail.relative_path}?timestamp=${item.modified.getTime()}`)
+            }
         }
 
         return ''
@@ -934,7 +936,9 @@ export default class GcodefilesPanel extends Mixins(BaseMixin) {
         if (item.thumbnails?.length) {
             const thumbnail = item.thumbnails.find(thumb => thumb.width >= thumbnailBigMin)
 
-            if (thumbnail && 'relative_path' in thumbnail) return this.apiUrl+'/server/files/'+this.currentPath+'/'+encodeURI(thumbnail.relative_path)+'?timestamp='+item.modified.getTime()
+            if (thumbnail && 'relative_path' in thumbnail) {
+                return encodeURI(`${this.apiUrl}/server/files/${this.currentPath}/${thumbnail.relative_path}?timestamp=${item.modified.getTime()}`)
+            }
         }
 
         return ''

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -595,8 +595,9 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
                 relative_url = item.filename.substr(0, item.filename.lastIndexOf('/')+1)
             }
 
-            if (thumbnail && 'relative_path' in thumbnail)
-                return this.apiUrl+'/server/files/gcodes/'+relative_url+thumbnail.relative_path+'?timestamp='+item.metadata.modified
+            if (thumbnail && 'relative_path' in thumbnail) {
+                return encodeURI(`${this.apiUrl}/server/files/gcodes/${relative_url+thumbnail.relative_path}?timestamp=${item.metadata.modified}`)
+            }
         }
 
         return false
@@ -616,7 +617,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
             }
 
             if (thumbnail && 'relative_path' in thumbnail)
-                return this.apiUrl+'/server/files/gcodes/'+relative_url+thumbnail.relative_path+'?timestamp='+item.metadata.modified
+                return encodeURI(`${this.apiUrl}/server/files/gcodes/${relative_url+thumbnail.relative_path}?timestamp=${item.metadata.modified}`)
         }
 
         return false

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -657,7 +657,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin) {
 
     downloadFile() {
         const filename = (this.absolutePath+'/'+this.contextMenu.item.filename)
-        const href = this.apiUrl + '/server/files' + filename
+        const href = encodeURI(`${this.apiUrl}/server/files${filename}`)
         window.open(href)
     }
 

--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -513,8 +513,9 @@ export default class StatusPanel extends Mixins(BaseMixin) {
                     relative_url = this.current_file.filename.substr(0, this.current_file.filename.lastIndexOf('/')+1)
                 }
 
-                if (thumbnail && 'relative_path' in thumbnail)
-                    return this.apiUrl+'/server/files/gcodes/'+relative_url+thumbnail.relative_path+'?timestamp='+this.current_file.modified
+                if (thumbnail && 'relative_path' in thumbnail) {
+                    return encodeURI(`${this.apiUrl}/server/files/gcodes/${relative_url+thumbnail.relative_path}?timestamp=${this.current_file.modified}`)
+                }
             }
         }
 
@@ -534,8 +535,9 @@ export default class StatusPanel extends Mixins(BaseMixin) {
                     relative_url = this.current_file.filename.substr(0, this.current_file.filename.lastIndexOf('/')+1)
                 }
 
-                if (thumbnail && 'relative_path' in thumbnail)
-                    return this.apiUrl+'/server/files/gcodes/'+relative_url+thumbnail.relative_path+'?timestamp='+this.current_file.modified
+                if (thumbnail && 'relative_path' in thumbnail) {
+                    return encodeURI(`${this.apiUrl}/server/files/gcodes/${relative_url+thumbnail.relative_path}?timestamp=${this.current_file.modified}`)
+                }
             }
         }
 

--- a/src/components/panels/Timelapse/TimelapseFilesPanel.vue
+++ b/src/components/panels/Timelapse/TimelapseFilesPanel.vue
@@ -443,7 +443,7 @@ export default class TimelapseFilesPanel extends Mixins(BaseMixin) {
         const filename = item.filename.slice(0, item.filename.lastIndexOf('.'))
         const preview = this.files?.find((file) => file.filename === filename+'.jpg')
         if (preview) {
-            return this.apiUrl+'/server/files/'+this.currentPath+'/'+preview.filename+'?timestamp='+preview.modified.getTime()
+            return encodeURI(`${this.apiUrl}/server/files/${this.currentPath}/${preview.filename}?timestamp=${preview.modified.getTime()}`)
         }
 
         return ''
@@ -457,7 +457,7 @@ export default class TimelapseFilesPanel extends Mixins(BaseMixin) {
             else if (item.filename.endsWith('zip')) {
                 this.downloadFile(item.filename)
             } else if (item.filename.endsWith('mp4')) {
-                this.videoDialogFilename =  this.currentPath + '/' + item.filename
+                this.videoDialogFilename =  encodeURI(`${this.currentPath}/${item.filename}`)
                 this.boolVideoDialog = true
             }
         }


### PR DESCRIPTION
GET requests including file names with special characters such as '%' will properly encode the request to the server.

## Description

I run mainsail and moonraker behind Nginx. My g-code files are named to include infill percentage, i.e. "25%", which for URLs is a reserved escape character. Nginx parses these requests incorrectly and returns a 400 Bad Request code, leaving thumbnail icons and timelapse videos inaccessible for me.

### Before fix:
![Before](https://user-images.githubusercontent.com/20323081/149823541-b19b6094-8a64-4b5f-bb4c-183d1404eda8.png)

Clicking the first file in timelapse view breaks:

![Before2](https://user-images.githubusercontent.com/20323081/149823569-573142eb-0b8b-486d-b12d-a2e62fac1b11.png)

Note the g-code file without the '%' symbol successfully obtains it's thumbnail, but all others are breaking.

I did a grep through the code base and replaced lines where encodeURI was missing for the GET request.

### After fix:

![Working2](https://user-images.githubusercontent.com/20323081/149824196-af0d3646-d785-4894-a140-c32022b538ac.png)

The first timelapse video is successfully found and displayed:

![working-vid](https://user-images.githubusercontent.com/20323081/149824201-67b33be5-18c7-4c2a-8354-9ac48e636d4d.png)

Lmk about any concerns, and thank you for providing a great and useful UI! 🎉