### PR TITLE
fix: margin bottom of TemperaturePanel.vue

### DIFF
--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -175,8 +175,8 @@
                     </template>
                 </responsive>
             </v-card-text>
-            <v-card-text v-if="boolTempchart" class="pa-0">
-                <v-divider class="my-2"></v-divider>
+            <v-card-text v-if="boolTempchart" class="pa-0 d-inline-block">
+                <v-divider class="mt-0 mb-2"></v-divider>
                 <v-row>
                     <v-col class="py-0">
                         <temp-chart></temp-chart>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8167632/167314982-05a7070e-f6d0-4f7a-8b91-311ee59e79cb.png)

After:
![image](https://user-images.githubusercontent.com/8167632/167315005-eae956eb-4881-4c05-be8d-867953f99148.png)

Signed-off-by: Stefan Dej <meteyou@gmail.com>