### PR TITLE
fix(UI): tweak font sizes

### DIFF
--- a/src/components/inputs/MiscellaneousSlider.vue
+++ b/src/components/inputs/MiscellaneousSlider.vue
@@ -313,8 +313,8 @@ export default class MiscellaneousSlider extends Mixins(BaseMixin) {
 }
 
 ._slider-input {
-    font-size: 0.875rem;
-    max-width: 5.4rem;
+    min-width: 4.2rem;
+    max-width: 5rem;
     margin-left: 12px;
 }
 

--- a/src/components/inputs/TemperatureInput.vue
+++ b/src/components/inputs/TemperatureInput.vue
@@ -1,7 +1,6 @@
 <style scoped>
 ._temp-input {
-    font-size: 0.875rem;
-    min-width: 4rem;
+    min-width: 4.2rem;
     max-width: 5rem;
 }
 
@@ -12,12 +11,17 @@
 }
 
 ._temp-input >>> .v-text-field__slot input {
-    padding: 4px 0 4px;
+    padding-top: 4px;
+    padding-bottom: 4px;
 }
 
 ._preset {
-    font-size: 0.8125rem;
-    font-weight: 500;
+    font-size: 0.875rem;
+}
+
+._preset-icon {
+    margin-top: -1px;
+    margin-right: 4px;
 }
 </style>
 
@@ -57,11 +61,11 @@
                     link
                     style="min-height: 32px"
                     @click="doSend(`${command} ${attributeName}=${name} TARGET=${preset.value}`)">
-                    <div class="d-flex align-center _preset">
-                        <v-icon v-if="preset.value === 0" else color="primary" small class="mr-1">
+                    <div class="_preset">
+                        <v-icon v-if="preset.value === 0" else color="primary" small class="_preset-icon">
                             {{ mdiSnowflake }}
                         </v-icon>
-                        <v-icon v-else small class="mr-1">{{ mdiFire }}</v-icon>
+                        <v-icon v-else small class="_preset-icon">{{ mdiFire }}</v-icon>
                         <span style="padding-top: 2px">{{ preset.value }}°C</span>
                     </div>
                 </v-list-item>

--- a/src/components/inputs/TemperatureInput.vue
+++ b/src/components/inputs/TemperatureInput.vue
@@ -1,30 +1,3 @@
-<style scoped>
-._temp-input {
-    min-width: 4.2rem;
-    max-width: 5rem;
-}
-
-._temp-input >>> .v-input__slot {
-    min-height: 1rem !important;
-    padding-left: 8px !important;
-    padding-right: 8px !important;
-}
-
-._temp-input >>> .v-text-field__slot input {
-    padding-top: 4px;
-    padding-bottom: 4px;
-}
-
-._preset {
-    font-size: 0.875rem;
-}
-
-._preset-icon {
-    margin-top: -1px;
-    margin-right: 4px;
-}
-</style>
-
 <template>
     <div class="d-flex align-center">
         <form @submit.prevent="setTemps">
@@ -128,3 +101,30 @@ export default class TemperatureInput extends Mixins(BaseMixin, ControlMixin) {
     }
 }
 </script>
