### PR TITLE
feat: add settings for klipper & moonraker 'SAVE & RESTART'

### DIFF
--- a/src/components/settings/SettingsEditorTab.vue
+++ b/src/components/settings/SettingsEditorTab.vue
@@ -16,6 +16,32 @@
                     <v-switch v-model="confirmUnsavedChanges" hide-details class="mt-0"></v-switch>
                 </settings-row>
                 <v-divider class="my-2"></v-divider>
+                <settings-row
+                    :title="$t('Settings.EditorTab.KlipperRestartMethod')"
+                    :sub-title="$t('Settings.EditorTab.KlipperRestartMethodDescription')">
+                    <v-select
+                        v-model="klipperRestartMethod"
+                        :items="klipperRestartMethods"
+                        hide-details
+                        outlined
+                        dense
+                        attached></v-select>
+                </settings-row>
+                <v-divider class="my-2"></v-divider>
+                <template v-if="availableMoonrakerInstances.length > 1">
+                    <settings-row
+                        :title="$t('Settings.EditorTab.MoonrakerRestartInstance')"
+                        :sub-title="$t('Settings.EditorTab.MoonrakerRestartInstanceDescription')">
+                        <v-select
+                            v-model="moonrakerRestartInstance"
+                            :items="availableMoonrakerInstances"
+                            hide-details
+                            outlined
+                            dense
+                            attached></v-select>
+                    </settings-row>
+                    <v-divider class="my-2"></v-divider>
+                </template>
             </v-card-text>
         </v-card>
     </div>
@@ -30,6 +56,17 @@ import SettingsRow from '@/components/settings/SettingsRow.vue'
     components: { SettingsRow },
 })
 export default class SettingsEditorTab extends Mixins(BaseMixin) {
+    private klipperRestartMethods = [
+        {
+            text: 'FIRMWARE_RESTART',
+            value: 'FIRMWARE_RESTART',
+        },
+        {
+            text: 'RESTART',
+            value: 'RESTART',
+        },
+    ]
+
     get escToClose() {
         return this.$store.state.gui.editor.escToClose
     }
@@ -44,6 +81,28 @@ export default class SettingsEditorTab extends Mixins(BaseMixin) {
 
     set confirmUnsavedChanges(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'editor.confirmUnsavedChanges', value: newVal })
+    }
+
+    get klipperRestartMethod() {
+        return this.$store.state.gui.editor.klipperRestartMethod
+    }
+
+    set klipperRestartMethod(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'editor.klipperRestartMethod', value: newVal })
+    }
+
+    get moonrakerRestartInstance() {
+        return this.$store.state.gui.editor.moonrakerRestartInstance
+    }
+
+    set moonrakerRestartInstance(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'editor.moonrakerRestartInstance', value: newVal })
+    }
+
+    get availableMoonrakerInstances() {
+        const available_instances = this.$store.state.server.system_info?.available_services ?? []
+
+        return available_instances.filter((name: string) => name.startsWith('moonraker')).sort()
     }
 }
 </script>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -149,7 +149,11 @@
         "UnsavedChangesSubMessage": "Deine Änderungen werden verloren gehen wenn du sie nicht speicherst. Du kannst diese Meldung in den Editor-Einstellungen deaktivieren.",
         "DontSave": "Nicht speichern",
         "Cancel": "Abbrechen",
