### PR TITLE
feat(console): add the ability to clear the console

### DIFF
--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -17,8 +17,8 @@
         card-class="miniconsole-panel"
         :hide-buttons-on-collapse="true">
         <template #buttons>
+            <v-btn icon tile @click="clearConsole"><v-icon small>mdi-trash-can</v-icon></v-btn>
             <command-help-modal :in-toolbar="true" @onCommand="gcode = $event"></command-help-modal>
-
             <v-menu
                 :offset-y="true"
                 :close-on-content-click="false"
@@ -139,7 +139,11 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
     }
 
     get events() {
-        return this.$store.getters['server/getConsoleEvents'](this.consoleDirection === 'table', 250)
+        return this.$store.getters['server/getConsoleEvents'](
+            this.consoleDirection === 'table',
+            250,
+            this.$store.state.gui.console.cleared_since
+        )
     }
 
     @Watch('events')
@@ -149,6 +153,10 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
                 this.scrollToBottom()
             }, 50)
         }
+    }
+
+    clearConsole() {
+        this.$store.dispatch('gui/console/clear')
     }
 
     get hideWaitTemperatures(): boolean {

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -106,7 +106,6 @@ import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { ServerStateEvent } from '@/store/server/types'
 
 @Component({
     components: {

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -106,6 +106,7 @@ import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
 import Panel from '@/components/ui/Panel.vue'
+import { ServerStateEvent } from '@/store/server/types'
 
 @Component({
     components: {
@@ -139,11 +140,7 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
     }
 
     get events() {
-        return this.$store.getters['server/getConsoleEvents'](
-            this.consoleDirection === 'table',
-            250,
-            this.$store.state.gui.console.cleared_since
-        )
+        return this.$store.getters['server/getConsoleEvents'](this.consoleDirection === 'table', 250)
     }
 
     @Watch('events')

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -38,6 +38,9 @@
             </v-col>
 
             <v-col class="col-auto d-flex align-center">
+                <v-btn class="mr-3 px-2 minwidth-0" color="lightgray" @click="clearConsole">
+                    <v-icon>mdi-trash-can</v-icon>
+                </v-btn>
                 <command-help-modal @onCommand="gcode = $event"></command-help-modal>
                 <v-menu
                     offset-y
@@ -101,6 +104,7 @@ import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import { reverseString, strLongestEqual } from '@/plugins/helpers'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
+import { ServerStateEvent } from '@/store/server/types'
 
 @Component({
     components: {
@@ -128,7 +132,11 @@ export default class PageConsole extends Mixins(BaseMixin) {
     }
 
     get events() {
-        return this.$store.getters['server/getConsoleEvents'](this.consoleDirection === 'table')
+        return this.$store.getters['server/getConsoleEvents'](
+            this.consoleDirection === 'table',
+            500,
+            this.$store.state.gui.console.cleared_since
+        )
     }
 
     @Watch('events')
@@ -146,6 +154,10 @@ export default class PageConsole extends Mixins(BaseMixin) {
 
     set hideWaitTemperatures(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'console.hideWaitTemperatures', value: newVal })
+    }
+
+    clearConsole() {
+        this.$store.dispatch('gui/console/clear')
     }
 
     get hideTlCommands(): boolean {

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -104,7 +104,6 @@ import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import { reverseString, strLongestEqual } from '@/plugins/helpers'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
-import { ServerStateEvent } from '@/store/server/types'
 
 @Component({
     components: {

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -132,11 +132,7 @@ export default class PageConsole extends Mixins(BaseMixin) {
     }
 
     get events() {
-        return this.$store.getters['server/getConsoleEvents'](
-            this.consoleDirection === 'table',
-            500,
-            this.$store.state.gui.console.cleared_since
-        )
+        return this.$store.getters['server/getConsoleEvents'](this.consoleDirection === 'table')
     }
 
     @Watch('events')

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,6 +1,7 @@
 import router from '@/plugins/router'
 import { ActionTree } from 'vuex'
 import { RootState } from './types'
+import Vue from 'vue'
 
 export const actions: ActionTree<RootState, RootState> = {
     switchToDashboard() {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,7 +1,6 @@
 import router from '@/plugins/router'
 import { ActionTree } from 'vuex'
 import { RootState } from './types'
-import Vue from 'vue'
 
 export const actions: ActionTree<RootState, RootState> = {
     switchToDashboard() {

--- a/src/store/gui/console/actions.ts
+++ b/src/store/gui/console/actions.ts
@@ -20,6 +20,9 @@ export const actions: ActionTree<GuiConsoleState, RootState> = {
         commit('clear', {
             cleared_since,
         })
+
+        commit('server/clearGcodeStore', {}, { root: true })
+        commit('server/setConsoleClearedThisSession', {}, { root: true })
     },
 
     saveSetting({ dispatch }, payload) {

--- a/src/store/gui/console/actions.ts
+++ b/src/store/gui/console/actions.ts
@@ -9,6 +9,19 @@ export const actions: ActionTree<GuiConsoleState, RootState> = {
         commit('reset')
     },
 
+    clear({ commit }) {
+        const cleared_since = new Date().valueOf()
+        Vue.$socket.emit('server.database.post_item', {
+            namespace: 'mainsail',
+            key: 'console.cleared_since',
+            value: cleared_since,
+        })
+
+        commit('clear', {
+            cleared_since,
+        })
+    },
+
     saveSetting({ dispatch }, payload) {
         dispatch(
             'gui/saveSetting',

--- a/src/store/gui/console/getters.ts
+++ b/src/store/gui/console/getters.ts
@@ -36,4 +36,8 @@ export const getters: GetterTree<GuiConsoleState, any> = {
 
         return output
     },
+
+    getConsoleClearedSince: (state, getters, rootState) => {
+        return state.cleared_since
+    },
 }

--- a/src/store/gui/console/mutations.ts
+++ b/src/store/gui/console/mutations.ts
@@ -10,6 +10,7 @@ export const mutations: MutationTree<GuiConsoleState> = {
 
     clear(state, payload) {
         Vue.set(state, 'cleared_since', payload.cleared_since)
+        Vue.set(state, 'cleared_this_session', true)
     },
 
     filterStore(state, payload) {

--- a/src/store/gui/console/mutations.ts
+++ b/src/store/gui/console/mutations.ts
@@ -10,7 +10,6 @@ export const mutations: MutationTree<GuiConsoleState> = {
 
     clear(state, payload) {
         Vue.set(state, 'cleared_since', payload.cleared_since)
-        Vue.set(state, 'cleared_this_session', true)
     },
 
     filterStore(state, payload) {

--- a/src/store/gui/console/mutations.ts
+++ b/src/store/gui/console/mutations.ts
@@ -8,6 +8,10 @@ export const mutations: MutationTree<GuiConsoleState> = {
         Object.assign(state, getDefaultState())
     },
 
+    clear(state, payload) {
+        Vue.set(state, 'cleared_since', payload.cleared_since)
+    },
+
     filterStore(state, payload) {
         Vue.set(state.consolefilters, payload.id, payload.values)
     },

--- a/src/store/gui/console/types.ts
+++ b/src/store/gui/console/types.ts
@@ -1,4 +1,5 @@
 export interface GuiConsoleState {
+    cleared_since?: number
     hideWaitTemperatures: boolean
     hideTlCommands: boolean
     direction: 'table' | 'shell'

--- a/src/store/gui/console/types.ts
+++ b/src/store/gui/console/types.ts
@@ -1,5 +1,6 @@
 export interface GuiConsoleState {
     cleared_since?: number
+    cleared_this_session?: boolean
     hideWaitTemperatures: boolean
     hideTlCommands: boolean
     direction: 'table' | 'shell'

--- a/src/store/gui/console/types.ts
+++ b/src/store/gui/console/types.ts
@@ -1,6 +1,5 @@
 export interface GuiConsoleState {
     cleared_since?: number
-    cleared_this_session?: boolean
     hideWaitTemperatures: boolean
     hideTlCommands: boolean
     direction: 'table' | 'shell'

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -63,10 +63,6 @@ export const actions: ActionTree<ServerState, RootState> = {
         commit('setSystemInfo', payload.system_info)
     },
 
-    clearConsole({ commit }, payload) {
-        commit('setSystemInfo', payload.system_info)
-    },
-
     initProcStats({ commit }, payload) {
         if (payload.throttled_state !== null) commit('setThrottledState', payload.throttled_state)
     },

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -144,7 +144,7 @@ export const actions: ActionTree<ServerState, RootState> = {
         commit('setData', payload)
     },
 
-    getGcodeStore({ state, commit, rootGetters }, payload) {
+    getGcodeStore({ commit, rootGetters }, payload) {
         commit('clearGcodeStore')
 
         let events: ServerStateEvent[] = payload.gcode_store

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -63,6 +63,10 @@ export const actions: ActionTree<ServerState, RootState> = {
         commit('setSystemInfo', payload.system_info)
     },
 
+    clearConsole({ commit }, payload) {
+        commit('setSystemInfo', payload.system_info)
+    },
+
     initProcStats({ commit }, payload) {
         if (payload.throttled_state !== null) commit('setThrottledState', payload.throttled_state)
     },

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -165,8 +165,6 @@ export const actions: ActionTree<ServerState, RootState> = {
                 return true
             }
 
-            console.log(event, event.time, cleared_since)
-
             if (event.time && event.time * 1000 < cleared_since) {
                 return false
             }

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -144,7 +144,7 @@ export const actions: ActionTree<ServerState, RootState> = {
         commit('setData', payload)
     },
 
-    getGcodeStore({ commit, rootGetters }, payload) {
+    getGcodeStore({ state, commit, rootGetters }, payload) {
         commit('clearGcodeStore')
 
         let events: ServerStateEvent[] = payload.gcode_store
@@ -156,6 +156,26 @@ export const actions: ActionTree<ServerState, RootState> = {
             } catch {
                 window.console.error("Custom console filter '" + filter + "' doesn't work")
             }
+        })
+
+        const cleared_since = rootGetters['gui/console/getConsoleClearedSince']
+
+        events = events.filter((event) => {
+            if (!cleared_since) {
+                return true
+            }
+
+            console.log(event, event.time, cleared_since)
+
+            if (event.time && event.time * 1000 < cleared_since) {
+                return false
+            }
+
+            if (event.date && new Date(event.date).valueOf() < cleared_since) {
+                return false
+            }
+
+            return true
         })
 
         commit('setGcodeStore', events)

--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -6,14 +6,10 @@ import { formatConsoleMessage, formatFilesize, formatTime } from '@/plugins/help
 export const getters: GetterTree<ServerState, any> = {
     getConsoleEvents:
         (state) =>
-        (reverse = true, limit = 500, cleared_since: undefined | number = undefined) => {
-            let events = [...state.events].slice(limit * -1) ?? []
+        (reverse = true, limit = 500) => {
+            const events = [...state.events].slice(limit * -1) ?? []
 
-            events = events.filter(
-                (event: ServerStateEvent) => !cleared_since || new Date(event.date).valueOf() > cleared_since
-            )
-
-            if (events.length < 20) {
+            if (events.length < 20 && !state.console_cleared_this_session) {
                 const date = events.length ? events[0].date : new Date()
                 let message = ''
 

--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -1,13 +1,17 @@
 import { GetterTree } from 'vuex'
-import { ServerState } from '@/store/server/types'
+import { ServerState, ServerStateEvent } from '@/store/server/types'
 import { formatConsoleMessage, formatFilesize, formatTime } from '@/plugins/helpers'
 
 // eslint-disable-next-line
 export const getters: GetterTree<ServerState, any> = {
     getConsoleEvents:
         (state) =>
-        (reverse = true, limit = 500) => {
-            const events = [...state.events].slice(limit * -1) ?? []
+        (reverse = true, limit = 500, cleared_since: undefined | number = undefined) => {
+            let events = [...state.events].slice(limit * -1) ?? []
+
+            events = events.filter(
+                (event: ServerStateEvent) => !cleared_since || new Date(event.date).valueOf() > cleared_since
+            )
 
             if (events.length < 20) {
                 const date = events.length ? events[0].date : new Date()

--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -1,5 +1,5 @@
 import { GetterTree } from 'vuex'
-import { ServerState, ServerStateEvent } from '@/store/server/types'
+import { ServerState } from '@/store/server/types'
 import { formatConsoleMessage, formatFilesize, formatTime } from '@/plugins/helpers'
 
 // eslint-disable-next-line

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -64,6 +64,10 @@ export const mutations: MutationTree<ServerState> = {
         })
     },
 
+    setConsoleClearedThisSession(state) {
+        Vue.set(state, 'console_cleared_this_session', true)
+    },
+
     clearGcodeStore(state) {
         Vue.set(state, 'events', [])
     },

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -40,6 +40,8 @@ export interface ServerState {
     websocket_count: number
     moonraker_version: string
 
+    console_cleared_this_session?: boolean
+
     power?: ServerPowerState
     updateManager?: ServerUpdateMangerState
     history?: ServerHistoryState
@@ -48,6 +50,7 @@ export interface ServerState {
 
 export interface ServerStateEvent {
     date: Date
+    time?: number
     formatTime: string
     type: string
     message: string


### PR DESCRIPTION
This just keeps a `cleared_since` date in the database and filters the events that came before that.