### PR TITLE
feat: download button for crowsnest.log and sonar.log

### DIFF
--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -72,7 +72,7 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
     mdiDownload = mdiDownload
 
     get logfiles() {
-        return this.$store.getters['files/getDirectory']('logs').childrens
+        return this.$store.getters['files/getDirectory']('logs')?.childrens ?? []
     }
 
     get existsCrowsnestLog(): boolean {

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -1,6 +1,6 @@
 <template>
     <panel
-        :title="$t('Machine.LogfilesPanel.Logfiles')"
+        :title="$t('Machine.LogfilesPanel.Logfiles').toString()"
         :icon="mdiFileDocumentEdit"
         card-class="machine-logfiles-panel"
         :collapsible="true">

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -29,7 +29,7 @@
                         </v-btn>
                     </v-col>
                     <v-col
-                        v-if="crowsnestLog"
+                        v-if="existCrowsnestLog"
                         :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
                         <v-btn
                             :href="apiUrl + '/server/files/logs/crowsnest.log'"
@@ -41,7 +41,7 @@
                         </v-btn>
                     </v-col>
                     <v-col
-                        v-if="sonarLog && sonarLog.size > 0"
+                        v-if="existSonarLog"
                         :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
                         <v-btn
                             :href="apiUrl + '/server/files/logs/sonar.log'"
@@ -62,6 +62,7 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '../../mixins/base'
 import Panel from '@/components/ui/Panel.vue'
+import { FileStateFile } from '@/store/files/types'
 import { mdiDownload, mdiFileDocumentEdit } from '@mdi/js'
 @Component({
     components: { Panel },
@@ -70,16 +71,18 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
     mdiFileDocumentEdit = mdiFileDocumentEdit
     mdiDownload = mdiDownload
 
-    get crowsnestLog() {
-        const logfiles = this.$store.getters['files/getDirectory']('logs').childrens
-
-        return logfiles.find((log: { filename: string }) => log.filename === 'crowsnest.log')
+    get logfiles() {
+        return this.$store.getters['files/getDirectory']('logs').childrens
     }
 
-    get sonarLog() {
-        const logfiles = this.$store.getters['files/getDirectory']('logs').childrens
+    get existCrowsnestLog(): boolean {
+        return this.logfiles.findIndex((log: FileStateFile) => log.filename === 'crowsnest.log') !== -1
+    }
 
-        return logfiles.find((log: { filename: string }) => log.filename === 'sonar.log')
+    get existSonarLog(): boolean {
+        const sonarLog = this.logfiles.find((log: FileStateFile) => log.filename === 'sonar.log')
+
+        return sonarLog?.size > 0
     }
 
     downloadLog(event: any) {

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -28,6 +28,30 @@
                             Moonraker
                         </v-btn>
                     </v-col>
+                    <v-col
+                        v-if="crowsnestLog"
+                        :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
+                        <v-btn
+                            :href="apiUrl + '/server/files/logs/crowsnest.log'"
+                            block
+                            class="primary--text"
+                            @click="downloadLog">
+                            <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
+                            Crowsnest
+                        </v-btn>
+                    </v-col>
+                    <v-col
+                        v-if="sonarLog && sonarLog.size > 0"
+                        :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
+                        <v-btn
+                            :href="apiUrl + '/server/files/logs/sonar.log'"
+                            block
+                            class="primary--text"
+                            @click="downloadLog">
+                            <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
+                            Sonar
+                        </v-btn>
+                    </v-col>
                 </v-row>
             </v-container>
         </v-card-text>
@@ -45,6 +69,18 @@ import { mdiDownload, mdiFileDocumentEdit } from '@mdi/js'
 export default class LogfilesPanel extends Mixins(BaseMixin) {
     mdiFileDocumentEdit = mdiFileDocumentEdit
     mdiDownload = mdiDownload
+
+    get crowsnestLog() {
+        const logfiles = this.$store.getters['files/getDirectory']('logs').childrens
+
+        return logfiles.find((log: { filename: string }) => log.filename === 'crowsnest.log')
+    }
+
+    get sonarLog() {
+        const logfiles = this.$store.getters['files/getDirectory']('logs').childrens
+
+        return logfiles.find((log: { filename: string }) => log.filename === 'sonar.log')
+    }
 
     downloadLog(event: any) {
         event.preventDefault()

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -29,7 +29,7 @@
                         </v-btn>
                     </v-col>
                     <v-col
-                        v-if="existCrowsnestLog"
+                        v-if="existsCrowsnestLog"
                         :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
                         <v-btn
                             :href="apiUrl + '/server/files/logs/crowsnest.log'"
@@ -41,7 +41,7 @@
                         </v-btn>
                     </v-col>
                     <v-col
-                        v-if="existSonarLog"
+                        v-if="existsSonarLog"
                         :class="'col-12 pt-0 ' + (klipperState !== 'ready' ? 'col-md-6 mt-md-3 ' : 'col-md-12') + ''">
                         <v-btn
                             :href="apiUrl + '/server/files/logs/sonar.log'"
@@ -75,11 +75,11 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
         return this.$store.getters['files/getDirectory']('logs').childrens
     }
 
-    get existCrowsnestLog(): boolean {
+    get existsCrowsnestLog(): boolean {
         return this.logfiles.findIndex((log: FileStateFile) => log.filename === 'crowsnest.log') !== -1
     }
 
-    get existSonarLog(): boolean {
+    get existsSonarLog(): boolean {
         const sonarLog = this.logfiles.find((log: FileStateFile) => log.filename === 'sonar.log')
 
         return sonarLog?.size > 0


### PR DESCRIPTION
### Solves the following problem:
Fixes #979

This PR will add a download button for crowsnest.log and sonar.log:
![image](https://user-images.githubusercontent.com/31533186/182036898-617df02f-dcbc-4c8b-a210-49c5b26dce43.png)

Those button appear under the following conditions:
crowsnest.log exists in the logfile directory
sonar.log exists in the logfile directory and its filesize is greater than 0

Signed-off-by: Dominik Willner <th33xitus@gmail.com>