### PR TITLE
fix(UI): missing bottom border radius in status panel

### DIFF
--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -1,5 +1,3 @@
-<style lang="scss" scoped></style>
-
 <template>
     <div>
         <min-settings-panel></min-settings-panel>
@@ -65,7 +63,7 @@
                 <v-tab href="#jobqueue">{{ $t('Panels.StatusPanel.Jobqueue', { count: jobsCount }) }}</v-tab>
             </v-tabs>
             <v-divider class="my-0"></v-divider>
-            <v-tabs-items v-model="activeTab">
+            <v-tabs-items v-model="activeTab" class="_border-radius">
                 <v-tab-item v-if="current_filename" value="status">
                     <status-panel-printstatus></status-panel-printstatus>
                 </v-tab-item>
@@ -284,3 +282,10 @@ export default class StatusPanel extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style lang="scss" scoped>
+._border-radius {
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
+}
+</style>


### PR DESCRIPTION
Fixes missing bottom border radius in the status panel.

## Before:
![22-10-05_19-33-57_chrome](https://user-images.githubusercontent.com/31533186/194124810-07926b14-eb39-45c8-8566-2ea479975e86.png)

## After:
![22-10-05_19-33-37_chrome](https://user-images.githubusercontent.com/31533186/194124819-fc7fb7db-d418-4841-b53b-76bc240d72b4.png)

Signed-off-by: Dominik Willner <th33xitus@gmail.com>