### PR TITLE
refactor: remove duplicated settings header

### DIFF
--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -6,7 +6,13 @@
             <v-card-text>
                 <v-form ref="formControlExtruder">
                     <!-- TOOLHEAD CONTROL SETTINGS -->
-                    <v-card-title class="mx-n4">{{ $t('Panels.ToolheadControlPanel.Headline') }}</v-card-title>
+                    <div class="d-flex align-center">
+                        <v-icon style="opacity: 0.7">{{ mdiGamepad }}</v-icon>
+                        <v-card-title class="mx-n2">
+                            {{ $t('Panels.ToolheadControlPanel.Headline') }}
+                        </v-card-title>
+                        <v-divider class="ml-3"></v-divider>
+                    </div>
                     <settings-row :title="$t('Settings.ControlTab.Style').toString()">
                         <v-select
                             v-model="controlStyle"
@@ -201,8 +207,6 @@
                         </settings-row>
                         <v-divider class="my-2"></v-divider>
                     </template>
-                    <!-- EXTRUDER CONTROL SETTINGS -->
-                    <v-card-title class="mx-n4">{{ $t('Panels.ExtruderControlPanel.Headline') }}</v-card-title>
                     <settings-row
                         :title="$t('Settings.ControlTab.ZOffsetIncrements').toString()"
                         :mobile-second-row="true">
@@ -226,6 +230,14 @@
                             hide-spin-buttons />
                     </settings-row>
                     <v-divider class="my-2"></v-divider>
+                    <!-- EXTRUDER CONTROL SETTINGS -->
+                    <div class="d-flex align-center">
+                        <v-icon style="opacity: 0.7">{{ mdiPrinter3dNozzle }}</v-icon>
+                        <v-card-title class="mx-n2">
+                            {{ $t('Panels.ExtruderControlPanel.Headline') }}
+                        </v-card-title>
+                        <v-divider class="ml-3"></v-divider>
+                    </div>
                     <settings-row
                         :title="$t('Settings.ControlTab.MoveDistancesEInMm').toString()"
                         :mobile-second-row="true">
@@ -269,6 +281,7 @@
                             outlined
                             hide-spin-buttons></v-combobox>
                     </settings-row>
+                    <v-divider class="my-2"></v-divider>
                     <settings-row
                         :title="$t('Settings.ControlTab.EstimatedExtrusionInfo').toString()"
                         :sub-title="$t('Settings.ControlTab.EstimatedExtrusionInfoDescription').toString()"
@@ -286,11 +299,15 @@ import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import ControlMixin from '@/components/mixins/control'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
+import { mdiPrinter3dNozzle, mdiGamepad } from '@mdi/js'
 
 @Component({
     components: { SettingsRow },
 })
 export default class SettingsControlTab extends Mixins(BaseMixin, ControlMixin) {
+    mdiGamepad = mdiGamepad
+    mdiPrinter3dNozzle = mdiPrinter3dNozzle
+
     declare $refs: {
         formControlExtruder: HTMLFormElement
     }

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -226,8 +226,6 @@
                             hide-spin-buttons />
                     </settings-row>
                     <v-divider class="my-2"></v-divider>
-                    <!-- EXTRUDER CONTROL SETTINGS -->
-                    <v-card-title class="mx-n4">{{ $t('Panels.ExtruderControlPanel.Headline') }}</v-card-title>
                     <settings-row
                         :title="$t('Settings.ControlTab.MoveDistancesEInMm').toString()"
                         :mobile-second-row="true">

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -229,7 +229,6 @@
                             outlined
                             hide-spin-buttons />
                     </settings-row>
-                    <v-divider class="my-2"></v-divider>
                     <!-- EXTRUDER CONTROL SETTINGS -->
                     <div class="d-flex align-center">
                         <v-icon style="opacity: 0.7">{{ mdiPrinter3dNozzle }}</v-icon>


### PR DESCRIPTION
This PR fixes an issue with a duplicated extruder settings header and removes it.
It also improves the visuals of said headers by adding their respective panel icons and a divider to the header.

### Before
![22-05-20_17-35-28_chrome](https://user-images.githubusercontent.com/31533186/169562724-029a48e6-4596-4f92-8841-4c0e3d05dff3.png)

![22-05-20_17-35-34_chrome](https://user-images.githubusercontent.com/31533186/169562739-66a71105-6a83-485f-a09b-f9142a895d74.png)



### After
![22-05-20_17-34-25_chrome](https://user-images.githubusercontent.com/31533186/169562749-404f3f2b-d35d-4a42-ab7c-fae05c5f7335.png)

![image](https://user-images.githubusercontent.com/31533186/169563275-3488b2d3-09fe-43b4-a345-07a01d4e4704.png)



Signed-off-by: Dominik Willner <th33xitus@gmail.com>