### PR TITLE
chore(build): Sets Node engine to version 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
   "browserslist": [
     "> 1%",
     "last 2 versions"
-  ]
+  ],
+  "engines": {
+    "node": "^16"
+  }
 }


### PR DESCRIPTION
If one tries to build Mainsail with the latest Node (17 at the time of writing), it will not work as it has a new OpenSSL provider that is not directly compatible with some of the dependencies (though one can set `NODE_OPTIONS` to `--openssl-legacy-provider` in order to use the legacy provider)

In any case, as the current workflow is using Node 16 (LTS at time of writing), I think it would be wise to fix that version so anyone trying to build from source gets a warning if they are using a different version of Node.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>