-        "FileReadOnly": "schreibgeschützt"
+        "FileReadOnly": "schreibgeschützt",
+        "KlipperRestartMethod": "Klipper Neustartmethode",
+        "KlipperRestartMethodDescription": "Wählen der Neustartmethode die bei 'Speichern & Neustarten' verwendet wird, wenn Klipper-Konfigurationsdateien bearbeitet werden.",
+        "MoonrakerRestartInstance": "Moonraker Neustartinstanz",
+        "MoonrakerRestartInstanceDescription": "Wählen der Moonraker-Instanz die bei 'Speichern & Neustarten' neu gestartet wird, wenn Moonraker-Konfigurationsdateien bearbeitet werden."
     },
     "Files": {
         "GCodeFiles": "G-Code Dateien",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -917,7 +917,11 @@
             "UseEscToClose": "Use ESC to close editor",
             "UseEscToCloseDescription": "Allows the ESC key to close the editor",
             "ConfirmUnsavedChanges": "Prompt to save or discard unsaved changes",
-            "ConfirmUnsavedChangesDescription": "If enabled, the editor requires a confirmation to either save or discard the changes made. If disabled, changes are silently discarded."
+            "ConfirmUnsavedChangesDescription": "If enabled, the editor requires a confirmation to either save or discard the changes made. If disabled, changes are silently discarded.",
+            "KlipperRestartMethod": "Klipper restart method",
+            "KlipperRestartMethodDescription": "Select which restart method will be used on 'Save & Restart' when editing Klipper config files.",
+            "MoonrakerRestartInstance": "Moonraker restart instance",
+            "MoonrakerRestartInstanceDescription": "Select which Moonraker service will restart on 'Save & Restart' when editing Moonraker config files."
         }
     },
     "GCodeViewer": {

--- a/src/store/editor/actions.ts
+++ b/src/store/editor/actions.ts
@@ -77,7 +77,7 @@ export const actions: ActionTree<EditorState, RootState> = {
     },
 
     async saveFile(
-        { state, commit, rootGetters, dispatch },
+        { state, commit, getters, rootGetters, dispatch },
         payload: { content: string; restartServiceName: string | null }
     ) {
         const content = new Blob([payload.content], { type: 'text/plain' })
@@ -133,8 +133,12 @@ export const actions: ActionTree<EditorState, RootState> = {
                 dispatch('clearLoader')
                 Vue.$toast.success(i18n.t('Editor.SuccessfullySaved', { filename: data.item.path }).toString())
                 if (payload.restartServiceName === 'klipper') {
+                    const klipperRestartMethod = getters['getKlipperRestartMethod']
                     //dispatch('server/addEvent', { message: 'FIRMWARE_RESTART', type: 'command' })
-                    Vue.$socket.emit('printer.gcode.script', { script: 'FIRMWARE_RESTART' })
+                    Vue.$socket.emit('printer.gcode.script', { script: klipperRestartMethod })
+                } else if (payload.restartServiceName === 'moonraker') {
+                    const moonrakerRestartInstance = getters['getMoonrakerRestartInstance']
+                    Vue.$socket.emit('machine.services.restart', { service: moonrakerRestartInstance })
                 } else if (payload.restartServiceName !== null) {
                     Vue.$socket.emit('machine.services.restart', { service: payload.restartServiceName })
                 }

--- a/src/store/editor/getters.ts
+++ b/src/store/editor/getters.ts
@@ -1,4 +1,17 @@
 import { GetterTree } from 'vuex'
 import { EditorState } from '@/store/editor/types'
 
-export const getters: GetterTree<EditorState, any> = {}
+export const getters: GetterTree<EditorState, any> = {
+    getKlipperRestartMethod: (state, getters, rootState) => {
+        return rootState.gui.editor?.klipperRestartMethod ?? 'FIRMWARE_RESTART'
+    },
+
+    getMoonrakerRestartInstance: (state, getters, rootState) => {
+        const available_services = rootState.server?.system_info?.available_services ?? []
+        const setting = rootState.gui.editor?.moonrakerRestartInstance ?? 'moonraker'
+
+        if (available_services.includes(setting)) return setting
+
+        return 'moonraker'
+    },
+}

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -104,6 +104,8 @@ export const getDefaultState = (): GuiState => {
         editor: {
             escToClose: true,
             confirmUnsavedChanges: true,
+            klipperRestartMethod: 'FIRMWARE_RESTART',
+            moonrakerRestartInstance: null,
         },
         gcodeViewer: {
             extruderColors: ['#E76F51FF', '#F4A261FF', '#E9C46AFF', '#2A9D8FFF', '#264653FF'],

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -48,6 +48,8 @@ export interface GuiState {
     editor: {
         escToClose: boolean
         confirmUnsavedChanges: boolean
+        klipperRestartMethod: 'FIRMWARE_RESTART' | 'RESTART'
+        moonrakerRestartInstance: string | null
     }
     gcodeViewer: {
         extruderColors: string[]


### PR DESCRIPTION
switch between 'FIRMWARE_RESTART' and 'FIRMWARE' for klipper or add an option to select the right moonraker instance in multi instance systems.

Signed-off-by: Stefan Dej <meteyou@gmail.com>