### PR TITLE
fix: hide gcode thumbnail, if a webcam is active in printer farm

### DIFF
--- a/src/components/panels/FarmPrinterPanel.vue
+++ b/src/components/panels/FarmPrinterPanel.vue
@@ -213,6 +213,8 @@ export default class FarmPrinterPanel extends Mixins(BaseMixin) {
     }
 
     get printer_image() {
+        if (this.currentWebcam) return '/img/sidebar-background.svg'
+
         return this.$store.getters['farm/' + this.printer._namespace + '/getImage']
     }
 


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>