### PR TITLE
fix: distro output for armbian in SystemPanel

### DIFF
--- a/src/components/panels/Machine/SystemPanelHost.vue
+++ b/src/components/panels/Machine/SystemPanelHost.vue
@@ -27,16 +27,10 @@
                     <div v-if="hostStats.os">
                         {{ $t('Machine.SystemPanel.Values.Os', { os: hostStats.os }) }}
                     </div>
-                    <div
-                        v-if="
-                            hostStats.release_info &&
-                            'name' in hostStats.release_info &&
-                            hostStats.release_info.name !== '0.'
-                        "
-                        class="text-no-wrap">
+                    <div v-if="releaseName" class="text-no-wrap">
                         {{
                             $t('Machine.SystemPanel.Values.Distro', {
-                                name: hostStats.release_info.name,
+                                name: releaseName,
                                 version_id: hostStats.release_info.version_id,
                             })
                         }}
@@ -223,6 +217,15 @@ export default class SystemPanelHost extends Mixins(BaseMixin) {
 
     get systemInfo() {
         return this.$store.state.server?.system_info ?? {}
+    }
+
+    get releaseName() {
+        let name = this.hostStats.release_info?.name ?? null
+
+        if (name.startsWith('#')) return this.hostStats.release_info?.id ?? null
+        if (name.startsWith('0.')) return null
+
+        return name
     }
 
     get directory() {


### PR DESCRIPTION
old output:
![image](https://user-images.githubusercontent.com/8167632/184237562-298a879e-58ef-4147-966f-d7bb5fa42e41.png)

new output:
![image](https://user-images.githubusercontent.com/8167632/184237638-4a15e6c6-30ad-4f31-93c0-9dac848182e0.png)

problem is the output of moonraker in the case of armbian (armbian is not LSB conform):
![image](https://user-images.githubusercontent.com/8167632/184237729-87ffc72a-8202-43a8-9832-a35becdd1ad2.png)

an example for a real LSB output from mainsailOS:
![image](https://user-images.githubusercontent.com/8167632/184237905-b2363918-1aef-4211-b4c5-1b579ff0b0be.png)


Signed-off-by: Stefan Dej <meteyou@gmail.com>