### PR TITLE
fix: global form validation error misalignment

### DIFF
--- a/src/components/inputs/MoveToInput.vue
+++ b/src/components/inputs/MoveToInput.vue
@@ -97,12 +97,7 @@ export default class MoveToInput extends Mixins(BaseMixin) {
 }
 </script>
 
-<style>
-label {
-    font-size: 14px !important;
-    color: rgba(255, 255, 255, 0.5) !important;
-}
-
+<style scoped lang="scss">
 .v-input.error--text .v-input__slot {
     padding-left: 3px !important;
 }


### PR DESCRIPTION
### Solves the following issue:
![image](https://user-images.githubusercontent.com/31533186/184178116-5d31be0a-a673-4ab8-b4fe-d887fffb9cfa.png)

### Solution
![image](https://user-images.githubusercontent.com/31533186/184178014-5f916ae4-3fa7-4768-a5c7-bcd8cf91c47b.png)

The solution does remove a css style that was applied to the label which was overwriting the font size of the label from 16px to 14px. Before we merge, we should re-evaluate if we want that again or if we apply the global 16px.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>