### PR TITLE
fix: divider in temperature presets is transparent

### DIFF
--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -31,7 +31,7 @@
                             </div>
                         </v-list-item>
                     </v-list>
-                    <v-divider></v-divider>
+                    <v-divider class="_fix_transparency"></v-divider>
                     <v-list dense class="py-0">
                         <v-list-item link @click="cooldown()">
                             <div class="d-flex align-center _preset-title">
@@ -419,5 +419,13 @@ export default class TemperaturePanel extends Mixins(BaseMixin, ControlMixin) {
 
 .temperature-panel-table .target {
     width: 140px;
+}
+
+/*
+workaround for fixing a transparency issue
+which is assumingly a vuetify bug
+*/
+._fix_transparency {
+    background-color: #1e1e1e;
 }
 </style>


### PR DESCRIPTION
### Solves the following issue:
For some reason the `v-divider` inside of the `v-menu` is rendered transparent and you can see the text underneath the `v-menu` through it.
![22-08-05_20-57-18_chrome](https://user-images.githubusercontent.com/31533186/183144256-90487540-96f9-4152-8f9c-2035d86ea7a9.png)

Probably due to the case that it is set by Vuetify that way.
![22-08-05_20-46-29_chrome](https://user-images.githubusercontent.com/31533186/183143971-aa9a0a53-b1f2-4527-9fa1-5a5e74f7e472.png)
The expected behavior though would be, that the background color of the `v-menu` gets respected. Which, for some reason, is not the case. Presumably this might be a bug with Vuetify?

This PR solves the issue with applying a background color to that `v-divider` element as a workaround.
![22-08-05_20-56-55_chrome](https://user-images.githubusercontent.com/31533186/183144544-575ab62c-82df-492d-8b67-ac7b5a7c2ef6.png)



Signed-off-by: Dominik Willner <th33xitus@gmail.com>