### PR TITLE
chore: fix initial development environment

### DIFF
--- a/docker/config/moonraker.conf.example
+++ b/docker/config/moonraker.conf.example
@@ -4,7 +4,8 @@
 host: 0.0.0.0
 port: 7125
 enable_debug_logging: True
-config_path: /home/node/printer_config/
+config_path: /home/node/klipper_config/
+database_path: /home/node/.moonraker_database
 
 [authorization]
 enabled: True


### PR DESCRIPTION
I couldn't start the development environment initially using Docker. 

Got this error:

```
PermissionError: [Errno 13] Permission denied: '/root/.moonraker_database'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/node/moonraker/moonraker/moonraker.py", line 872, in main
    server = Server(app_args, file_logger, event_loop)
  File "/home/node/moonraker/moonraker/moonraker.py", line 152, in __init__
    self._load_components(config)
  File "/home/node/moonraker/moonraker/moonraker.py", line 230, in _load_components
    self.load_component(config, component)
  File "/home/node/moonraker/moonraker/moonraker.py", line 257, in load_component
    raise ServerError(msg)
utils.ServerError: Unable to load component: (database)
2022-01-28 14:14:43,035 [moonraker.py:main()] - Server Shutdown
```

Providing the correct database path fixed it.