### PR TITLE
fix: webcam name input alignment

### DIFF
--- a/src/components/settings/SettingsWebcamsTab.vue
+++ b/src/components/settings/SettingsWebcamsTab.vue
@@ -1,30 +1,3 @@
-<style lang="scss" scoped>
-._transition i::before {
-    transition: transform 500ms;
-}
-._rotate-180:before {
-    transform: rotate(180deg);
-}
-
-.v-item-group {
-    button:hover::before,
-    button:focus::before {
-        opacity: 0 !important;
-    }
-    ._menu-button {
-        height: 40px;
-        width: 62px;
-        border: 1px solid rgba(255, 255, 255, 0.25) !important;
-    }
-    ._menu-button:hover {
-        border-color: rgba(255, 255, 255, 1) !important;
-    }
-    ._menu-button:focus {
-        border: 2px solid var(--color-primary) !important;
-    }
-}
-</style>
-
 <template>
     <div>
         <v-card v-if="!form.bool" flat>
@@ -424,3 +397,30 @@ export default class SettingsWebcamsTab extends Mixins(BaseMixin, WebcamMixin) {
     }
 }
 </script>
+
+<style lang="scss" scoped>
+._transition i::before {
+    transition: transform 500ms;
+}
+._rotate-180:before {
+    transform: rotate(180deg);
+}
+
+.v-item-group {
+    button:hover::before,
+    button:focus::before {
+        opacity: 0 !important;
+    }
+    ._menu-button {
+        height: 40px;
+        width: 62px;
+        border: 1px solid rgba(255, 255, 255, 0.25) !important;
+    }
+    ._menu-button:hover {
+        border-color: rgba(255, 255, 255, 1) !important;
+    }
+    ._menu-button:focus {
+        border: 2px solid var(--color-primary) !important;
+    }
+}
+</style>

--- a/src/components/settings/SettingsWebcamsTab.vue
+++ b/src/components/settings/SettingsWebcamsTab.vue
@@ -127,7 +127,7 @@
                                 </v-col>
                             </v-row>
                             <v-row v-if="form.service === 'mjpegstreamer-adaptive'">
-                                <v-col class="py-2">
+                                <v-col class="py-2 col-6">
                                     <v-text-field
                                         v-model="form.targetFps"
                                         outlined
@@ -135,9 +135,7 @@
                                         hide-details
                                         :label="$t('Settings.WebcamsTab.TargetFPS')"></v-text-field>
                                 </v-col>
-                            </v-row>
-                            <v-row v-if="form.service === 'mjpegstreamer-adaptive'">
-                                <v-col class="py-2">
+                                <v-col class="py-2 col-6">
                                     <v-select
                                         v-model="form.rotate"
                                         :items="rotateItems"

--- a/src/components/settings/SettingsWebcamsTab.vue
+++ b/src/components/settings/SettingsWebcamsTab.vue
@@ -66,7 +66,7 @@
                     <v-row>
                         <v-col class="col-12 col-sm-6">
                             <v-row>
-                                <v-col class="d-flex align-center">
+                                <v-col class="d-flex">
                                     <v-item-group>
                                         <v-menu :offset-y="true" title="Icon">
                                             <template #activator="{ on, attrs }">


### PR DESCRIPTION
### Problem that will be solved:
![unknown](https://user-images.githubusercontent.com/31533186/184169544-c572cdeb-f21d-4bb6-8c8c-f67f77f16953.png)
The `align-center` class caused some misalignment

Solution:
![image](https://user-images.githubusercontent.com/31533186/184169672-7710a0c4-ad98-4fbf-baf3-34b4edd2c72f.png)

~~I haven't located the culprit of that cursor and label misalignment though, this is present in multiple input fields with form validation. It might be an issue introduced by ourself or a general Vuetify issue?~~
Located and fixed with: https://github.com/mainsail-crew/mainsail/pull/1020

### Also solves:
Places the Target FPS and Rotate input fields into one line
![image](https://user-images.githubusercontent.com/31533186/184170193-0f2329ef-de88-4ff5-9cc0-adca4b6ee267.png)
A single line per input wastes a lot of space and is not even required on very small screen resolutions.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>