### PR TITLE
fix: don't createObjectURL, when webcam img doesn't exist in Mjpegstreamer.vue

### DIFF
--- a/src/components/webcams/Mjpegstreamer.vue
+++ b/src/components/webcams/Mjpegstreamer.vue
@@ -148,8 +148,12 @@ export default class Mjpegstreamer extends Mixins(BaseMixin) {
                                         }
                                         // we're done reading the jpeg. Time to render it.
                                         else {
-                                            img.src = URL.createObjectURL(new Blob([imageBuffer], { type: TYPE_JPEG }))
-                                            img.onload = () => URL.revokeObjectURL(img.src)
+                                            if (img) {
+                                                img.src = URL.createObjectURL(
+                                                    new Blob([imageBuffer], { type: TYPE_JPEG })
+                                                )
+                                                img.onload = () => URL.revokeObjectURL(img.src)
+                                            }
                                             frames++
                                             contentLength = 0
                                             bytesRead = 0


### PR DESCRIPTION


Signed-off-by: Stefan Dej <meteyou@gmail.com>