### PR TITLE
style: Change emergency stop icon to avoid confusion on mobile

### DIFF
--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -91,7 +91,7 @@
                 class="button-min-width-auto px-3 emergency-button"
                 :loading="loadings.includes('topbarEmergencyStop')"
                 @click="btnEmergencyStop">
-                <v-icon class="mr-md-2">{{ mdiAlertCircleOutline }}</v-icon>
+                <v-icon class="mr-md-2">{{ mdiAlertOctagon }}</v-icon>
                 <span class="d-none d-md-inline">{{ $t('App.TopBar.EmergencyStop') }}</span>
             </v-btn>
             <the-notification-menu></the-notification-menu>
@@ -115,7 +115,7 @@
                 :title="$t('EmergencyStopDialog.EmergencyStop')"
                 toolbar-color="error"
                 card-class="emergency-stop-dialog"
-                :icon="mdiAlertCircleOutline"
+                :icon="mdiAlertOctagon"
                 :margin-bottom="false">
                 <template #buttons>
                     <v-btn icon tile @click="showEmergencyStopDialog = false">

--- a/src/store/server/history/getters.ts
+++ b/src/store/server/history/getters.ts
@@ -5,7 +5,7 @@ import {
     ServerHistoryStateJob,
 } from '@/store/server/history/types'
 import {
-    mdiAlertCircleOutline,
+    mdiAlertOctagon,
     mdiAlertOutline,
     mdiCheckboxMarkedCircleOutline,
     mdiCloseCircleOutline,


### PR DESCRIPTION
_Note: I didn't bother bringing this up anywhere before submitting this PR. I figured it was a quick enough edit that I wasn't out much time if the dev team doesn't want to make this change. Just consider this PR a suggestion._ 

Currently, the emergency stop icon is a circle with a exclamation mark inside. This can cause confusion on mobile when the "emergency stop" text is not displayed along side the icon. This is especially true for new users coming from octoprint, because octoprint uses an exclamation mark in the same location to alert users to warnings or errors detected. This confusion can cause new users to accidentally e-stop in the middle of a print thinking that they are just viewing an alert (ask me how I know). This has been brought up at least once on discord as well.

This PR changes the icon to an octagon with an exclamation mark inside. This "stop sign" should be a more intuitive indication of button function on mobile when the "emergency stop" text is hidden. Specifically, it changes the icon from `mdiAlertCircleOutline` to `mdiAlertOctagon`.