### PR TITLE
refactor: remove input validation from MoveToInput

### DIFF
--- a/src/components/inputs/MoveToInput.vue
+++ b/src/components/inputs/MoveToInput.vue
@@ -7,7 +7,6 @@
             :disabled="disabled"
             :step="step"
             :readonly="readonly"
-            :error="!validate"
             hide-details="auto"
             type="number"
             hide-spin-buttons
@@ -15,30 +14,18 @@
             reverse
             dense
             @blur="onBlur"
-            @focus="!readonly ? $event.target.select() : {}">
-            <template v-if="errorMsg.length" #append>
-                <v-tooltip top>
-                    <template #activator="{ on, attrs }">
-                        <v-icon color="error" v-bind="attrs" v-on="on">{{ mdiAlert }}</v-icon>
-                    </template>
-                    <span>{{ errorMsg.join(', ') }}</span>
-                </v-tooltip>
-            </template>
-        </v-text-field>
+            @focus="!readonly ? $event.target.select() : {}"></v-text-field>
     </form>
 </template>
 
 <script lang="ts">
 import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { mdiAlert } from '@mdi/js'
 
 @Component({
     components: {},
 })
 export default class MoveToInput extends Mixins(BaseMixin) {
-    mdiAlert = mdiAlert
-
     @VModel({ type: String })
     declare position: string
 
@@ -51,12 +38,6 @@ export default class MoveToInput extends Mixins(BaseMixin) {
     @Prop({ type: String, required: false })
     declare readonly suffix: string
 
-    @Prop({ type: Number, required: true })
-    declare readonly positionMax: number
-
-    @Prop({ type: Number, required: true })
-    declare readonly positionMin: number
-
     @Prop({ type: Number, required: false, default: 1 })
     declare readonly step: number
 
@@ -67,42 +48,13 @@ export default class MoveToInput extends Mixins(BaseMixin) {
     declare readonly readonly: boolean
 
     onBlur() {
-        if (!this.validate && this.position !== this.currentPos) {
+        if (this.position !== this.currentPos) {
             this.position = this.currentPos
-            this.$emit('validate', { axis: this.suffix.toLowerCase(), valid: true })
         }
     }
 
     submit(): void {
         this.$emit('submit')
     }
-
-    get validate(): boolean {
-        const isValid =
-            this.position !== '' &&
-            parseFloat(this.position) <= this.positionMax &&
-            parseFloat(this.position) >= this.positionMin
-        this.$emit('validate', { axis: this.suffix.toLowerCase(), valid: isValid })
-        return isValid
-    }
-
-    get errorMsg() {
-        const errors = []
-        if (this.position === '') errors.push(this.$t('Panels.ToolheadControlPanel.Invalid'))
-        if (parseFloat(this.position) > this.positionMax || parseFloat(this.position) < this.positionMin)
-            errors.push(this.$t('Panels.ToolheadControlPanel.OutOfRange'))
-
-        return errors
-    }
 }
 </script>
-
-<style scoped lang="scss">
-.v-input.error--text .v-input__slot {
-    padding-left: 3px !important;
-}
-
-.v-input.error--text .v-input__append-inner {
-    margin-right: 5px !important;
-}
-</style>

--- a/src/components/panels/ToolheadControls/MoveToControl.vue
+++ b/src/components/panels/ToolheadControls/MoveToControl.vue
@@ -41,13 +41,10 @@
                             v-model="input.x.pos"
                             :label="livePositions.x"
                             :suffix="'X'"
-                            :position-max="stepperXmax"
-                            :position-min="stepperXmin"
                             :step="0.01"
                             :current-pos="gcodePositions.x"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!xAxisHomed"
-                            @validate="validate"
                             @submit="sendCmd"></move-to-input>
                     </v-col>
                     <v-col :class="el.is.xsmall ? 'col-12' : 'col-4'">
@@ -55,13 +52,10 @@
                             v-model="input.y.pos"
                             :label="livePositions.y"
                             :suffix="'Y'"
-                            :position-max="stepperYmax"
-                            :position-min="stepperYmin"
                             :step="0.01"
                             :current-pos="gcodePositions.y"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!yAxisHomed"
-                            @validate="validate"
                             @submit="sendCmd"></move-to-input>
                     </v-col>
                     <v-col :class="el.is.xsmall ? 'col-12' : 'col-4'">
@@ -69,13 +63,10 @@
                             v-model="input.z.pos"
                             :label="livePositions.z"
                             :suffix="'Z'"
-                            :position-max="stepperZmax"
-                            :position-min="stepperZmin"
                             :step="0.001"
                             :current-pos="gcodePositions.z"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!zAxisHomed"
-                            @validate="validate"
                             @submit="sendCmd"></move-to-input>
                     </v-col>
                 </v-row>
@@ -105,10 +96,6 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
         z: { pos: '', valid: true },
     }
 
-    validate(event: { axis: string; valid: boolean }): void {
-        this.input[event.axis].valid = event.valid
-    }
-
     @Watch('gcodePositions.x', { immediate: true })
     updatePositionX(newVal: string): void {
         this.input.x.pos = newVal
@@ -122,33 +109,6 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
     @Watch('gcodePositions.z', { immediate: true })
     updatePositionZ(newVal: string): void {
         this.input.z.pos = newVal
-    }
-
-    /**
-     * Axis limits
-     */
-    get stepperXmin(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_x?.position_min ?? Number.NEGATIVE_INFINITY
-    }
-
-    get stepperXmax(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_x?.position_max ?? Number.POSITIVE_INFINITY
-    }
-
-    get stepperYmin(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_y?.position_min ?? Number.NEGATIVE_INFINITY
-    }
-
-    get stepperYmax(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_y?.position_max ?? Number.POSITIVE_INFINITY
-    }
-
-    get stepperZmin(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_z?.position_min ?? Number.NEGATIVE_INFINITY
-    }
-
-    get stepperZmax(): number {
-        return this.$store.state.printer.configfile?.settings?.stepper_z?.position_max ?? Number.POSITIVE_INFINITY
     }
 
     /**


### PR DESCRIPTION
### Solves the following problem:
The input was validated against `position_min` and `position_max` of the configuration file. If the input falls below / exceeds the boundaries set inside the config, a visible error would be shown.
The real issue is, that those errors are also shown if there wasn't input from the user. The culprit in that case seems to be Klipper. The error was often reported, but wasn't possible to reproduce but looked like this:
![image](https://user-images.githubusercontent.com/31533186/184370552-e26714d0-7090-4608-baf4-ff9134a58169.png)

It is suspected to be a rounding error in Klipper, hence Klipper actually reporting the wrong toolhead position which then appears to exceed the position_max by 0,01 which is enough to trigger an error during the validation methods. This often led to confusion for the user because the error simply was not comprehensible.

So the current solution aims at removing all validation from that component to reduce confusion. 
As a trade-off `Move out of range` errors are then only logged in the console **after** submitting a move command.


Signed-off-by: Dominik Willner <th33xitus@gmail.com>