### PR TITLE
build: add official Docker image

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+
+  include /etc/nginx/extra-conf.d/*.conf;
+}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,46 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master', 'develop']
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master') }}
+            type=edge,branch=develop
+            type=ref,event=tag
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Builder stage, builds the application in node
+#
+FROM node:16-alpine as builder
+
+RUN apk add zip
+
+WORKDIR /app
+COPY package*.json /app/
+
+RUN npm install
+
+COPY ./ /app/
+
+RUN npm run build
+
+#
+# Runner stage, runs the application in nginx
+#
+FROM nginx:stable-alpine as runner
+
+COPY --from=builder /app/.docker/nginx.conf  /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist/ /usr/share/nginx/html/


### PR DESCRIPTION
This creates an official image for Mainsail that can be used by Docker users.﻿

How to test this:

```sh
docker build . -t mainsail && docker run -p "4444:80" mainsail
```

Open http://localhost:4444
