### PR TITLE
fix: hide toolhead, extruder & temperature panel if they have no content

### DIFF
--- a/src/components/mixins/dashboard.ts
+++ b/src/components/mixins/dashboard.ts
@@ -8,6 +8,22 @@ import Vue from 'vue'
 
 @Component
 export default class DashboardMixin extends BaseMixin {
+    get printerKinematics() {
+        return this.$store.getters['printer/getKinematics']
+    }
+
+    get printerExtruderCount() {
+        return this.$store.getters['printer/getExtruders'].length
+    }
+
+    get printerAvailableHeatersCount() {
+        return this.$store.getters['printer/getAvailableHeaters'].length
+    }
+
+    get printerAvailableSensorsCount() {
+        return this.$store.getters['printer/getAvailableSensors'].length
+    }
+
     get macroMode() {
         return this.$store.state.gui.macros.mode ?? 'simple'
     }
@@ -64,6 +80,21 @@ export default class DashboardMixin extends BaseMixin {
             })
 
             allPanels = allPanels.filter((name) => name !== 'macros')
+        }
+
+        // remove toolhead panel, if kinematics === none
+        if (this.printerKinematics === 'none') {
+            allPanels = allPanels.filter((name) => name !== 'toolhead-control')
+        }
+
+        // remove extruder panel, if printerExtruderCount < 1
+        if (this.printerExtruderCount < 1) {
+            allPanels = allPanels.filter((name) => name !== 'extruder-control')
+        }
+
+        // remove temperature panel, if heaters & sensors < 1
+        if (this.printerAvailableHeatersCount + this.printerAvailableSensorsCount < 1) {
+            allPanels = allPanels.filter((name) => name !== 'temperature')
         }
 
         // remove webcam panel, if no webcam exists

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -115,12 +115,27 @@ import kebabCase from 'lodash.kebabcase'
 })
 export default class PageDashboard extends Mixins(DashboardMixin) {
     get allComponents() {
-        const output: string[] = []
+        let output: string[] = []
         const components = Object.keys(this.$options.components ?? {})
 
         components?.forEach((component) => {
             if (component.endsWith('Panel')) output.push(kebabCase(component))
         })
+
+        // remove toolhead panel, if kinematics === none
+        if (this.printerKinematics === 'none') {
+            output = output.filter((name) => name !== 'toolhead-control-panel')
+        }
+
+        // remove extruder panel, if printerExtruderCount < 1
+        if (this.printerExtruderCount < 1) {
+            output = output.filter((name) => name !== 'extruder-control-panel')
+        }
+
+        // remove temperature panel, if heaters & sensors < 1
+        if (this.printerAvailableHeatersCount + this.printerAvailableSensorsCount < 1) {
+            output = output.filter((name) => name !== 'temperature-panel')
+        }
 
         return output
     }

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -47,7 +47,7 @@ export const getters: GetterTree<GuiState, any> = {
                 panels = panels.filter((element: any) => {
                     if (!element.name.startsWith('macrogroup_')) return true
 
-                    const macrogroupId = element.name.substr(11)
+                    const macrogroupId = element.name.slice(11)
                     return (
                         macrogroups.findIndex(
                             (macrogroup: GuiMacrosStateMacrogroup) => macrogroup.id === macrogroupId

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -1,7 +1,6 @@
 import { GetterTree } from 'vuex'
 import { GuiState } from '@/store/gui/types'
 import { GuiMacrosStateMacrogroup } from '@/store/gui/macros/types'
-import Vue from 'vue'
 
 // eslint-disable-next-line
 export const getters: GetterTree<GuiState, any> = {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -452,6 +452,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
         return additionValues
     },
 
+    getAvailableHeaters: (state) => {
+        return state.heaters?.available_heaters ?? []
+    },
+
     getAvailableSensors: (state) => {
         return state.heaters?.available_sensors ?? []
     },
@@ -868,6 +872,12 @@ export const getters: GetterTree<PrinterState, RootState> = {
             )
 
         return tools
+    },
+
+    getKinematics: (state) => {
+        if (!state.configfile?.settings?.printer) return false
+
+        return state.configfile?.settings?.printer.kinematics ?? 'none'
     },
 
     existsQGL: (state) => {


### PR DESCRIPTION
- hide toolhead panel, if kinematics === none
- hide extruder panel, if no extruder is in the config
- hide temperature panel, if header & sensor count === 0

Signed-off-by: Stefan Dej <meteyou@gmail.com>