### PR TITLE
fix: properly size Gcode drag zone in Safari

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -19,7 +19,7 @@
     display: table;
     position: absolute;
     top: 0; left: 0;
-    width: 100%; height: 100%;
+    width: 100%; height: 100vh;
     z-index: 9999999999;
     background-color: rgba(0, 0, 0, 0.5);
     transition: visibility 175ms, opacity 175ms;


### PR DESCRIPTION
In Safari, the drag zone for Gcode doesn't show up properly, making it really hard to drop Gcode files into Mainsail:

https://user-images.githubusercontent.com/2745/152683919-aaaef124-a70d-413d-8dc1-9cde7ab4e61d.mov

I did some Googling, and [found a suggestion on Stack Overflow to try using `100vh` instead of `100%`](https://stackoverflow.com/a/44819258), which seems to work:

https://user-images.githubusercontent.com/2745/152683977-e66e3f60-f7e6-4d14-b918-b1dc42fd312d.mov

It seems to look the same in Firefox/Chrome to me now, though I understand if there are any concerns from a random CSS change I pulled off Stack Overflow 😂 
