### PR TITLE
perf: load codemirror into a chunk for faster LCP

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -51,14 +51,14 @@
                     >
                     <v-btn icon tile @click="close"><v-icon>mdi-close-thick</v-icon></v-btn>
                 </template>
-                <v-card-text class="pa-0">
+                <v-card-text class="pa-0" v-if="show">
                     <overlay-scrollbars style="height: calc(var(--app-height) - 48px)" :options="{}">
-                        <codemirror
+                        <codemirror-async
                             ref="editor"
                             v-model="sourcecode"
                             :name="filename"
                             v-bind:file-extension="fileExtension"
-                        ></codemirror>
+                        ></codemirror-async>
                     </overlay-scrollbars>
                 </v-card-text>
             </panel>
@@ -129,11 +129,11 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { formatFilesize } from '@/plugins/helpers'
-import Codemirror from '@/components/inputs/Codemirror.vue'
 import Panel from '@/components/ui/Panel.vue'
+import CodemirrorAsync from '@/components/inputs/CodemirrorAsync'
 
 @Component({
-    components: { Panel, Codemirror },
+    components: { Panel, CodemirrorAsync },
 })
 export default class TheEditor extends Mixins(BaseMixin) {
     private dialogConfirmChange = false

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -51,9 +51,10 @@
                     >
                     <v-btn icon tile @click="close"><v-icon>mdi-close-thick</v-icon></v-btn>
                 </template>
-                <v-card-text class="pa-0" v-if="show">
+                <v-card-text class="pa-0">
                     <overlay-scrollbars style="height: calc(var(--app-height) - 48px)" :options="{}">
                         <codemirror-async
+                            v-if="show"
                             ref="editor"
                             v-model="sourcecode"
                             :name="filename"

--- a/src/components/inputs/CodemirrorAsync.ts
+++ b/src/components/inputs/CodemirrorAsync.ts
@@ -1,0 +1,10 @@
+import Vue from 'vue'
+
+/**
+ * Load code mirror into a chunk
+ */
+export default Vue.component(
+    'codemirror-async',
+    // A dynamic import returns a Promise.
+    () => import('@/components/inputs/Codemirror.vue')
+)


### PR DESCRIPTION
This loads codemirror into a seperate chuk for faster LCP.

More information: https://web.dev/lcp/

You can use the `analyze` label to see the difference in bundle size.