+
+<style scoped>
+._temp-input {
+    min-width: 4.2rem;
+    max-width: 5rem;
+}
+
+._temp-input >>> .v-input__slot {
+    min-height: 1rem !important;
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+}
+
+._temp-input >>> .v-text-field__slot input {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+._preset {
+    font-size: 0.875rem;
+}
+
+._preset-icon {
+    margin-top: -1px;
+    margin-right: 4px;
+}
+</style>

--- a/src/components/inputs/ToolSlider.vue
+++ b/src/components/inputs/ToolSlider.vue
@@ -1,54 +1,3 @@
-<style scoped>
-._tool-slider-subheader {
-    height: auto;
-}
-
-._lock-button {
-    margin-left: -6px;
-}
-
-._error-msg {
-    color: #ff5252;
-    font-size: 12px;
-    padding: 4px 16px 2px 0;
-}
-
-.fade-enter-active {
-    animation: slide-in 0.15s reverse;
-    opacity: 1;
-}
-
-.fade-leave-active {
-    animation: slide-in 0.15s;
-    opacity: 1;
-}
-
-@keyframes slide-in {
-    100% {
-        transform: translateY(-5px);
-    }
-}
-
-._slider-input {
-    min-width: 4.2rem;
-    max-width: 5rem;
-    margin-left: 12px;
-}
-
-._slider-input >>> .v-input__slot {
-    min-height: 1rem !important;
-}
-
-._slider-input >>> .v-text-field__slot input {
-    padding-top: 4px;
-    padding-bottom: 4px;
-}
-
-._slider-input >>> .v-input__append-inner {
-    margin: auto -5px auto 0 !important;
-}
-</style>
-
 <template>
     <v-row dense>
         <v-col class="pa-0">
@@ -302,3 +251,54 @@ export default class ToolSlider extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+._tool-slider-subheader {
+    height: auto;
+}
+
+._lock-button {
+    margin-left: -6px;
+}
+
+._error-msg {
+    color: #ff5252;
+    font-size: 12px;
+    padding: 4px 16px 2px 0;
+}
+
+.fade-enter-active {
+    animation: slide-in 0.15s reverse;
+    opacity: 1;
+}
+
+.fade-leave-active {
+    animation: slide-in 0.15s;
+    opacity: 1;
+}
+
+@keyframes slide-in {
+    100% {
+        transform: translateY(-5px);
+    }
+}
+
+._slider-input {
+    min-width: 4.2rem;
+    max-width: 5rem;
+    margin-left: 12px;
+}
+
+._slider-input >>> .v-input__slot {
+    min-height: 1rem !important;
+}
+
+._slider-input >>> .v-text-field__slot input {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+._slider-input >>> .v-input__append-inner {
+    margin: auto -5px auto 0 !important;
+}
+</style>

--- a/src/components/inputs/ToolSlider.vue
+++ b/src/components/inputs/ToolSlider.vue
@@ -30,8 +30,8 @@
 }
 
 ._slider-input {
-    font-size: 0.875rem;
-    max-width: 5.4rem;
+    min-width: 4.2rem;
+    max-width: 5rem;
     margin-left: 12px;
 }
 
@@ -40,7 +40,8 @@
 }
 
 ._slider-input >>> .v-text-field__slot input {
-    padding: 4px 0 4px;
+    padding-top: 4px;
+    padding-bottom: 4px;
 }
 
 ._slider-input >>> .v-input__append-inner {

--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -81,7 +81,7 @@
             <v-card-text class="pa-0">
                 <responsive
                     :breakpoints="{
-                        mobile: (el) => el.width <= 390,
+                        mobile: (el) => el.width <= 395,
                     }">
                     <template #default="{ el }">
                         <v-simple-table class="temperature-panel-table">
@@ -120,9 +120,9 @@
                                     <td v-if="!el.is.mobile" class="state">
                                         <v-tooltip v-if="object.state !== null" top>
                                             <template #activator="{ on, attrs }">
-                                                <small v-bind="attrs" v-on="on">
+                                                <div v-bind="attrs" v-on="on">
                                                     {{ object.state }}
-                                                </small>
+                                                </div>
                                             </template>
                                             <span>{{ $t('Panels.TemperaturePanel.Avg') }}: {{ object.avgState }}</span>
                                         </v-tooltip>


### PR DESCRIPTION
This PR tweaks a few font sizes, primarily the ones of the temperature input field and the slider input fields so they are 1rem / 16px tall. This should fix #1038

The font of the state message was increased to 14px, so its identically to the fontsize of the current temperature.
Also the font size of the presets accessible via the dropdown to the right hand side of the temperature input fields were increased to 14px.

## Before:
![image](https://user-images.githubusercontent.com/31533186/194139843-c6213964-b050-43f6-b49c-91d1b2a0238f.png)

## After:
![22-10-05_20-54-30_chrome](https://user-images.githubusercontent.com/31533186/194139878-5d9fa77b-da9a-43dc-82e4-7d0f93a203ec.png)


Signed-off-by: Dominik Willner <th33xitus@gmail.com>