### PR TITLE
fix: tool selection in extruder panel

### DIFF
--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -117,22 +117,7 @@
         <responsive :breakpoints="{ large: (el) => el.width >= 640 }">
             <template #default="{ el }">
                 <!-- TOOL SELECTOR BUTTONS -->
-                <v-container v-if="extruders.length === toolchangeMacros.length" class="pb-1">
-                    <v-item-group class="_btn-group py-0">
-                        <v-btn
-                            v-for="extruder in extruders"
-                            :key="extruder.key"
-                            :class="extruder.key === activeExtruder ? 'primary--text' : {}"
-                            :value="extruder.key"
-                            :disabled="isPrinting"
-                            dense
-                            class="flex-grow-1 px-0"
-                            @click="doSend(toolchangeMacros[extruders.indexOf(extruder)])">
-                            {{ toolchangeMacros[extruders.indexOf(extruder)] }}
-                        </v-btn>
-                    </v-item-group>
-                </v-container>
-                <v-container v-else-if="extruderSteppers.length === toolchangeMacros.length" class="pb-1">
+                <v-container v-if="toolchangeMacros.length" class="pb-1">
                     <v-item-group class="_btn-group py-0">
                         <v-btn
                             v-for="tool in toolchangeMacros"
@@ -376,7 +361,7 @@ import {
     mdiDotsVertical,
 } from '@mdi/js'
 import { Component, Mixins, Watch } from 'vue-property-decorator'
-import { PrinterStateExtruder, PrinterStateExtruderStepper } from '@/store/printer/types'
+import { PrinterStateExtruder } from '@/store/printer/types'
 import BaseMixin from '../mixins/base'
 import ControlMixin from '../mixins/control'
 import NumberInput from '@/components/inputs/NumberInput.vue'
@@ -428,10 +413,6 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
 
     get extruders(): PrinterStateExtruder[] {
         return this.$store.getters['printer/getExtruders']
-    }
-
-    get extruderSteppers(): PrinterStateExtruderStepper[] {
-        return this.$store.getters['printer/getExtruderSteppers']
     }
 
     get activeExtruder(): string {

--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -117,16 +117,17 @@
         <responsive :breakpoints="{ large: (el) => el.width >= 640 }">
             <template #default="{ el }">
                 <!-- TOOL SELECTOR BUTTONS -->
-                <v-container v-if="toolchangeMacros.length" class="pb-1">
+                <v-container v-if="toolchangeMacros.length > 1" class="pb-1">
                     <v-item-group class="_btn-group py-0">
                         <v-btn
                             v-for="tool in toolchangeMacros"
-                            :key="tool"
+                            :key="tool.name"
+                            :class="tool.active ? 'primary--text' : {}"
                             :disabled="isPrinting"
                             dense
                             class="flex-grow-1 px-0"
-                            @click="doSend(tool)">
-                            {{ tool }}
+                            @click="doSend(tool.name)">
+                            {{ tool.name }}
                         </v-btn>
                     </v-item-group>
                 </v-container>
@@ -361,7 +362,7 @@ import {
     mdiDotsVertical,
 } from '@mdi/js'
 import { Component, Mixins, Watch } from 'vue-property-decorator'
-import { PrinterStateExtruder } from '@/store/printer/types'
+import { PrinterStateExtruder, PrinterStateToolchangeMacro } from '@/store/printer/types'
 import BaseMixin from '../mixins/base'
 import ControlMixin from '../mixins/control'
 import NumberInput from '@/components/inputs/NumberInput.vue'
@@ -392,14 +393,8 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
         return ['printing'].includes(this.printer_state)
     }
 
-    get toolchangeMacros(): string[] {
-        const macros = this.$store.getters['printer/getMacros']
-        let tools: string[] = []
-        macros
-            .filter((macro: any) => macro.name.toUpperCase().match(/^T\d+/))
-            .forEach((macro: any) => tools.push(macro.name))
-
-        return tools
+    get toolchangeMacros(): PrinterStateToolchangeMacro[] {
+        return this.$store.getters['printer/getToolchangeMacros']
     }
 
     get filamentChangeMacros(): boolean {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -18,6 +18,7 @@ import {
     PrinterStateMacro,
     PrinterStateTemperatureObject,
     PrinterStateTemperatureSensor,
+    PrinterStateToolchangeMacro,
 } from '@/store/printer/types'
 import { caseInsensitiveSort, formatFrequency, getMacroParams } from '@/plugins/helpers'
 import { RootState } from '@/store/types'
@@ -69,11 +70,14 @@ export const getters: GetterTree<PrinterState, RootState> = {
                     !('rename_existing' in state.configfile.config[prop]) &&
                     !(hiddenMacros.indexOf(prop.replace('gcode_macro ', '').toLowerCase()) > -1)
                 ) {
+                    const variables = state[prop] ?? {}
+
                     array.push({
                         name: prop.replace('gcode_macro ', ''),
                         description: state.configfile.config[prop].description ?? null,
                         prop: state.configfile.config[prop],
                         params: getMacroParams(state.configfile.config[prop]),
+                        variables,
                     })
                 }
             })
@@ -461,11 +465,14 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 !prop.startsWith('gcode_macro _') &&
                 !Object.hasOwnProperty.call(state.configfile.config[prop], 'rename_existing')
             ) {
+                const variables = state[prop] ?? {}
+
                 array.push({
                     name: prop.replace('gcode_macro ', ''),
                     description: state.configfile.config[prop].description ?? null,
                     prop: state.configfile.config[prop],
                     params: getMacroParams(state.configfile.config[prop]),
+                    variables,
                 })
             }
         })
