### PR TITLE
fix: set default for min_extrude_temp

### DIFF
--- a/src/components/panels/ControlPanelExtruder.vue
+++ b/src/components/panels/ControlPanelExtruder.vue
@@ -121,7 +121,7 @@ export default class ControlPanelExtruder extends Mixins(BaseMixin) {
     }
 
     get minExtrudeTemp() {
-        return this.$store.state.printer.configfile.config.extruder.min_extrude_temp ?? 170
+        return this.$store.state.printer.configfile.settings.extruder.min_extrude_temp
     }
 
     doSend(gcode: string) {

--- a/src/components/panels/ControlPanelExtruder.vue
+++ b/src/components/panels/ControlPanelExtruder.vue
@@ -121,7 +121,7 @@ export default class ControlPanelExtruder extends Mixins(BaseMixin) {
     }
 
     get minExtrudeTemp() {
-        return this.$store.state.printer.configfile.config.extruder.min_extrude_temp
+        return this.$store.state.printer.configfile.config.extruder.min_extrude_temp ?? 170
     }
 
     doSend(gcode: string) {


### PR DESCRIPTION
`min_extrude_temp` is undefined if the user has not specified `min_extrude_temp` in their Klipper config leading to a small display error in the extrude/retract tooltip:
![Screenshot 2022-01-17 224253](https://user-images.githubusercontent.com/840291/149840098-5abe1419-4190-4f89-88a8-ee61cc1d1b66.png)

This PR sets `min_extrude_temp`to Klipper's default 170 if it is undefined.

Signed-off-by: Morten Lindhardt <r3fuze@gmail.com>