### PR TITLE
ci: use the correct sha for the compressed size action check

### DIFF
--- a/.github/workflows/build_size_report.yml
+++ b/.github/workflows/build_size_report.yml
@@ -9,6 +9,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: preactjs/compressed-size-action@v2
         with:
           strip-hash: "\\b\\w{8}\\."


### PR DESCRIPTION
This makes sure the PR gets run instead of upstream.