### PR TITLE
refactor: make sure that port '80' and '443' are correctly passed through

### DIFF
--- a/src/store/socket/index.ts
+++ b/src/store/socket/index.ts
@@ -3,19 +3,37 @@ import { SocketState } from '@/store/socket/types'
 import { actions } from '@/store/socket/actions'
 import { mutations } from '@/store/socket/mutations'
 import { getters } from '@/store/socket/getters'
-import {RootState} from '@/store/types'
+import { RootState } from '@/store/types'
 
 export const getDefaultState = (): SocketState => {
+    let remoteMode: boolean
+    let hostname: string
+    let port: number
+
+    if (
+        document.location.hostname === 'my.mainsail.xyz' ||
+        import.meta.env.VUE_APP_REMOTE_MODE
+    ) {
+        remoteMode = true
+        hostname = ''
+        port = 7125
+    } else  {
+        remoteMode = false
+        hostname = import.meta.env.VUE_APP_HOSTNAME as string || window.location.hostname
+        const defaultPort = window.location.port || (window.location.protocol === 'https:' ? 443 : 80)
+        port  = import.meta.env.VUE_APP_PORT ? Number(import.meta.env.VUE_APP_PORT) : Number(defaultPort)
+    }
+
     return {
-        remoteMode: import.meta.env.VUE_APP_REMOTE_MODE === true || (document.location.hostname === 'my.mainsail.xyz'),
-        hostname: (import.meta.env.VUE_APP_HOSTNAME as string) || ((import.meta.env.VUE_APP_REMOTE_MODE === true || document.location.hostname === 'my.mainsail.xyz') ? '' : window.location.hostname),
-        port: Number(import.meta.env.VUE_APP_PORT || (import.meta.env.VUE_APP_REMOTE_MODE === true || document.location.hostname === 'my.mainsail.xyz' ? 7125 : window.location.port)),
+        remoteMode,
+        hostname,
+        port,
         protocol: document.location.protocol === 'https:' ? 'wss' : 'ws',
         reconnectInterval: Number(import.meta.env.VUE_APP_RECONNECT_INTERVAL || 2000),
         isConnected: false,
         isConnecting: false,
         connectingFailed: false,
-        loadings: []
+        loadings: [],
     }
 }
 
@@ -27,5 +45,5 @@ export const socket: Module<SocketState, RootState> = {
     state,
     getters,
     actions,
-    mutations
+    mutations,
 }


### PR DESCRIPTION
This fixes the problem described in https://github.com/mainsail-crew/mainsail/pull/594#pullrequestreview-880965010.

>For me, Mainsail has been trying to connect to moonraker on port 0 (rather than port 80) ever since this PR has been merged. The issue is that in the case Mainsail falls back onto window.port.location, if the browser has loaded mainsail via HTTP on port 80, said variable will be an empty string (as per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location/port)). Number('') yields 0, which makes Mainsail connect on the wrong port. Removing the cast to number fixes the issue.