### PR TITLE
feat: add default moonraker instances to config.json

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -84,10 +84,6 @@ export default class App extends Mixins(BaseMixin) {
         return this.$store.getters['getTitle']
     }
 
-    get remoteMode(): boolean {
-        return this.$store.state.socket.remoteMode ?? false
-    }
-
     get mainBackground(): string {
         return this.$store.getters['files/getMainBackground']
     }

--- a/src/components/TheSelectPrinterDialog.vue
+++ b/src/components/TheSelectPrinterDialog.vue
@@ -157,7 +157,7 @@
                                             </v-icon>
                                         </v-col>
                                         <v-col>{{ getPrinterName(printer.id) }}</v-col>
-                                        <v-col class="col-auto pa-0">
+                                        <v-col v-if="canAddPrinters" class="col-auto pa-0">
                                             <v-btn
                                                 tile
                                                 text
@@ -190,7 +190,7 @@
                             </p>
                         </v-col>
                     </v-row>
-                    <v-row>
+                    <v-row v-if="canAddPrinters">
                         <v-col class="text-center mt-0">
                             <v-btn text color="primary" @click="dialogAddPrinter.bool = true">
                                 {{ $t('SelectPrinterDialog.AddPrinter') }}
@@ -250,6 +250,10 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
 
     get printers() {
         return this.$store.getters['gui/remoteprinters/getRemoteprinters'] ?? []
+    }
+
+    get canAddPrinters() {
+        return this.$store.state.configInstances.length === 0
     }
 
     get protocol() {

--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -12,7 +12,7 @@ export default class BaseMixin extends Vue {
     }
 
     get remoteMode() {
-        return this.$store.state.socket.remoteMode
+        return this.$store.state.remoteMode
     }
 
     get socketIsConnected(): boolean {

--- a/src/components/settings/SettingsRemotePrintersTab.vue
+++ b/src/components/settings/SettingsRemotePrintersTab.vue
@@ -9,7 +9,7 @@
                         :title="formatPrinterName(printer)"
                         :loading="printer.socket.isConnecting"
                         :icon="printer.socket.isConnected ? mdiCheckboxMarkedCircle : mdiCancel">
-                        <v-btn small outlined @click="editPrinter(printer)">
+                        <v-btn small outlined :disabled="!canAddPrinters" @click="editPrinter(printer)">
                             <v-icon left small>{{ mdiPencil }}</v-icon>
                             {{ $t('Settings.Edit') }}
                         </v-btn>
@@ -18,6 +18,7 @@
                             outlined
                             class="ml-3 minwidth-0 px-2"
                             color="error"
+                            :disabled="!canAddPrinters"
                             @click="delPrinter(printer.id)">
                             <v-icon small>{{ mdiDelete }}</v-icon>
                         </v-btn>
@@ -25,7 +26,7 @@
                 </div>
             </v-card-text>
             <v-card-actions class="d-flex justify-end">
-                <v-btn text color="primary" @click="createPrinter">
+                <v-btn text color="primary" :disabled="!canAddPrinters" @click="createPrinter">
                     {{ $t('Settings.RemotePrintersTab.AddPrinter') }}
                 </v-btn>
             </v-card-actions>
@@ -110,6 +111,10 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
 
     get printers() {
         return this.$store.getters['gui/remoteprinters/getRemoteprinters'] ?? []
+    }
+
+    get canAddPrinters() {
+        return this.$store.state.configInstances.length === 0
     }
 
     get protocol() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,8 +65,8 @@ Vue.component('EChart', ECharts)
 //load config.json and init vue
 fetch('/config.json')
     .then((res) => res.json())
-    .then((file) => {
-        store.commit('socket/setData', file)
+    .then(async (file) => {
+        await store.dispatch('importConfigJson', file)
 
         const url = store.getters['socket/getWebsocketUrl']
         Vue.use(WebSocketPlugin, {
@@ -74,7 +74,7 @@ fetch('/config.json')
             store: store,
         })
 
-        if (!store?.state?.socket?.remoteMode) Vue.$socket.connect()
+        if (!store?.state?.remoteMode) Vue.$socket.connect()
 
         new Vue({
             vuetify,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,6 +1,7 @@
 import router from '@/plugins/router'
 import { ActionTree } from 'vuex'
-import { RootState } from './types'
+import { ConfigJson, RootState } from './types'
+import { v4 as uuidv4 } from 'uuid'
 
 export const actions: ActionTree<RootState, RootState> = {
     switchToDashboard() {
@@ -8,7 +9,7 @@ export const actions: ActionTree<RootState, RootState> = {
     },
 
     changePrinter({ dispatch, getters, state }, payload) {
-        const remoteMode = state.socket?.remoteMode
+        const remoteMode = state.remoteMode
 
         dispatch('files/reset')
         dispatch('gui/reset')
@@ -21,11 +22,23 @@ export const actions: ActionTree<RootState, RootState> = {
         dispatch('socket/setSocket', {
             hostname: printerSocket.hostname,
             port: printerSocket.port,
-            remoteMode: remoteMode,
         })
     },
 
     setNaviDrawer({ commit }, payload) {
         commit('setNaviDrawer', payload)
+    },
+
+    /**
+     * This funciton will parse the config.json content and config mainsail
+     * @param commit - vuex commit
+     * @param dispatch - vuex dispatch
+     * @param payload - content of config.json as a object
+     */
+    importConfigJson({ commit, dispatch }, payload: ConfigJson) {
+        const remoteMode = 'remoteMode' in payload ? payload.remoteMode : false
+        if (remoteMode) {
+            commit('setRemoteMode', true)
+        }
     },
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -39,6 +39,10 @@ export const actions: ActionTree<RootState, RootState> = {
         const remoteMode = 'remoteMode' in payload ? payload.remoteMode : false
         if (remoteMode) {
             commit('setRemoteMode', true)
+
+            if ('instances' in payload && Array.isArray(payload.instances) && payload.instances.length) {
+                commit('setConfigInstances', payload.instances)
+            }
         }
     },
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -30,7 +30,7 @@ export const actions: ActionTree<RootState, RootState> = {
     },
 
     /**
-     * This funciton will parse the config.json content and config mainsail
+     * This function will parse the config.json content and config mainsail
      * @param commit - vuex commit
      * @param dispatch - vuex dispatch
      * @param payload - content of config.json as a object

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -25,8 +25,7 @@ export const actions: ActionTree<GuiState, RootState> = {
         const mainsailUrl = baseUrl + '?namespace=mainsail'
 
         if ('remoteprinters' in payload.value) {
-            if (!rootState.socket?.remoteMode)
-                dispatch('remoteprinters/initStore', payload.value.remoteprinters.printers)
+            if (!rootState.remoteMode) dispatch('remoteprinters/initStore', payload.value.remoteprinters.printers)
             delete payload.value.remoteprinters
         }
 

--- a/src/store/gui/remoteprinters/actions.ts
+++ b/src/store/gui/remoteprinters/actions.ts
@@ -13,8 +13,9 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
         commit('reset')
     },
 
-    initFromLocalstorage({ dispatch }) {
-        const value = JSON.parse(localStorage.getItem('printers') ?? '{}')
+    initFromLocalstorage({ dispatch, rootState }) {
+        let value = rootState.configInstances ?? []
+        if (value.length === 0) value = JSON.parse(localStorage.getItem('printers') ?? '{}')
         if (Array.isArray(value)) {
             const printers: any = {}
 

--- a/src/store/gui/remoteprinters/actions.ts
+++ b/src/store/gui/remoteprinters/actions.ts
@@ -46,7 +46,7 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
     },
 
     upload({ state, rootState }, id) {
-        if (rootState.socket?.remoteMode) {
+        if (rootState.remoteMode) {
             const printers: any[] = []
 
             Object.keys(state.printers).forEach((id: string) => {
@@ -111,7 +111,7 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
         commit('delete', id)
         dispatch('farm/unregisterPrinter', id, { root: true })
 
-        if (rootState.socket?.remoteMode) dispatch('upload')
+        if (rootState.remoteMode) dispatch('upload')
         else {
             Vue.$socket.emit('server.database.delete_item', {
                 namespace: 'mainsail',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,10 +18,20 @@ import { gcodeviewer } from '@/store/gcodeviewer'
 Vue.use(Vuex)
 
 export const getDefaultState = (): RootState => {
+    let remoteMode = false
+
+    if (
+        document.location.hostname === 'my.mainsail.xyz' ||
+        String(import.meta.env.VUE_APP_REMOTE_MODE).toLowerCase() === 'true' ||
+        String(import.meta.env.VUE_APP_REMOTE_MODE) === '1'
+    )
+        remoteMode = true
+
     return {
         packageVersion: (import.meta.env.PACKAGE_VERSION as string) || '0.0.0',
         debugMode: (import.meta.env.VUE_APP_DEBUG_MODE as boolean) || false,
         naviDrawer: null,
+        remoteMode,
     }
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,7 +3,7 @@ import Vuex from 'vuex'
 import { actions } from '@/store/actions'
 import { mutations } from '@/store/mutations'
 import { getters } from '@/store/getters'
-import { RootState } from './types'
+import { ConfigJsonInstance, RootState } from './types'
 
 // load modules
 import { socket } from '@/store/socket'
@@ -32,6 +32,7 @@ export const getDefaultState = (): RootState => {
         debugMode: (import.meta.env.VUE_APP_DEBUG_MODE as boolean) || false,
         naviDrawer: null,
         remoteMode,
+        configInstances: [],
     }
 }
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -10,4 +10,8 @@ export const mutations: MutationTree<RootState> = {
     setRemoteMode(state, payload) {
         Vue.set(state, 'remoteMode', payload)
     },
+
+    setConfigInstances(state, payload) {
+        Vue.set(state, 'configInstances', payload)
+    },
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,4 +6,8 @@ export const mutations: MutationTree<RootState> = {
     setNaviDrawer(state, payload) {
         Vue.set(state, 'naviDrawer', payload)
     },
+
+    setRemoteMode(state, payload) {
+        Vue.set(state, 'remoteMode', payload)
+    },
 }

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { ActionTree } from 'vuex'
 import { SocketState } from '@/store/socket/types'
 import { RootState } from '@/store/types'
+import { v4 as uuidv4 } from 'uuid'
 
 export const actions: ActionTree<SocketState, RootState> = {
     reset({ commit }) {

--- a/src/store/socket/index.ts
+++ b/src/store/socket/index.ts
@@ -6,27 +6,11 @@ import { getters } from '@/store/socket/getters'
 import { RootState } from '@/store/types'
 
 export const getDefaultState = (): SocketState => {
-    let remoteMode: boolean
-    let hostname: string
-    let port: number
-
-    if (
-        document.location.hostname === 'my.mainsail.xyz' ||
-        String(import.meta.env.VUE_APP_REMOTE_MODE).toLowerCase() === 'true' ||
-        String(import.meta.env.VUE_APP_REMOTE_MODE) === '1'
-    ) {
-        remoteMode = true
-        hostname = ''
-        port = 7125
-    } else {
-        remoteMode = false
-        hostname = (import.meta.env.VUE_APP_HOSTNAME as string) || window.location.hostname
-        const defaultPort = window.location.port || (window.location.protocol === 'https:' ? 443 : 80)
-        port = import.meta.env.VUE_APP_PORT ? Number(import.meta.env.VUE_APP_PORT) : Number(defaultPort)
-    }
+    const hostname = (import.meta.env.VUE_APP_HOSTNAME as string) || window.location.hostname
+    const defaultPort = window.location.port || (window.location.protocol === 'https:' ? 443 : 80)
+    const port = import.meta.env.VUE_APP_PORT ? Number(import.meta.env.VUE_APP_PORT) : Number(defaultPort)
 
     return {
-        remoteMode,
         hostname,
         port,
         protocol: document.location.protocol === 'https:' ? 'wss' : 'ws',

--- a/src/store/socket/types.ts
+++ b/src/store/socket/types.ts
@@ -1,5 +1,4 @@
 export interface SocketState {
-    remoteMode: boolean
     hostname: string
     port: number
     protocol: string

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ export interface RootState {
     packageVersion: string
     debugMode: boolean
     naviDrawer: boolean | null
+    remoteMode: boolean
 
     socket?: SocketState
     gui?: GuiState
@@ -20,4 +21,14 @@ export interface RootStateDependency {
     serviceName: string
     installedVersion: string
     neededVersion: string
+}
+
+export interface ConfigJson {
+    remoteMode?: boolean
+    instances?: ConfigJsonInstance[]
+}
+
+export interface ConfigJsonInstance {
+    hostname: string
+    port?: number
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -9,6 +9,7 @@ export interface RootState {
     debugMode: boolean
     naviDrawer: boolean | null
     remoteMode: boolean
+    configInstances: ConfigJsonInstance[]
 
     socket?: SocketState
     gui?: GuiState


### PR DESCRIPTION
this PR will fix #630 

config.json example:
```json
{
  "remoteMode": true,
  "instances": [
    { "hostname": "192.168.0.210", "port": 7125 },
    { "hostname": "192.168.0.211", "port": 7125 }
  ]
}
```

Signed-off-by: Stefan Dej <meteyou@gmail.com>