### PR TITLE
refactor: replace drag handle icons

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -147,7 +147,7 @@
                                         link>
                                         <v-row>
                                             <v-col class="col-auto pr-0">
-                                                <v-icon class="handle">{{ mdiArrowUpDown }}</v-icon>
+                                                <v-icon class="handle">{{ mdiDragVertical }}</v-icon>
                                             </v-col>
                                             <v-col>
                                                 {{ header.text }}
@@ -541,7 +541,7 @@ import Panel from '@/components/ui/Panel.vue'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import draggable from 'vuedraggable'
 import {
-    mdiArrowUpDown,
+    mdiDragVertical,
     mdiCheckboxBlankOutline,
     mdiCheckboxMarked,
     mdiCloseThick,
@@ -614,7 +614,7 @@ export default class GcodefilesPanel extends Mixins(BaseMixin) {
     mdiCloseThick = mdiCloseThick
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
     mdiCheckboxMarked = mdiCheckboxMarked
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
 
     validGcodeExtensions = validGcodeExtensions
     formatDate = formatDate

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -105,8 +105,7 @@
                                     <v-list-item
                                         v-for="header of configurableHeaders"
                                         :key="header.value"
-                                        class="minHeight36"
-                                        link>
+                                        class="minHeight36">
                                         <v-row>
                                             <v-col class="col-auto pr-0">
                                                 <v-icon class="handle">{{ mdiDragVertical }}</v-icon>
@@ -1375,5 +1374,9 @@ export default class GcodefilesPanel extends Mixins(BaseMixin) {
 .file-list__count_printed {
     position: relative;
     top: 1px;
+}
+
+.handle {
+    cursor: move;
 }
 </style>

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -1,41 +1,3 @@
-<style>
-/*noinspection CssUnusedSymbol*/
-.files-table .v-data-table-header__icon {
-    margin-left: 7px;
-}
-
-.files-table .file-list-cursor:hover {
-    cursor: pointer;
-}
-
-/*noinspection CssUnusedSymbol*/
-.file-list--select-td {
-    width: 20px;
-}
-
-/*noinspection CssUnusedSymbol*/
-.files-table th.text-start {
-    padding-right: 0 !important;
-}
-
-/*noinspection CssUnusedSymbol*/
-.v-chip.minimum-chip {
-    padding: 0;
-    min-width: 24px;
-}
-
-/*noinspection CssUnusedSymbol*/
-.v-chip.minimum-chip .v-chip__content {
-    margin: 0 auto;
-}
-
-/*noinspection CssUnusedSymbol*/
-.file-list__count_printed {
-    position: relative;
-    top: 1px;
-}
-</style>
-
 <template>
     <div>
         <panel
@@ -1377,3 +1339,41 @@ export default class GcodefilesPanel extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style>
+/*noinspection CssUnusedSymbol*/
+.files-table .v-data-table-header__icon {
+    margin-left: 7px;
+}
+
+.files-table .file-list-cursor:hover {
+    cursor: pointer;
+}
+
+/*noinspection CssUnusedSymbol*/
+.file-list--select-td {
+    width: 20px;
+}
+
+/*noinspection CssUnusedSymbol*/
+.files-table th.text-start {
+    padding-right: 0 !important;
+}
+
+/*noinspection CssUnusedSymbol*/
+.v-chip.minimum-chip {
+    padding: 0;
+    min-width: 24px;
+}
+
+/*noinspection CssUnusedSymbol*/
+.v-chip.minimum-chip .v-chip__content {
+    margin: 0 auto;
+}
+
+/*noinspection CssUnusedSymbol*/
+.file-list__count_printed {
+    position: relative;
+    top: 1px;
+}
+</style>

--- a/src/components/settings/SettingsDashboardTab.vue
+++ b/src/components/settings/SettingsDashboardTab.vue
@@ -5,7 +5,7 @@
         <v-card-text>
             <v-row>
                 <v-col class="text-center">
-                    <v-btn-toggle v-model="currentViewport" class="mx-auto">
+                    <v-btn-toggle v-model="currentViewport" class="mx-auto" mandatory>
                         <v-btn value="mobile">
                             <span class="hidden-sm-and-down">{{ $t('Settings.DashboardTab.Mobile') }}</span>
                             <v-icon right class="hidden-sm-and-down">{{ mdiCellphone }}</v-icon>

--- a/src/components/settings/SettingsDashboardTabDesktop.vue
+++ b/src/components/settings/SettingsDashboardTabDesktop.vue
@@ -26,7 +26,7 @@
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout1">
                                     <v-list-item :key="'item-desktop-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
@@ -66,7 +66,7 @@
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout2">
                                     <v-list-item :key="'item-desktop-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>

--- a/src/components/settings/SettingsDashboardTabDesktop.vue
+++ b/src/components/settings/SettingsDashboardTabDesktop.vue
@@ -109,7 +109,7 @@
 import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import draggable from 'vuedraggable'
-import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
+import { convertPanelnameToIcon } from '@/plugins/helpers'
 import DashboardMixin from '@/components/mixins/dashboard'
 import { mdiInformation, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiLock, mdiDragVertical } from '@mdi/js'
 
@@ -119,7 +119,6 @@ import { mdiInformation, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiLock, md
     },
 })
 export default class SettingsDashboardTabDesktop extends Mixins(DashboardMixin) {
-    capitalize = capitalize
     convertPanelnameToIcon = convertPanelnameToIcon
 
     /**

--- a/src/components/settings/SettingsDashboardTabDesktop.vue
+++ b/src/components/settings/SettingsDashboardTabDesktop.vue
@@ -1,10 +1,3 @@
-<style scoped>
-.ghost {
-    opacity: 0.5;
-    background: #c8ebfb;
-}
-</style>
-
 <template>
     <v-card flat>
         <v-card-text>
@@ -14,34 +7,34 @@
                         <v-list dense>
                             <v-list-item>
                                 <v-row>
-                                    <v-col class="col-auto pr-0">
+                                    <v-col class="col-auto pr-0 pl-8">
                                         <v-icon>{{ mdiInformation }}</v-icon>
                                     </v-col>
-                                    <v-col>
+                                    <v-col class="pr-0 text-truncate">
                                         {{ $t('Panels.StatusPanel.Headline') }}
                                     </v-col>
-                                    <v-col class="col-auto">
+                                    <v-col class="col-auto pl-0">
                                         <v-icon color="grey lighten-1">{{ mdiLock }}</v-icon>
                                     </v-col>
                                 </v-row>
                             </v-list-item>
                             <draggable
                                 v-model="desktopLayout1"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout1">
                                     <v-list-item :key="'item-desktop-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -67,21 +60,21 @@
                         <v-list dense>
                             <draggable
                                 v-model="desktopLayout2"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout2">
                                     <v-list-item :key="'item-desktop-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -118,7 +111,7 @@ import { Mixins } from 'vue-property-decorator'
 import draggable from 'vuedraggable'
 import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
 import DashboardMixin from '@/components/mixins/dashboard'
-import { mdiInformation, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiLock, mdiArrowUpDown } from '@mdi/js'
+import { mdiInformation, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiLock, mdiDragVertical } from '@mdi/js'
 
 @Component({
     components: {
@@ -135,7 +128,7 @@ export default class SettingsDashboardTabDesktop extends Mixins(DashboardMixin) 
 
     mdiLock = mdiLock
     mdiInformation = mdiInformation
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
@@ -188,3 +181,10 @@ export default class SettingsDashboardTabDesktop extends Mixins(DashboardMixin) 
     }
 }
 </script>
+
+<style scoped>
+.ghost {
+    opacity: 0.5;
+    background: #c8ebfb;
+}
+</style>

--- a/src/components/settings/SettingsDashboardTabDesktop.vue
+++ b/src/components/settings/SettingsDashboardTabDesktop.vue
@@ -25,7 +25,7 @@
                                 ghost-class="ghost"
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout1">
-                                    <v-list-item :key="'item-desktop-' + element.name" link>
+                                    <v-list-item :key="'item-desktop-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -65,7 +65,7 @@
                                 ghost-class="ghost"
                                 group="desktopViewport">
                                 <template v-for="element in desktopLayout2">
-                                    <v-list-item :key="'item-desktop-' + element.name" link>
+                                    <v-list-item :key="'item-desktop-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -119,17 +119,16 @@ import { mdiInformation, mdiCheckboxMarked, mdiCheckboxBlankOutline, mdiLock, md
     },
 })
 export default class SettingsDashboardTabDesktop extends Mixins(DashboardMixin) {
-    convertPanelnameToIcon = convertPanelnameToIcon
-
     /**
      * Icons
      */
-
     mdiLock = mdiLock
     mdiInformation = mdiInformation
     mdiDragVertical = mdiDragVertical
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
+
+    convertPanelnameToIcon = convertPanelnameToIcon
 
     get desktopLayout1() {
         let panels = this.$store.getters['gui/getPanels']('desktopLayout1')
@@ -185,5 +184,9 @@ export default class SettingsDashboardTabDesktop extends Mixins(DashboardMixin) 
 .ghost {
     opacity: 0.5;
     background: #c8ebfb;
+}
+
+.handle {
+    cursor: move;
 }
 </style>

--- a/src/components/settings/SettingsDashboardTabMobile.vue
+++ b/src/components/settings/SettingsDashboardTabMobile.vue
@@ -70,7 +70,7 @@ import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import DashboardMixin from '@/components/mixins/dashboard'
 import draggable from 'vuedraggable'
-import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
+import { convertPanelnameToIcon } from '@/plugins/helpers'
 import { mdiDragVertical, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
 @Component({
     components: {
@@ -87,7 +87,6 @@ export default class SettingsDashboardTabMobile extends Mixins(DashboardMixin) {
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
-    capitalize = capitalize
     convertPanelnameToIcon = convertPanelnameToIcon
 
     get mobileLayout() {

--- a/src/components/settings/SettingsDashboardTabMobile.vue
+++ b/src/components/settings/SettingsDashboardTabMobile.vue
@@ -1,10 +1,3 @@
-<style scoped>
-.ghost {
-    opacity: 0.5;
-    background: #c8ebfb;
-}
-</style>
-
 <template>
     <v-card flat>
         <v-card-text>
@@ -14,34 +7,34 @@
                         <v-list dense>
                             <v-list-item>
                                 <v-row>
-                                    <v-col class="col-auto pr-0">
+                                    <v-col class="col-auto pr-0 pl-8">
                                         <v-icon>{{ mdiInformation }}</v-icon>
                                     </v-col>
-                                    <v-col>
+                                    <v-col class="pr-0 text-truncate">
                                         {{ $t('Panels.StatusPanel.Headline') }}
                                     </v-col>
-                                    <v-col class="col-auto">
+                                    <v-col class="col-auto pl-0">
                                         <v-icon color="grey lighten-1">{{ mdiLock }}</v-icon>
                                     </v-col>
                                 </v-row>
                             </v-list-item>
                             <draggable
                                 v-model="mobileLayout"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="mobileViewport">
                                 <template v-for="element in mobileLayout">
                                     <v-list-item :key="'item-mobile-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -78,7 +71,7 @@ import { Mixins } from 'vue-property-decorator'
 import DashboardMixin from '@/components/mixins/dashboard'
 import draggable from 'vuedraggable'
 import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
-import { mdiArrowUpDown, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
+import { mdiDragVertical, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
 @Component({
     components: {
         draggable,
@@ -90,7 +83,7 @@ export default class SettingsDashboardTabMobile extends Mixins(DashboardMixin) {
      */
     mdiLock = mdiLock
     mdiInformation = mdiInformation
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
@@ -124,3 +117,10 @@ export default class SettingsDashboardTabMobile extends Mixins(DashboardMixin) {
     }
 }
 </script>
+
+<style scoped>
+.ghost {
+    opacity: 0.5;
+    background: #c8ebfb;
+}
+</style>

--- a/src/components/settings/SettingsDashboardTabMobile.vue
+++ b/src/components/settings/SettingsDashboardTabMobile.vue
@@ -25,7 +25,7 @@
                                 ghost-class="ghost"
                                 group="mobileViewport">
                                 <template v-for="element in mobileLayout">
-                                    <v-list-item :key="'item-mobile-' + element.name" link>
+                                    <v-list-item :key="'item-mobile-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -121,5 +121,9 @@ export default class SettingsDashboardTabMobile extends Mixins(DashboardMixin) {
 .ghost {
     opacity: 0.5;
     background: #c8ebfb;
+}
+
+.handle {
+    cursor: move;
 }
 </style>

--- a/src/components/settings/SettingsDashboardTabMobile.vue
+++ b/src/components/settings/SettingsDashboardTabMobile.vue
@@ -26,7 +26,7 @@
                                 group="mobileViewport">
                                 <template v-for="element in mobileLayout">
                                     <v-list-item :key="'item-mobile-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>

--- a/src/components/settings/SettingsDashboardTabTablet.vue
+++ b/src/components/settings/SettingsDashboardTabTablet.vue
@@ -25,7 +25,7 @@
                                 ghost-class="ghost"
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout1">
-                                    <v-list-item :key="'item-tablet-' + element.name" link>
+                                    <v-list-item :key="'item-tablet-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -65,7 +65,7 @@
                                 ghost-class="ghost"
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout2">
-                                    <v-list-item :key="'item-tablet-' + element.name" link>
+                                    <v-list-item :key="'item-tablet-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -183,5 +183,9 @@ export default class SettingsDashboardTabTablet extends Mixins(DashboardMixin) {
 .ghost {
     opacity: 0.5;
     background: #c8ebfb;
+}
+
+.handle {
+    cursor: move;
 }
 </style>

--- a/src/components/settings/SettingsDashboardTabTablet.vue
+++ b/src/components/settings/SettingsDashboardTabTablet.vue
@@ -1,10 +1,3 @@
-<style scoped>
-.ghost {
-    opacity: 0.5;
-    background: #c8ebfb;
-}
-</style>
-
 <template>
     <v-card flat>
         <v-card-text>
@@ -14,34 +7,34 @@
                         <v-list dense>
                             <v-list-item>
                                 <v-row>
-                                    <v-col class="col-auto pr-0">
+                                    <v-col class="col-auto pr-0 pl-8">
                                         <v-icon>{{ mdiInformation }}</v-icon>
                                     </v-col>
-                                    <v-col>
+                                    <v-col class="pr-0 text-truncate">
                                         {{ $t('Panels.StatusPanel.Headline') }}
                                     </v-col>
-                                    <v-col class="col-auto">
+                                    <v-col class="col-auto pl-0">
                                         <v-icon color="grey lighten-1">{{ mdiLock }}</v-icon>
                                     </v-col>
                                 </v-row>
                             </v-list-item>
                             <draggable
                                 v-model="tabletLayout1"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout1">
                                     <v-list-item :key="'item-tablet-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -67,21 +60,21 @@
                         <v-list dense>
                             <draggable
                                 v-model="tabletLayout2"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout2">
                                     <v-list-item :key="'item-tablet-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -118,7 +111,7 @@ import { Mixins } from 'vue-property-decorator'
 import DashboardMixin from '@/components/mixins/dashboard'
 import draggable from 'vuedraggable'
 import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
-import { mdiLock, mdiInformation, mdiArrowUpDown, mdiCheckboxMarked, mdiCheckboxBlankOutline } from '@mdi/js'
+import { mdiLock, mdiInformation, mdiDragVertical, mdiCheckboxMarked, mdiCheckboxBlankOutline } from '@mdi/js'
 @Component({
     components: {
         draggable,
@@ -130,7 +123,7 @@ export default class SettingsDashboardTabTablet extends Mixins(DashboardMixin) {
      */
     mdiLock = mdiLock
     mdiInformation = mdiInformation
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
@@ -186,3 +179,10 @@ export default class SettingsDashboardTabTablet extends Mixins(DashboardMixin) {
     }
 }
 </script>
+
+<style scoped>
+.ghost {
+    opacity: 0.5;
+    background: #c8ebfb;
+}
+</style>

--- a/src/components/settings/SettingsDashboardTabTablet.vue
+++ b/src/components/settings/SettingsDashboardTabTablet.vue
@@ -26,7 +26,7 @@
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout1">
                                     <v-list-item :key="'item-tablet-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
@@ -66,7 +66,7 @@
                                 group="tabletViewport">
                                 <template v-for="element in tabletLayout2">
                                     <v-list-item :key="'item-tablet-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>

--- a/src/components/settings/SettingsDashboardTabTablet.vue
+++ b/src/components/settings/SettingsDashboardTabTablet.vue
@@ -110,7 +110,7 @@ import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import DashboardMixin from '@/components/mixins/dashboard'
 import draggable from 'vuedraggable'
-import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
+import { convertPanelnameToIcon } from '@/plugins/helpers'
 import { mdiLock, mdiInformation, mdiDragVertical, mdiCheckboxMarked, mdiCheckboxBlankOutline } from '@mdi/js'
 @Component({
     components: {
@@ -127,7 +127,6 @@ export default class SettingsDashboardTabTablet extends Mixins(DashboardMixin) {
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
-    capitalize = capitalize
     convertPanelnameToIcon = convertPanelnameToIcon
 
     get tabletLayout1() {

--- a/src/components/settings/SettingsDashboardTabWidescreen.vue
+++ b/src/components/settings/SettingsDashboardTabWidescreen.vue
@@ -25,7 +25,7 @@
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout1">
-                                    <v-list-item :key="'item-widescreen-' + element.name" link>
+                                    <v-list-item :key="'item-widescreen-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -65,7 +65,7 @@
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout2">
-                                    <v-list-item :key="'item-widescreen-' + element.name" link>
+                                    <v-list-item :key="'item-widescreen-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -105,7 +105,7 @@
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout3">
-                                    <v-list-item :key="'item-widescreen-' + element.name" link>
+                                    <v-list-item :key="'item-widescreen-' + element.name">
                                         <v-row>
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
@@ -254,5 +254,9 @@ export default class SettingsDashboardTabWidescreen extends Mixins(DashboardMixi
 .ghost {
     opacity: 0.5;
     background: #c8ebfb;
+}
+
+.handle {
+    cursor: move;
 }
 </style>

--- a/src/components/settings/SettingsDashboardTabWidescreen.vue
+++ b/src/components/settings/SettingsDashboardTabWidescreen.vue
@@ -106,7 +106,7 @@
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout3">
                                     <v-list-item :key="'item-widescreen-' + element.name">
-                                        <v-row>
+                                        <v-row class="d-flex align-center">
                                             <v-col class="col-auto px-0">
                                                 <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
                                                 <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>

--- a/src/components/settings/SettingsDashboardTabWidescreen.vue
+++ b/src/components/settings/SettingsDashboardTabWidescreen.vue
@@ -149,7 +149,7 @@
 import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import draggable from 'vuedraggable'
-import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
+import { convertPanelnameToIcon } from '@/plugins/helpers'
 import DashboardMixin from '@/components/mixins/dashboard'
 import { mdiDragVertical, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
 @Component({
@@ -167,7 +167,6 @@ export default class SettingsDashboardTabWidescreen extends Mixins(DashboardMixi
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
-    capitalize = capitalize
     convertPanelnameToIcon = convertPanelnameToIcon
 
     get widescreenLayout1() {

--- a/src/components/settings/SettingsDashboardTabWidescreen.vue
+++ b/src/components/settings/SettingsDashboardTabWidescreen.vue
@@ -1,10 +1,3 @@
-<style scoped>
-.ghost {
-    opacity: 0.5;
-    background: #c8ebfb;
-}
-</style>
-
 <template>
     <v-card flat>
         <v-card-text>
@@ -14,34 +7,34 @@
                         <v-list dense>
                             <v-list-item>
                                 <v-row>
-                                    <v-col class="col-auto pr-0">
+                                    <v-col class="col-auto pr-0 pl-8">
                                         <v-icon>{{ mdiInformation }}</v-icon>
                                     </v-col>
-                                    <v-col>
+                                    <v-col class="pr-0 text-truncate">
                                         {{ $t('Panels.StatusPanel.Headline') }}
                                     </v-col>
-                                    <v-col class="col-auto">
+                                    <v-col class="col-auto pl-0">
                                         <v-icon color="grey lighten-1">{{ mdiLock }}</v-icon>
                                     </v-col>
                                 </v-row>
                             </v-list-item>
                             <draggable
                                 v-model="widescreenLayout1"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout1">
                                     <v-list-item :key="'item-widescreen-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -67,21 +60,21 @@
                         <v-list dense>
                             <draggable
                                 v-model="widescreenLayout2"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout2">
                                     <v-list-item :key="'item-widescreen-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -107,21 +100,21 @@
                         <v-list dense>
                             <draggable
                                 v-model="widescreenLayout3"
-                                :handle="isMobile ? '.handle' : ''"
+                                handle=".handle"
                                 class="v-list-item-group"
                                 ghost-class="ghost"
                                 group="widescreenViewport">
                                 <template v-for="element in widescreenLayout3">
                                     <v-list-item :key="'item-widescreen-' + element.name" link>
                                         <v-row>
-                                            <v-col class="col-auto pr-0">
-                                                <v-icon v-if="isMobile" class="handle">{{ mdiArrowUpDown }}</v-icon>
-                                                <v-icon v-else v-text="convertPanelnameToIcon(element.name)"></v-icon>
+                                            <v-col class="col-auto px-0">
+                                                <v-icon class="handle pr-2">{{ mdiDragVertical }}</v-icon>
+                                                <v-icon v-text="convertPanelnameToIcon(element.name)"></v-icon>
                                             </v-col>
-                                            <v-col class="pr-0">
+                                            <v-col class="pr-0 text-truncate">
                                                 {{ getPanelName(element.name) }}
                                             </v-col>
-                                            <v-col class="col-auto pl-0">
+                                            <v-col class="col-auto pl-2">
                                                 <v-icon
                                                     v-if="!element.visible"
                                                     color="grey lighten-1"
@@ -158,7 +151,7 @@ import { Mixins } from 'vue-property-decorator'
 import draggable from 'vuedraggable'
 import { capitalize, convertPanelnameToIcon } from '@/plugins/helpers'
 import DashboardMixin from '@/components/mixins/dashboard'
-import { mdiArrowUpDown, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
+import { mdiDragVertical, mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiInformation, mdiLock } from '@mdi/js'
 @Component({
     components: {
         draggable,
@@ -170,7 +163,7 @@ export default class SettingsDashboardTabWidescreen extends Mixins(DashboardMixi
      */
     mdiLock = mdiLock
     mdiInformation = mdiInformation
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiCheckboxBlankOutline = mdiCheckboxBlankOutline
 
@@ -257,3 +250,10 @@ export default class SettingsDashboardTabWidescreen extends Mixins(DashboardMixi
     }
 }
 </script>
+
+<style scoped>
+.ghost {
+    opacity: 0.5;
+    background: #c8ebfb;
+}
+</style>

--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -145,7 +145,7 @@
                             <div :key="macro.name">
                                 <v-row>
                                     <v-col class="col-auto pr-0 d-flex">
-                                        <v-icon class="handle">{{ mdiArrowUpDown }}</v-icon>
+                                        <v-icon class="handle">{{ mdiDragVertical }}</v-icon>
                                     </v-col>
                                     <v-col>
                                         <settings-row
@@ -309,7 +309,7 @@ import {
     mdiPause,
     mdiPrinter3dNozzle,
     mdiPlus,
-    mdiArrowUpDown,
+    mdiDragVertical,
     mdiPalette,
     mdiPencil,
 } from '@mdi/js'
@@ -319,15 +319,15 @@ import {
 })
 export default class SettingsMacrosTabExpert extends Mixins(BaseMixin) {
     /**
-Icons
-*/
+     * Icons
+     */
     mdiPencil = mdiPencil
     mdiDelete = mdiDelete
     mdiSleep = mdiSleep
     mdiPause = mdiPause
     mdiPrinter3dNozzle = mdiPrinter3dNozzle
     mdiPlus = mdiPlus
-    mdiArrowUpDown = mdiArrowUpDown
+    mdiDragVertical = mdiDragVertical
     mdiPalette = mdiPalette
 
     private rules = {


### PR DESCRIPTION
## This PR currently includes:
- replace old drag handles with proper dragging icons
  - GcodefilesPanel.vue, SettingsMacroTabExpert, SettingsDashboardTab (multiple)
- always show drag handles
- truncate text if viewport too narrow
- bugfix: it was possible to toogle viewports on and off
- cursor style becomes "move" on hover over drag handle

## Screenshots:
![image](https://user-images.githubusercontent.com/31533186/173133756-67240776-c840-42cf-b1aa-48810e016825.png)
![image](https://user-images.githubusercontent.com/31533186/173157100-e7a7cb09-4b9e-413f-b05b-29f83a650f9d.png)
![image](https://user-images.githubusercontent.com/31533186/173157117-2bed8cb0-3d87-434b-9cfd-a4dd44992785.png)





Signed-off-by: Dominik Willner <th33xitus@gmail.com>