### PR TITLE
fix: video and download link in timelapse video dialog

### DIFF
--- a/src/components/panels/Timelapse/TimelapseFilesPanel.vue
+++ b/src/components/panels/Timelapse/TimelapseFilesPanel.vue
@@ -239,16 +239,16 @@
                 <v-card-text class="">
                     <v-row>
                         <v-col class="pb-0">
-                            <video :src="hostUrl+'server/files/'+videoDialogFilename" controls style="width: 100%;">
+                            <video :src="this.apiUrl+'/server/files/'+videoDialogFilename" controls style="width: 100%;">
                                 Sorry, your browser doesn't support embedded videos,
-                                but don't worry, you can <a :href="hostUrl+'server/files/'+videoDialogFilename">download it</a>
+                                but don't worry, you can <a :href="this.apiUrl+'/server/files/'+videoDialogFilename">download it</a>
                                 and watch it with your favorite video player!
                             </video>
                         </v-col>
                     </v-row>
                     <v-row>
                         <v-col class="text-center">
-                            <v-btn text color="primary" :href="hostUrl+'server/files/'+videoDialogFilename" target="_blank">{{ $t('Timelapse.Download') }}</v-btn>
+                            <v-btn text color="primary" :href="this.apiUrl+'/server/files/'+videoDialogFilename" target="_blank">{{ $t('Timelapse.Download') }}</v-btn>
                         </v-col>
                     </v-row>
                 </v-card-text>


### PR DESCRIPTION
When using mainsail on a different port, the video preview and download link was pointing to a wrong url.

Signed-off-by:  Christoph Frei <fryakatkop@gmail.com>