### PR TITLE
fix: hide TemperaturePanel if no sensors would be shown

### DIFF
--- a/src/components/mixins/dashboard.ts
+++ b/src/components/mixins/dashboard.ts
@@ -20,8 +20,8 @@ export default class DashboardMixin extends BaseMixin {
         return this.$store.getters['printer/getAvailableHeaters'].length
     }
 
-    get printerAvailableSensorsCount() {
-        return this.$store.getters['printer/getAvailableSensors'].length
+    get printerTemperatureSensorsCount() {
+        return this.$store.getters['printer/getTemperatureSensors'].length
     }
 
     get macroMode() {
@@ -93,7 +93,7 @@ export default class DashboardMixin extends BaseMixin {
         }
 
         // remove temperature panel, if heaters & sensors < 1
-        if (this.printerAvailableHeatersCount + this.printerAvailableSensorsCount < 1) {
+        if (this.printerAvailableHeatersCount + this.printerTemperatureSensorsCount < 1) {
             allPanels = allPanels.filter((name) => name !== 'temperature')
         }
 

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -133,7 +133,7 @@ export default class PageDashboard extends Mixins(DashboardMixin) {
         }
 
         // remove temperature panel, if heaters & sensors < 1
-        if (this.printerAvailableHeatersCount + this.printerAvailableSensorsCount < 1) {
+        if (this.printerAvailableHeatersCount + this.printerTemperatureSensorsCount < 1) {
             output = output.filter((name) => name !== 'temperature-panel')
         }
 


### PR DESCRIPTION
If all Temperature sensors start with `_` an empty `TemperaturePanel` was shown.

Signed-off-by: Manuel Thomassen <thom@ssen.codes>