### PR TITLE
fix(ConfigFilesPanel): change delete button color

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -186,8 +186,9 @@
                 </v-list-item>
                 <v-list-item
                     v-if="contextMenu.item.isDirectory && contextMenu.item.permissions.includes('w')"
+                    class="red--text"
                     @click="deleteDirectory(contextMenu.item)">
-                    <v-icon class="mr-1">{{ mdiDelete }}</v-icon>
+                    <v-icon class="mr-1" color="error">{{ mdiDelete }}</v-icon>
                     {{ $t('Machine.ConfigFilesPanel.Delete') }}
                 </v-list-item>
             </v-list>


### PR DESCRIPTION
Fixes the delete button color for deleting folders in the config file filemanager

### Before:
![22-05-07_20-52-32_chrome](https://user-images.githubusercontent.com/31533186/167268141-7bf04a36-29ad-436b-9b12-1ed4237b1428.png)

### After:
![22-05-07_20-52-48_chrome](https://user-images.githubusercontent.com/31533186/167268143-a88e8d9f-c38e-4ba4-be8b-ab1edeaac2ec.png)


Signed-off-by: Dominik Willner <th33xitus@gmail.com>