### PR TITLE
ci: fix incorrect hash length of the bundle report

### DIFF
--- a/.github/workflows/build_size_report.yml
+++ b/.github/workflows/build_size_report.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          strip-hash: "\\b\\w{5}\\."
+          strip-hash: "\\b\\w{8}\\."
           pattern: "./dist/**/*.{js,css,html,json}"
           exclude: "{./dist/manifest.json,./dist/build.zip,**/*.map,**/node_modules/**}"


### PR DESCRIPTION
The hashes are 8 characters instead of 5.﻿