@@ -845,6 +852,22 @@ export const getters: GetterTree<PrinterState, RootState> = {
         if (time && timeCount) return Date.now() + (time / timeCount) * 1000
 
         return 0
+    },
+
+    getToolchangeMacros: (state, getters) => {
+        const macros = getters['getMacros']
+        const tools: PrinterStateToolchangeMacro[] = []
+
+        macros
+            .filter((macro: any) => macro.name.toUpperCase().match(/^T\d+/))
+            .forEach((macro: any) =>
+                tools.push({
+                    name: macro.name,
+                    active: macro.variables.active ?? false,
+                })
+            )
+
+        return tools
     },
 
     existsQGL: (state) => {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -9,6 +9,7 @@ import {
     PrinterState,
     PrinterStateBedMesh,
     PrinterStateExtruder,
+    PrinterStateExtruderStepper,
     PrinterStateFan,
     PrinterStateFilamentSensors,
     PrinterStateHeater,
@@ -674,7 +675,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
         const extruders: PrinterStateExtruder[] = []
         if (state.configfile?.settings) {
             Object.keys(state.configfile?.settings)
-                .filter((key) => key.startsWith('extruder'))
+                .filter((key) => key.match(/^(extruder)\d?$/g))
                 .sort()
                 .forEach((key: string) => {
                     const extruder = state.configfile?.settings[key]
@@ -689,6 +690,24 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 })
         }
         return extruders
+    },
+
+    getExtruderSteppers: (state) => {
+        const extruderSteppers: PrinterStateExtruderStepper[] = []
+        if (state.configfile?.settings) {
+            Object.keys(state.configfile?.settings)
+                .filter((key) => key.match(/^extruder_stepper/g))
+                .sort()
+                .forEach((key: string) => {
+                    const extruderStepper = state.configfile?.settings[key]
+                    extruderSteppers.push({
+                        key: key,
+                        name: key.replace('extruder_stepper ', ''),
+                        extruder: extruderStepper.extruder,
+                    })
+                })
+        }
+        return extruderSteppers
     },
 
     getExtrudePossible: (state) => {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -9,7 +9,6 @@ import {
     PrinterState,
     PrinterStateBedMesh,
     PrinterStateExtruder,
-    PrinterStateExtruderStepper,
     PrinterStateFan,
     PrinterStateFilamentSensors,
     PrinterStateHeater,
@@ -690,24 +689,6 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 })
         }
         return extruders
-    },
-
-    getExtruderSteppers: (state) => {
-        const extruderSteppers: PrinterStateExtruderStepper[] = []
-        if (state.configfile?.settings) {
-            Object.keys(state.configfile?.settings)
-                .filter((key) => key.match(/^extruder_stepper/g))
-                .sort()
-                .forEach((key: string) => {
-                    const extruderStepper = state.configfile?.settings[key]
-                    extruderSteppers.push({
-                        key: key,
-                        name: key.replace('extruder_stepper ', ''),
-                        extruder: extruderStepper.extruder,
-                    })
-                })
-        }
-        return extruderSteppers
     },
 
     getExtrudePossible: (state) => {

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -221,3 +221,9 @@ export interface PrinterStateExtruder {
     nozzleDiameter: number
     maxExtrudeOnlyDistance: number
 }
+
+export interface PrinterStateExtruderStepper {
+    key: string
+    name: string
+    extruder: number
+}

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -169,6 +169,10 @@ export interface PrinterStateMacro {
         // eslint-disable-next-line
         [key: string]: any
     }
+    variables: {
+        // eslint-disable-next-line
+        [key: string]: any
+    }
     params: PrinterStateMacroParams
 }
 
@@ -213,11 +217,7 @@ export interface PrinterStateExtruder {
     maxExtrudeOnlyDistance: number
 }
 
-export interface PrinterStateExtruder {
-    key: string
+export interface PrinterStateToolchangeMacro {
     name: string
-    filamentDiameter: number
-    minExtrudeTemp: number
-    nozzleDiameter: number
-    maxExtrudeOnlyDistance: number
+    active: boolean
 }

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -221,9 +221,3 @@ export interface PrinterStateExtruder {
     nozzleDiameter: number
     maxExtrudeOnlyDistance: number
 }
-
-export interface PrinterStateExtruderStepper {
-    key: string
-    name: string
-    extruder: number
-}


### PR DESCRIPTION
### Issue:
![image](https://user-images.githubusercontent.com/31533186/170110346-bff33139-8ca7-45c2-8c3c-745005219110.png)

### Solution:
![image](https://user-images.githubusercontent.com/31533186/170111499-0cd05a7b-8ebf-4ebd-86e5-2e27c586bfb7.png)


This will require the user to set up dedicated tool change macros in the form of `T0`, `T1` ... `Tn` to be able to switch between them via Mainsail. Not having those macros defined, will make those buttons NOT appear anymore.

This implementation lacks the highlighting of the currently active tool in case of multiple extruder that are set up with `extruder_stepper` and are being synced to a motion queue due to technical limitations of Klipper (it currently seems to be impossible to detect which extruder_stepper is currently synced to the active extruder). Highlighting the current active extruder in regular multi extruder setups is still functional!


Signed-off-by: Dominik Willner <th33xitus@gmail.com>