### PR TITLE
refactor: hide PA input fields if extruder_stepper is configured

### DIFF
--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -146,8 +146,10 @@
                         attribute-name="S"></tool-slider>
                 </v-container>
                 <!-- PRESSURE ADVANCE SETTINGS -->
-                <v-divider></v-divider>
-                <pressure-advance-settings></pressure-advance-settings>
+                <template v-if="!extruderSteppers.length > 0">
+                    <v-divider></v-divider>
+                    <pressure-advance-settings></pressure-advance-settings>
+                </template>
                 <v-divider class="pb-1"></v-divider>
                 <!-- EXTRUDER INPUTS AND QUICKSELECTS -->
                 <v-container>
@@ -362,7 +364,7 @@ import {
     mdiDotsVertical,
 } from '@mdi/js'
 import { Component, Mixins, Watch } from 'vue-property-decorator'
-import { PrinterStateExtruder, PrinterStateToolchangeMacro } from '@/store/printer/types'
+import { PrinterStateExtruder, PrinterStateExtruderStepper, PrinterStateToolchangeMacro } from '@/store/printer/types'
 import BaseMixin from '../mixins/base'
 import ControlMixin from '../mixins/control'
 import NumberInput from '@/components/inputs/NumberInput.vue'
@@ -408,6 +410,10 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
 
     get extruders(): PrinterStateExtruder[] {
         return this.$store.getters['printer/getExtruders']
+    }
+
+    get extruderSteppers(): PrinterStateExtruderStepper[] {
+        return this.$store.getters['printer/getExtruderSteppers']
     }
 
     get activeExtruder(): string {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -9,6 +9,7 @@ import {
     PrinterState,
     PrinterStateBedMesh,
     PrinterStateExtruder,
+    PrinterStateExtruderStepper,
     PrinterStateFan,
     PrinterStateFilamentSensors,
     PrinterStateHeater,
@@ -696,6 +697,24 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 })
         }
         return extruders
+    },
+
+    getExtruderSteppers: (state) => {
+        const extruderSteppers: PrinterStateExtruderStepper[] = []
+        if (state.configfile?.settings) {
+            Object.keys(state.configfile?.settings)
+                .filter((key) => key.match(/^extruder_stepper/g))
+                .sort()
+                .forEach((key: string) => {
+                    const extruderStepper = state.configfile?.settings[key]
+                    extruderSteppers.push({
+                        key: key,
+                        name: key.replace('extruder_stepper ', ''),
+                        extruder: extruderStepper.extruder,
+                    })
+                })
+        }
+        return extruderSteppers
     },
 
     getExtrudePossible: (state) => {

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -217,6 +217,12 @@ export interface PrinterStateExtruder {
     maxExtrudeOnlyDistance: number
 }
 
+export interface PrinterStateExtruderStepper {
+    key: string
+    name: string
+    extruder: number
+}
+
 export interface PrinterStateToolchangeMacro {
     name: string
     active: boolean


### PR DESCRIPTION
This PR is (hopefully only) a temporary solution to this issue: https://github.com/mainsail-crew/mainsail/issues/845
There is no safe way to set pressure advance values via those input fields, so we now disable them once we come across such printer configurations.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>