### PR TITLE
fix: missing file icon import in gcode file browser

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -545,6 +545,7 @@ import Panel from '@/components/ui/Panel.vue'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import {
     mdiFileDocumentMultipleOutline,
+    mdiFile,
     mdiMagnify,
     mdiUpload,
     mdiFolderPlus,
@@ -600,6 +601,7 @@ interface dialogRenameObject {
 })
 export default class GcodefilesPanel extends Mixins(BaseMixin) {
     mdiFileDocumentMultipleOutline = mdiFileDocumentMultipleOutline
+    mdiFile = mdiFile
     mdiMagnify = mdiMagnify
     mdiUpload = mdiUpload
     mdiFolderPlus = mdiFolderPlus


### PR DESCRIPTION
The mdi icon which is displayed for gcode files without embedded thumbnails was missing due to a missing import of that icon, resulting in an error in the browser console.

![image](https://user-images.githubusercontent.com/31533186/159781442-fdd3c726-3d77-49cd-9bdb-82c246fddfb9.png)
 

Signed-off-by: Dominik Willner <th33xitus@gmail.com>