### PR TITLE
fix: do not show `null RPM` in temp chart (fixes #818)

### DIFF
--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -155,7 +155,7 @@
                                             </span>
                                         </div>
                                         <div v-if="object.rpm !== null">
-                                            <small :class="object.rpmClass">{{ object.rpm }}</small>
+                                            <small :class="object.rpmClass">{{ object.rpm }} RPM</small>
                                         </div>
                                     </td>
                                     <td class="target">

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -254,7 +254,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
                     max_temp: fan.max_temp,
                     measured_min_temp: null,
                     measured_max_temp: null,
-                    rpm: `${fan.rpm} RPM`,
+                    rpm: fan.rpm,
                     rpmClass: fan.rpm === 0 && fan.speed > 0 ? 'red--text' : '',
                     command: 'SET_TEMPERATURE_FAN_TARGET',
                     commandAttributeName: 'TEMPERATURE_FAN',

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -86,7 +86,7 @@ export interface PrinterStateTemperatureObject {
     max_temp: number
     measured_min_temp: number | null
     measured_max_temp: number | null
-    rpm: string | null
+    rpm: number | null
     rpmClass: string
     command: 'SET_HEATER_TEMPERATURE' | 'SET_TEMPERATURE_FAN_TARGET' | null
     commandAttributeName: 'HEATER' | 'TEMPERATURE_FAN' | null


### PR DESCRIPTION
This PR will correct an issue with the `PrinterStateTemperatureObject` interface.

`object.rpm` in `TemperaturePanel.vue` always returned a string because `RPM` got appended to the rpm value, which made a checking for `!== null` always be true.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>