### PR TITLE
docker: set platform for build target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder stage, builds the application in node
 #
-FROM node:16-alpine as builder
+FROM --platform=$BUILDPLATFORM node:16-alpine as builder
 
 RUN apk add zip
 


### PR DESCRIPTION
This fixes the failed docker Builds caused by https://github.com/mainsail-crew/mainsail/pull/949.

As a bonus, this also speeds up the build process itself.   
The nature of the node application allows the generated static files to be used on multiple architectures. Therefore, they only need to be built once and then copied into the platform specific runtime images. 

Have a look at the test build I did: 
* Pipeline: https://github.com/mkuf/mainsail/runs/7250954266?check_suite_focus=true
* Image: https://github.com/mkuf/mainsail/pkgs/container/mainsail/27950035?tag=edge


-Markus