### PR TITLE
fix: duplicate checkbox for pwm fan (fixes #799)

### DIFF
--- a/src/components/charts/TempChart.vue
+++ b/src/components/charts/TempChart.vue
@@ -47,7 +47,7 @@ export default class TempChart extends Mixins(BaseMixin) {
                 fontSize: '14px',
             },
             padding: 15,
-            formatter: this.tooltipFormater,
+            formatter: this.tooltipFormatter,
             confine: true,
             className: 'echarts-tooltip',
             position: function (pos: any, params: any, dom: any, rect: any, size: any) {
@@ -297,7 +297,7 @@ export default class TempChart extends Mixins(BaseMixin) {
         }
     }
 
-    tooltipFormater(datasets: any) {
+    tooltipFormatter(datasets: any) {
         let output = ''
 
         const mainDatasets = datasets.filter((dataset: any) => {

--- a/src/components/charts/TempChart.vue
+++ b/src/components/charts/TempChart.vue
@@ -305,7 +305,7 @@ export default class TempChart extends Mixins(BaseMixin) {
             if (dataset.seriesName.includes('-')) {
                 if (dataset.seriesName.lastIndexOf('-') > -1) {
                     const suffix = dataset.seriesName.slice(dataset.seriesName.lastIndexOf('-') + 1)
-                    return !['target', 'power'].includes(suffix)
+                    return !['target', 'power', 'speed'].includes(suffix)
                 }
 
                 return true

--- a/src/components/charts/TempChart.vue
+++ b/src/components/charts/TempChart.vue
@@ -302,16 +302,12 @@ export default class TempChart extends Mixins(BaseMixin) {
 
         const mainDatasets = datasets.filter((dataset: any) => {
             if (dataset.seriesName === 'date') return false
-            if (dataset.seriesName.includes('-')) {
-                if (dataset.seriesName.lastIndexOf('-') > -1) {
-                    const suffix = dataset.seriesName.slice(dataset.seriesName.lastIndexOf('-') + 1)
-                    return !['target', 'power', 'speed'].includes(suffix)
-                }
 
-                return true
-            }
+            const lastIndex = dataset.seriesName.lastIndexOf('-')
+            if (lastIndex === -1) return true
 
-            return true
+            const suffix = dataset.seriesName.slice(lastIndex + 1)
+            return !['target', 'power', 'speed'].includes(suffix)
         })
         if (datasets.length) {
             let outputTime = datasets[0]['axisValueLabel']

--- a/src/store/printer/tempHistory/actions.ts
+++ b/src/store/printer/tempHistory/actions.ts
@@ -108,7 +108,7 @@ export const actions: ActionTree<PrinterTempHistoryState, RootState> = {
                     if (tmp.startsWith('_')) return false
                     if (tmp.lastIndexOf('-') > -1) {
                         const suffix = tmp.slice(tmp.lastIndexOf('-') + 1)
-                        return !['target', 'power'].includes(suffix)
+                        return !['target', 'power', 'speed'].includes(suffix)
                     }
 
                     return true

--- a/src/store/printer/tempHistory/actions.ts
+++ b/src/store/printer/tempHistory/actions.ts
@@ -106,12 +106,12 @@ export const actions: ActionTree<PrinterTempHistoryState, RootState> = {
             const masterDatasetKeys = tempDatasetKeys
                 .filter((tmp) => {
                     if (tmp.startsWith('_')) return false
-                    if (tmp.lastIndexOf('-') > -1) {
-                        const suffix = tmp.slice(tmp.lastIndexOf('-') + 1)
-                        return !['target', 'power', 'speed'].includes(suffix)
-                    }
 
-                    return true
+                    const lastIndex = tmp.lastIndexOf('-')
+                    if (lastIndex === -1) return true
+
+                    const suffix = tmp.slice(lastIndex + 1)
+                    return !['target', 'power', 'speed'].includes(suffix)
                 })
                 .sort()
             const series: PrinterTempHistoryStateSerie[] = []


### PR DESCRIPTION
This should fix https://github.com/mainsail-crew/mainsail/issues/799

There was, what i assume, an issue during the construction of the dataset for the tempchart which led to duplicated pushes of the pwm fan name.

Lets say i had a pwm fan with the name `my_pwm_fan`, a dataset for `my_pwm_fan` and a dataset for `my_pwm_fan-speed` was added to the master dataset resulting in duplicated entries for the pwm checkbox and duplicated entries for the tempchart tooltip.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>