### PR TITLE
ci: run build size report on 'analyze' label

### DIFF
--- a/.github/workflows/build_size_report.yml
+++ b/.github/workflows/build_size_report.yml
@@ -1,8 +1,11 @@
 name: Build Size Report
-on: [ pull_request ]
+on:
+  pull_request_target:
+    types: [ labeled ]
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'analyze')
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -11,3 +14,6 @@ jobs:
           strip-hash: "\\b\\w{8}\\."
           pattern: "./dist/**/*.{js,css,html,json}"
           exclude: "{./dist/manifest.json,./dist/build.zip,**/*.map,**/node_modules/**}"
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: analyze # analyze complete, remote the label afterwards

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -16,7 +16,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  lint:
+  style:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -28,30 +28,16 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: 16
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint files
-        run: npm run lint
-
-  format:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      - name: Fetch repo
-        uses: actions/checkout@v2
-
-      - name: Install node
-        uses: actions/setup-node@v2
+      - name: Run linters
+        uses: wearerequired/lint-action@v1
         with:
-          node-version: '16'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check files for formatting
-        run: npm run format:check
+          eslint: true
+          prettier: true
+          eslint_dir: src
+          eslint_extensions: ts,vue
+          prettier_dir: src


### PR DESCRIPTION
The size report is only ran after adding the label. This way `pull_request_target` is still safe to use.

Like this:

![image](https://user-images.githubusercontent.com/3403851/153848142-dfcb7c18-80fb-495c-a757-251d2c2d0e64.png)


If you want something different than `analyze`, just let me know.

Also updated the linter jobs to be a bit more standard.
