### PR TITLE
chore: Use node 16 for base docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:buster AS base
+FROM node:16-buster AS base
 
 EXPOSE 8080
 


### PR DESCRIPTION
The npm docker image is using `node:buster` as base image, and that currently points to Node 17 (current, not LTS)

Node 17 introduced a new OpenSSL provider and some dependencies do not work with it (though one can set `NODE_OPTIONS` to `--openssl-legacy-provider` in order to use the legacy provider)

As the existing workflow is using Node 16, the easiest fix is to just point the base image to Node 16, hence this fix.

Fixes #567

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>