### PR TITLE
feat: add custom number input component

### DIFF
--- a/src/components/inputs/NumberInput.vue
+++ b/src/components/inputs/NumberInput.vue
@@ -70,47 +70,47 @@ export default class NumberInput extends Mixins(BaseMixin) {
 
     // input field name and identifier
     @Prop({ type: String, required: true })
-    readonly label!: string
+    declare readonly label: string
 
     @Prop({ type: String, required: true })
-    readonly param!: string
+    declare readonly param: string
 
     // props defining incoming data
     @Prop({ type: Number, required: true, default: 0 })
-    readonly target!: number
+    declare readonly target: number
 
     @Prop({ type: Number, required: true, default: 0 })
-    readonly defaultValue!: number
+    declare readonly defaultValue: number
 
     // props for internal processing
     @Prop({ type: Number, required: true , default: 0 })
-    readonly min!: number
+    declare readonly min: number
 
     @Prop({ type: Number, default: null })
-    readonly max!: number | null
+    declare readonly max: number | null
 
     @Prop({ type: Number, required: true , default: 0 })
-    readonly dec!: number
+    declare readonly dec: number
 
     @Prop({ type: Number, required: false , default: 1 })
-    readonly step!: number
+    declare readonly step: number
 
     @Prop({ type: String, required: true })
-    readonly unit!: string
+    declare readonly unit: string
 
     // spinner related props
     @Prop({ type: Boolean, required: false , default: false })
-    readonly hasSpinner!: boolean
+    declare readonly hasSpinner: boolean
 
     @Prop({ type: Number, required: false , default: 1 })
-    readonly spinnerFactor!: number
+    declare readonly spinnerFactor: number
 
     // props for general internal behaviour
     @Prop({ type: Boolean, required: false , default: false })
-    readonly disabled!: boolean
+    declare readonly disabled: boolean
 
     @Prop({ type: Boolean, required: false , default: false })
-    readonly outputErrorMsg!: boolean
+    declare readonly outputErrorMsg: boolean
 
     created(): void {
         this.value = this.target

--- a/src/components/inputs/NumberInput.vue
+++ b/src/components/inputs/NumberInput.vue
@@ -1,12 +1,12 @@
 <style scoped>
-    ._spin_button_group {
-        width: 24px;
-        margin: -6px -6px 0 -6px;
-    }
+._spin_button_group {
+    width: 24px;
+    margin: -6px -6px 0 -6px;
+}
 
-    .v-input--has-state {
-        margin-bottom: -18px !important;
-    }
+.v-input--has-state {
+    margin-bottom: -18px !important;
+}
 </style>
 
 <template>
@@ -37,17 +37,21 @@
                 <div class="_spin_button_group">
                     <v-btn
                         @click="incrementValue"
-                        :disabled="((value >= max) && max !== null) || error || disabled"
+                        :disabled="(value >= max && max !== null) || error || disabled"
                         class="mt-n3"
-                        icon plain small
+                        icon
+                        plain
+                        small
                     >
                         <v-icon>mdi-chevron-up</v-icon>
                     </v-btn>
                     <v-btn
                         @click="decrementValue"
-                        :disabled="(value <= min) || error || disabled"
+                        :disabled="value <= min || error || disabled"
                         class="mb-n3"
-                        icon plain small
+                        icon
+                        plain
+                        small
                     >
                         <v-icon>mdi-chevron-down</v-icon>
                     </v-btn>
@@ -83,33 +87,33 @@ export default class NumberInput extends Mixins(BaseMixin) {
     declare readonly defaultValue: number
 
     // props for internal processing
-    @Prop({ type: Number, required: true , default: 0 })
+    @Prop({ type: Number, required: true, default: 0 })
     declare readonly min: number
 
     @Prop({ type: Number, default: null })
     declare readonly max: number | null
 
-    @Prop({ type: Number, required: true , default: 0 })
+    @Prop({ type: Number, required: true, default: 0 })
     declare readonly dec: number
 
-    @Prop({ type: Number, required: false , default: 1 })
+    @Prop({ type: Number, required: false, default: 1 })
     declare readonly step: number
 
     @Prop({ type: String, required: true })
     declare readonly unit: string
 
     // spinner related props
-    @Prop({ type: Boolean, required: false , default: false })
+    @Prop({ type: Boolean, required: false, default: false })
     declare readonly hasSpinner: boolean
 
-    @Prop({ type: Number, required: false , default: 1 })
+    @Prop({ type: Number, required: false, default: 1 })
     declare readonly spinnerFactor: number
 
     // props for general internal behaviour
-    @Prop({ type: Boolean, required: false , default: false })
+    @Prop({ type: Boolean, required: false, default: false })
     declare readonly disabled: boolean
 
-    @Prop({ type: Boolean, required: false , default: false })
+    @Prop({ type: Boolean, required: false, default: false })
     declare readonly outputErrorMsg: boolean
 
     created(): void {
@@ -122,8 +126,8 @@ export default class NumberInput extends Mixins(BaseMixin) {
     }
 
     incrementValue(): void {
-        if (this.value + (this.step * this.spinnerFactor) < this.max! || this.max === null) {
-            this.value = Math.round((this.value + this.step * this.spinnerFactor) * (10 ** this.dec)) / (10 ** this.dec)
+        if (this.value + this.step * this.spinnerFactor < this.max! || this.max === null) {
+            this.value = Math.round((this.value + this.step * this.spinnerFactor) * 10 ** this.dec) / 10 ** this.dec
         } else {
             this.value = this.max
         }
@@ -131,8 +135,8 @@ export default class NumberInput extends Mixins(BaseMixin) {
     }
 
     decrementValue(): void {
-        if (this.value - (this.step * this.spinnerFactor) > this.min) {
-            this.value = Math.round((this.value - this.step * this.spinnerFactor) * (10 ** this.dec)) / (10 ** this.dec)
+        if (this.value - this.step * this.spinnerFactor > this.min) {
+            this.value = Math.round((this.value - this.step * this.spinnerFactor) * 10 ** this.dec) / 10 ** this.dec
         } else {
             this.value = this.min
         }
@@ -144,7 +148,7 @@ export default class NumberInput extends Mixins(BaseMixin) {
         this.submit()
     }
 
-    submit(): void{
+    submit(): void {
         if (this.invalidInput()) return
         this.$emit('target-changed', this.param, this.value)
         this.$emit('submit', this.param)
@@ -158,7 +162,7 @@ export default class NumberInput extends Mixins(BaseMixin) {
     }
 
     invalidInput(): boolean {
-        return (this.value.toString() === '' || (this.value < this.min) || ((this.value > this.max!) && this.max !== null))
+        return this.value.toString() === '' || this.value < this.min || (this.value > this.max! && this.max !== null)
     }
 
     inputErrors() {
@@ -168,7 +172,7 @@ export default class NumberInput extends Mixins(BaseMixin) {
         if (this.value.toString() === '') {
             errors.push('Input must not be empty!')
         }
-        if (this.max === null && (this.value < this.min)) {
+        if (this.max === null && this.value < this.min) {
             errors.push(`Must be grater or equal than ${this.min}`)
         }
         if (this.max !== null && (this.value > this.max! || this.value < this.min)) {

--- a/src/components/inputs/NumberInput.vue
+++ b/src/components/inputs/NumberInput.vue
@@ -1,0 +1,180 @@
+<style scoped>
+    ._spin_button_group {
+        width: 24px;
+        margin: -6px -6px 0 -6px;
+    }
+
+    .v-input--has-state {
+        margin-bottom: -18px !important;
+    }
+</style>
+
+<template>
+    <form v-on:submit.prevent="submit">
+        <v-text-field
+            v-model.number="value"
+            class="d-flex align-top"
+            @blur="value = target"
+            @click:append="resetToDefault"
+            @keydown="checkInvalidChars"
+            :label="label"
+            :suffix="unit"
+            :append-icon="target !== defaultValue ? 'mdi-restart' : ''"
+            :error="invalidInput()"
+            :error-messages="inputErrors()"
+            :disabled="disabled"
+            :step="step"
+            :min="min"
+            :max="max"
+            :dec="dec"
+            type="number"
+            hide-spin-buttons
+            hide-details="auto"
+            outlined
+            dense
+        >
+            <template v-if="hasSpinner" v-slot:append-outer>
+                <div class="_spin_button_group">
+                    <v-btn
+                        @click="incrementValue"
+                        :disabled="((value >= max) && max !== null) || error || disabled"
+                        class="mt-n3"
+                        icon plain small
+                    >
+                        <v-icon>mdi-chevron-up</v-icon>
+                    </v-btn>
+                    <v-btn
+                        @click="decrementValue"
+                        :disabled="(value <= min) || error || disabled"
+                        class="mb-n3"
+                        icon plain small
+                    >
+                        <v-icon>mdi-chevron-down</v-icon>
+                    </v-btn>
+                </div>
+            </template>
+        </v-text-field>
+    </form>
+</template>
+
+<script lang="ts">
+import Component from 'vue-class-component'
+import { Mixins, Prop, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+
+@Component
+export default class NumberInput extends Mixins(BaseMixin) {
+    private value: number = 0
+    private error: boolean = false
+    private invalidChars: string[] = ['e', 'E', '+']
+
+    // input field name and identifier
+    @Prop({ type: String, required: true })
+    readonly label!: string
+
+    @Prop({ type: String, required: true })
+    readonly param!: string
+
+    // props defining incoming data
+    @Prop({ type: Number, required: true, default: 0 })
+    readonly target!: number
+
+    @Prop({ type: Number, required: true, default: 0 })
+    readonly defaultValue!: number
+
+    // props for internal processing
+    @Prop({ type: Number, required: true , default: 0 })
+    readonly min!: number
+
+    @Prop({ type: Number, default: null })
+    readonly max!: number | null
+
+    @Prop({ type: Number, required: true , default: 0 })
+    readonly dec!: number
+
+    @Prop({ type: Number, required: false , default: 1 })
+    readonly step!: number
+
+    @Prop({ type: String, required: true })
+    readonly unit!: string
+
+    // spinner related props
+    @Prop({ type: Boolean, required: false , default: false })
+    readonly hasSpinner!: boolean
+
+    @Prop({ type: Number, required: false , default: 1 })
+    readonly spinnerFactor!: number
+
+    // props for general internal behaviour
+    @Prop({ type: Boolean, required: false , default: false })
+    readonly disabled!: boolean
+
+    @Prop({ type: Boolean, required: false , default: false })
+    readonly outputErrorMsg!: boolean
+
+    created(): void {
+        this.value = this.target
+    }
+
+    @Watch('target')
+    updateTarget(): void {
+        this.value = this.target
+    }
+
+    incrementValue(): void {
+        if (this.value + (this.step * this.spinnerFactor) < this.max! || this.max === null) {
+            this.value = Math.round((this.value + this.step * this.spinnerFactor) * (10 ** this.dec)) / (10 ** this.dec)
+        } else {
+            this.value = this.max
+        }
+        this.submit()
+    }
+
+    decrementValue(): void {
+        if (this.value - (this.step * this.spinnerFactor) > this.min) {
+            this.value = Math.round((this.value - this.step * this.spinnerFactor) * (10 ** this.dec)) / (10 ** this.dec)
+        } else {
+            this.value = this.min
+        }
+        this.submit()
+    }
+
+    resetToDefault(): void {
+        this.value = this.defaultValue
+        this.submit()
+    }
+
+    submit(): void{
+        if (this.invalidInput()) return
+        this.$emit('target-changed', this.param, this.value)
+        this.$emit('submit', this.param)
+    }
+
+    // input validation //
+    checkInvalidChars(event: any): void {
+        // add '-' to invalid characters if no negative input is allowed
+        if (this.min >= 0) this.invalidChars.push('-')
+        if (this.invalidChars.includes(event.key)) event.preventDefault()
+    }
+
+    invalidInput(): boolean {
+        return (this.value.toString() === '' || (this.value < this.min) || ((this.value > this.max!) && this.max !== null))
+    }
+
+    inputErrors() {
+        if (!this.outputErrorMsg) return []
+
+        const errors = []
+        if (this.value.toString() === '') {
+            errors.push('Input must not be empty!')
+        }
+        if (this.max === null && (this.value < this.min)) {
+            errors.push(`Must be grater or equal than ${this.min}`)
+        }
+        if (this.max !== null && (this.value > this.max! || this.value < this.min)) {
+            errors.push(`Must be between ${this.min} and ${this.max}`)
+        }
+        return errors
+    }
+}
+</script>


### PR DESCRIPTION
This PR will add a new, custom number input component which is meant to be as re-usable as possible throughout the whole project.

With this component added, we will be able to completely replace:
https://github.com/mainsail-crew/mainsail/blob/develop/src/components/inputs/FirmwareRetractionSettingsInput.vue
https://github.com/mainsail-crew/mainsail/blob/develop/src/components/inputs/MotionSettingsInput.vue
https://github.com/mainsail-crew/mainsail/blob/develop/src/components/inputs/PressureAdvanceSettingsInput.vue
as those files currently hold a lot of duplicated code.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>