### PR TITLE
Adds weight-scale integration

### DIFF
--- a/src/components/inputs/WeightScale.vue
+++ b/src/components/inputs/WeightScale.vue
@@ -1,0 +1,58 @@
+<style scoped>
+._weightScale-subheader {
+    height: auto;
+}
+</style>
+
+<template>
+    <v-container class="px-0 py-2">
+        <v-row>
+            <v-col class="pb-3">
+                <v-subheader class="_weightScale-subheader">
+                    <v-icon small class="mr-2">{{ mdiScale }}</v-icon>
+                    <span>{{ convertName(name) }}</span>
+                    <v-spacer></v-spacer>
+                    <small>{{ weightText }}</small>
+                    <v-icon @click="setTareZero">
+                        {{ mdiNumeric0Box }}
+                    </v-icon>
+                </v-subheader>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>
+
+<script lang="ts">
+import { convertName } from '@/plugins/helpers'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import { mdiScale, mdiNumeric0Box } from '@mdi/js'
+
+@Component
+export default class WeightScale extends Mixins(BaseMixin) {
+    /**
+     * Icons
+     */
+
+    mdiScale = mdiScale
+    mdiNumeric0Box = mdiNumeric0Box
+
+    convertName = convertName
+
+    @Prop({ type: String, required: true }) declare readonly name: string
+    @Prop({ type: Boolean, required: true }) declare readonly calibrated: boolean
+    @Prop({ type: Number, required: true }) declare readonly weight: number
+
+    get weightText() {
+        if (!this.calibrated) return 'Uncalibrated'
+        // round so we don't have -0.0 values.
+        return Math.round(this.weight * 10) / 10
+    }
+
+    setTareZero() {
+        const gcode = 'TARE_SCALE SCALE=' + this.name
+        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
+        this.$socket.emit('printer.gcode.script', { script: gcode })
+    }
+}
+</script>

--- a/src/components/panels/MiscellaneousPanel.vue
+++ b/src/components/panels/MiscellaneousPanel.vue
@@ -2,7 +2,7 @@
 
 <template>
     <panel
-        v-if="klipperReadyForGui && (miscellaneous.length || filamentSensors.length || weightScale.length)"
+        v-if="klipperReadyForGui && (miscellaneous.length || filamentSensors.length || weightScales.length)"
         :icon="mdiDipSwitch"
         :title="$t('Panels.MiscellaneousPanel.Headline')"
         :collapsible="true"
@@ -39,10 +39,11 @@ import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MiscellaneousSlider from '@/components/inputs/MiscellaneousSlider.vue'
 import FilamentSensor from '@/components/inputs/FilamentSensor.vue'
+import WeightScale from '@/components/inputs/WeightScale.vue'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiDipSwitch } from '@mdi/js'
 @Component({
-    components: { Panel, FilamentSensor, MiscellaneousSlider },
+    components: { Panel, FilamentSensor, MiscellaneousSlider, WeightScale },
 })
 export default class MiscellaneousPanel extends Mixins(BaseMixin) {
     mdiDipSwitch = mdiDipSwitch

--- a/src/components/panels/MiscellaneousPanel.vue
+++ b/src/components/panels/MiscellaneousPanel.vue
@@ -2,7 +2,7 @@
 
 <template>
     <panel
-        v-if="klipperReadyForGui && (miscellaneous.length || filamentSensors.length)"
+        v-if="klipperReadyForGui && (miscellaneous.length || filamentSensors.length || weightScale.length)"
         :icon="mdiDipSwitch"
         :title="$t('Panels.MiscellaneousPanel.Headline')"
         :collapsible="true"
@@ -27,6 +27,10 @@
                 :enabled="sensor.enabled"
                 :filament_detected="sensor.filament_detected"></filament-sensor>
         </div>
+        <div v-for="(sensor, index) of weightScales" :key="'sensor_' + index">
+            <v-divider v-if="index"></v-divider>
+            <weight-scale :name="sensor.name" :calibrated="sensor.calibrated" :weight="sensor.weight"></weight-scale>
+        </div>
     </panel>
 </template>
 
@@ -35,6 +39,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MiscellaneousSlider from '@/components/inputs/MiscellaneousSlider.vue'
 import FilamentSensor from '@/components/inputs/FilamentSensor.vue'
+import WeightScale from '@/components/inputs/WeightScale.vue'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiDipSwitch } from '@mdi/js'
 @Component({
@@ -49,6 +54,10 @@ export default class MiscellaneousPanel extends Mixins(BaseMixin) {
 
     get filamentSensors() {
         return this.$store.getters['printer/getFilamentSensors'] ?? []
+    }
+
+    get weightScales() {
+        return this.$store.getters['printer/getWeightScales'] ?? []
     }
 }
 </script>

--- a/src/components/panels/MiscellaneousPanel.vue
+++ b/src/components/panels/MiscellaneousPanel.vue
@@ -39,7 +39,6 @@ import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MiscellaneousSlider from '@/components/inputs/MiscellaneousSlider.vue'
 import FilamentSensor from '@/components/inputs/FilamentSensor.vue'
-import WeightScale from '@/components/inputs/WeightScale.vue'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiDipSwitch } from '@mdi/js'
 @Component({

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -4,6 +4,7 @@ import {
     PrinterState,
     PrinterStateBedMesh,
     PrinterStateFan,
+    PrinterStateWeightScale,
     PrinterStateFilamentSensors,
     PrinterStateHeater,
     PrinterStateTemperatureFan,
@@ -241,6 +242,24 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
             return 0
         })
+    },
+
+    getWeightScales: (state) => {
+        const sensorObjectNames = ['weigh_scale']
+        const sensors: PrinterStateWeightScale[] = []
+
+        for (const [key, value] of Object.entries(state)) {
+            const nameSplit = key.split(' ')
+
+            if (sensorObjectNames.includes(nameSplit[0])) {
+                sensors.push({
+                    name: nameSplit[1],
+                    calibrated: value.calibrated,
+                    weight: value.weight,
+                })
+            }
+        }
+        return caseInsensitiveSort(sensors, 'name')
     },
 
     getMiscellaneous: (state) => {

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -84,6 +84,12 @@ export interface PrinterStateFan {
     controllable: boolean
 }
 
+export interface PrinterStateWeightScale {
+    name: string
+    calibrated: boolean
+    weight: number
+}
+
 export interface PrinterStateMiscellaneous {
     name: string
     type: string


### PR DESCRIPTION
Supports notifying the user of an uncalibrated scale, setting
the tare, and current weight readout.   Multiple scales are
supported.

Klipper load cell integration is at:
https://github.com/Klipper3d/klipper/pull/5399
https://github.com/clearchris/klipper/tree/weight-scale

This patch is in support of the Valkyrie High Temperature
printer with integrated dry box.  More information can be
found at:

Valkryie Scope Doc
https://vkingprinter.com/project-valkyrie/

Roy's Youtube Channel, with videos of the Valkyrie
https://www.youtube.com/c/PRO3DESIGN

Picture of Mainsail Load Cell Integration:
https://drive.google.com/file/d/19ZtCDI5RWX6maxSyBihxYoMspzT_4sJR/view?usp=sharing

Signed-off-by: Chris Lombardi <clearchris@hotmail.com>