### PR TITLE
feat: implement moonraker connection identify

### DIFF
--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -12,14 +12,32 @@ export const actions: ActionTree<ServerState, RootState> = {
         dispatch('updateManager/reset')
     },
 
-    init() {
+    async init({ dispatch }) {
         window.console.debug('init Server')
 
-        Vue.$socket.emit('server.info', {}, { action: 'server/initServerInfo' })
-        Vue.$socket.emit('server.config', {}, { action: 'server/initServerConfig' })
-        Vue.$socket.emit('machine.system_info', {}, { action: 'server/initSystemInfo' })
-        Vue.$socket.emit('machine.proc_stats', {}, { action: 'server/initProcStats' })
-        Vue.$socket.emit('server.database.list', { root: 'config' }, { action: 'server/checkDatabases' })
+        await dispatch('identify')
+        await Vue.$socket.emit('server.info', {}, { action: 'server/initServerInfo' })
+        await Vue.$socket.emit('server.config', {}, { action: 'server/initServerConfig' })
+        await Vue.$socket.emit('machine.system_info', {}, { action: 'server/initSystemInfo' })
+        await Vue.$socket.emit('machine.proc_stats', {}, { action: 'server/initProcStats' })
+        await Vue.$socket.emit('server.database.list', { root: 'config' }, { action: 'server/checkDatabases' })
+    },
+
+    identify({ rootState }) {
+        Vue.$socket.emit(
+            'server.connection.identify',
+            {
+                client_name: 'mainsail',
+                version: rootState.packageVersion,
+                type: 'web',
+                url: 'https://github.com/mainsail-crew/mainsail',
+            },
+            { action: 'server/setConnectionId' }
+        )
+    },
+
+    setConnectionId({ commit }, payload) {
+        commit('setConnectionId', payload.connection_id)
     },
 
     checkDatabases({ dispatch, commit, rootState }, payload) {

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -46,6 +46,10 @@ export const mutations: MutationTree<ServerState> = {
         Vue.set(state, 'moonraker_stats', payload.moonraker_stats)
     },
 
+    setConnectionId(state, payload) {
+        Vue.set(state, 'connection_id', payload)
+    },
+
     setData(state, payload) {
         if ('requestParams' in payload) delete payload.requestParams
 

--- a/src/store/socket/index.ts
+++ b/src/store/socket/index.ts
@@ -19,6 +19,7 @@ export const getDefaultState = (): SocketState => {
         isConnecting: false,
         connectingFailed: false,
         loadings: [],
+        connection_id: null,
     }
 }
 

--- a/src/store/socket/types.ts
+++ b/src/store/socket/types.ts
@@ -7,4 +7,5 @@ export interface SocketState {
     isConnecting: boolean
     connectingFailed: boolean
     loadings: string[]
+    connection_id: number | null
 }

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -2,7 +2,7 @@ export const defaultLogoColor = '#D41216'
 export const defaultPrimaryColor = '#2196f3'
 
 export const minKlipperVersion = 'v0.10.0-271'
-export const minMoonrakerVersion = 'v0.7.1-193'
+export const minMoonrakerVersion = 'v0.7.1-449'
 
 export const colorArray = ['#F44336', '#8e379d', '#03DAC5', '#3F51B5', '#ffde03', '#009688', '#E91E63']
 


### PR DESCRIPTION
send an identification if websocket is connected.

moonraker.log looks like this after this PR:
```
2022-03-05 23:12:34,650 [websockets.py:open()] - Websocket Opened: ID: 1740547184, Proxied: True, User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36, Host Name: 192.168.0.212
2022-03-05 23:12:35,098 [websockets.py:_handle_identify()] - Websocket 1740547184 Client Identified - Name: mainsail, Version: 2.2.0-alpha, Type: web
```

Signed-off-by: Stefan Dej <meteyou@gmail.com>