### PR TITLE
feat: support tvoc units

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -442,6 +442,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
                                 tmp[key]['unit'] = '%'
                                 break
 
+                            case 'tvoc':
+                                tmp[key]['unit'] = 'ppb'
+                                break
+
                             default:
                                 tmp[key]['unit'] = ''
                         }

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -446,6 +446,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
                                 tmp[key]['unit'] = 'ppb'
                                 break
 
+                            case 'eco2':
+                                tmp[key]['unit'] = 'ppm'
+                                break
+
                             default:
                                 tmp[key]['unit'] = ''
                         }

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -14,7 +14,7 @@ export const themeDir = '.theme'
 export const datasetInterval = 1000
 export const datasetTypes = ['temperature', 'target', 'power', 'speed']
 export const datasetTypesInPercents = ['power', 'speed']
-export const additionalSensors = ['bme280', 'htu21d']
+export const additionalSensors = ['bme280', 'htu21d', 'sgp30']
 
 /*
  * List of valid gcode file extensions


### PR DESCRIPTION

<img width="697" alt="Screen Shot 2022-06-24 at 8 28 26 PM" src="https://user-images.githubusercontent.com/5288782/175753162-182eef0d-1fd1-40b0-9ae4-6dcc8dfcc453.png">

In the Voron community, we are developing a controller for the [nevermore max](https://github.com/nevermore3d/Nevermore_Max). Part of this will be displaying [VOC](https://en.wikipedia.org/wiki/Volatile_organic_compound) levels from sensors such as the [SGP30](https://www.adafruit.com/product/3709).

This is only a partial solution. Currently, the additional values are only displayed if the sensor is advertised as being in the list in [additionalSensors](https://github.com/mainsail-crew/mainsail/blob/6661e031fbe8d4662fa2c838ede6668f137a1dcb/src/store/variables.ts#L17). In my testing, I am advertising to be a `bme280`. We might want to think about making this more generic in the future. 

However, I think my change in its current form is noninvasive and self-contained.