### PR TITLE
fix: add error message in webcam panel, if no webcam is available

### DIFF
--- a/src/components/panels/WebcamPanel.vue
+++ b/src/components/panels/WebcamPanel.vue
@@ -36,7 +36,7 @@
                 </v-list>
             </v-menu>
         </template>
-        <v-card-text class="px-0 py-0 content d-inline-block">
+        <v-card-text v-if="webcams.length" class="px-0 py-0 content d-inline-block">
             <v-row>
                 <v-col class="pb-0" style="position: relative">
                     <template v-if="currentCam.service === 'grid'">
@@ -59,6 +59,9 @@
                     </template>
                 </v-col>
             </v-row>
+        </v-card-text>
+        <v-card-text v-else>
+            <p class="text-center mb-0 text--disabled">{{ $t('Panels.WebcamPanel.NoWebcam') }}</p>
         </v-card-text>
     </panel>
 </template>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -592,6 +592,7 @@
             "All": "Alle",
             "FPS": "FPS",
             "Headline": "Webcam",
+            "NoWebcam": "Keine Webcam verfügbar. Füge eine Webcam unter \"Interface Einstellungen\" -> \"Webcams\".",
             "UnknownWebcamService": "Unbekannter Webcam Dienst",
             "UrlNotAvailable": "URL nicht verfügbar"
         },
@@ -742,7 +743,7 @@
             "Restore": "Wiederherstellung",
             "RestoreDialog": "Bitte wähle alle Abschnitte aus, die du wiederherstellen möchtest:"
         },
-        "InterfaceSettings": "Schnittstelleneinstellungen",
+        "InterfaceSettings": "Interface Einstellungen",
         "MacrosTab": {
             "Add": "hinzufügen",
             "AddGroup": "Gruppe hinzufügen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -593,6 +593,7 @@
             "All": "All",
             "FPS": "FPS",
             "Headline": "Webcam",
+            "NoWebcam": "No webcam available. Add your webcam under the \"Interface Settings\" -> \"Webcams\".",
             "UnknownWebcamService": "Unknown Webcam Service",
             "UrlNotAvailable": "URL not available"
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -593,7 +593,7 @@
             "All": "All",
             "FPS": "FPS",
             "Headline": "Webcam",
-            "NoWebcam": "No webcam available. Add your webcam under the \"Interface Settings\" -> \"Webcams\".",
+            "NoWebcam": "No webcam available. Add a webcam under \"Interface Settings\" -> \"Webcams\".",
             "UnknownWebcamService": "Unknown Webcam Service",
             "UrlNotAvailable": "URL not available"
         },


### PR DESCRIPTION
This PR fix #752 

Signed-off-by: Stefan Dej <meteyou@gmail.com>