### PR TITLE
refactor: rework of the KlippyState panel

### DIFF
--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -1,10 +1,10 @@
 <template>
     <div v-if="klipperState !== 'ready' && socketIsConnected">
         <v-container v-if="klippyIsConnected" class="pa-0 pb-6">
-            <v-alert :color="messageType" dense text border="left" class="mb-0">
+            <v-alert :color="messageType.color" dense text border="left" class="mb-0">
                 <!-- KLIPPER MESSAGE TITLE -->
                 <p class="font-weight-medium d-flex align-center">
-                    <v-icon :color="messageType" class="pr-2">{{ iconType }}</v-icon>
+                    <v-icon :color="messageType.color" class="pr-2">{{ messageType.icon }}</v-icon>
                     {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Klipper' }) }}:
                     {{ klipperState.toUpperCase() }}
                 </p>
@@ -15,13 +15,17 @@
                     <v-row>
                         <!-- RESTART BUTTONS -->
                         <v-col>
-                            <v-btn small :class="`${messageType}--text my-1`" style="width: 100%" @click="restart">
+                            <v-btn
+                                small
+                                :class="`${messageType.color}--text my-1`"
+                                style="width: 100%"
+                                @click="restart">
                                 <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
                                 {{ $t('Panels.KlippyStatePanel.Restart') }}
                             </v-btn>
                             <v-btn
                                 small
-                                :class="`${messageType}--text my-1`"
+                                :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="firmwareRestart">
                                 <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
@@ -33,7 +37,7 @@
                             <v-btn
                                 :href="apiUrl + '/server/files/klippy.log'"
                                 small
-                                :class="`${messageType}--text my-1`"
+                                :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="downloadLog">
                                 <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
@@ -42,7 +46,7 @@
                             <v-btn
                                 :href="apiUrl + '/server/files/moonraker.log'"
                                 small
-                                :class="`${messageType}--text my-1`"
+                                :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="downloadLog">
                                 <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
@@ -53,7 +57,7 @@
                 </div>
                 <!-- LOADER -->
                 <v-card-text v-else class="text-center py-3">
-                    <v-progress-circular indeterminate :color="messageType"></v-progress-circular>
+                    <v-progress-circular indeterminate :color="messageType.color"></v-progress-circular>
                 </v-card-text>
             </v-alert>
         </v-container>
@@ -61,7 +65,7 @@
         <v-container v-if="klipperState === 'disconnected'" class="pa-0">
             <v-alert dense text border="left">
                 <p class="font-weight-medium d-flex align-center">
-                    <v-icon class="pr-2">{{ iconType }}</v-icon>
+                    <v-icon class="pr-2">{{ messageType.icon }}</v-icon>
                     {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Moonraker' }) }}:
                     {{ klipperState.toUpperCase() }}
                 </p>
@@ -101,23 +105,19 @@ export default class KlippyStatePanel extends Mixins(BaseMixin) {
         return this.$store.state.server.klippy_message ?? null
     }
 
-    get messageType() {
-        let type
-
-        if (this.klipperState === 'startup') type = 'info'
-        if (this.klipperState === 'shutdown') type = 'warning'
-        if (this.klipperState === 'error') type = 'error'
-
-        return type
-    }
-
-    get iconType() {
-        if (this.klipperState === 'startup') return mdiRocketLaunch
-        if (this.klipperState === 'shutdown') return mdiAlertOutline
-        if (this.klipperState === 'error') return mdiAlertOutline
-        if (this.klipperState === 'disconnected') return mdiConnection
-
-        return mdiMessageOutline
+    get messageType(): { color: string; icon: string } {
+        switch (this.klipperState) {
+            case 'startup':
+                return { color: 'info', icon: mdiRocketLaunch }
+            case 'shutdown':
+                return { color: 'warning', icon: mdiAlertOutline }
+            case 'error':
+                return { color: 'error', icon: mdiAlertOutline }
+            case 'disconnected':
+                return { color: '', icon: mdiConnection }
+            default:
+                return { color: '', icon: mdiMessageOutline }
+        }
     }
 
     restart() {

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -4,33 +4,61 @@
         :icon="mdiAlertCircle"
         :title="$t('Panels.KlippyStatePanel.KlippyState') + ': ' + klipperState"
         card-class="klippy-state-panel">
-        <template v-if="klippyIsConnected">
-            <v-card-text v-if="klippy_message !== null" class="py-1 mt-2">
-                <pre style="white-space: pre-wrap">{{ klippy_message }}</pre>
-            </v-card-text>
-            <v-card-text v-else class="text-center py-3">
-                <v-progress-circular indeterminate color="primary"></v-progress-circular>
-            </v-card-text>
-            <v-divider class="mt-2"></v-divider>
-            <v-card-actions class="justify-start">
-                <v-btn small class="ml-2 error--text" @click="restart">
-                    <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                    {{ $t('Panels.KlippyStatePanel.Restart') }}
-                </v-btn>
-                <v-btn small class="ml-4 error--text" @click="firmwareRestart">
-                    <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                    {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
-                </v-btn>
-            </v-card-actions>
-        </template>
-        <template v-else>
-            <v-card-text class="pt-5 pb-1">
-                <connection-status :moonraker="true" :klipper="false"></connection-status>
-                <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
-                <v-divider class="my-2"></v-divider>
-                <p class="mt-2">{{ $t('Panels.KlippyStatePanel.KlipperCheck') }}</p>
-            </v-card-text>
-        </template>
+        <div>
+            <template v-if="klippyIsConnected">
+                <!-- KLIPPER MESSAGES -->
+                <v-container v-if="klippy_message !== null" class="py-1 mt-2">
+                    <v-alert :color="messageType" dense text border="left" class="mb-0">
+                        <p v-if="klipperState === 'error'">
+                            <v-icon :color="messageType">{{ iconType }}</v-icon>
+                            Klipper reports an error:
+                        </p>
+                        <p v-else-if="klipperState === 'shutdown'">
+                            <v-icon :color="messageType">{{ iconType }}</v-icon>
+                            Klipper reports a shutdown:
+                        </p>
+                        <p v-else-if="klipperState === 'startup'">
+                            <v-icon :color="messageType">{{ iconType }}</v-icon>
+                            Klipper is starting up:
+                        </p>
+                        <p v-else>
+                            <v-icon :color="messageType">{{ iconType }}</v-icon>
+                            Klipper reports:
+                        </p>
+                        <pre style="white-space: pre-wrap">{{ klippy_message }}</pre>
+                    </v-alert>
+                </v-container>
+                <!-- LOADER -->
+                <v-card-text v-else class="text-center py-3">
+                    <v-progress-circular indeterminate color="primary"></v-progress-circular>
+                </v-card-text>
+                <!-- RESTART BUTTONS -->
+                <v-card-actions class="justify-start">
+                    <v-btn small class="ml-2 error--text" @click="restart">
+                        <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                        {{ $t('Panels.KlippyStatePanel.Restart') }}
+                    </v-btn>
+                    <v-btn small class="ml-4 error--text" @click="firmwareRestart">
+                        <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                        {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
+                    </v-btn>
+                </v-card-actions>
+            </template>
+            <!-- DISCONNECTED INFOGRAPHIC -->
+            <template v-else>
+                <v-container class="pt-5 pb-1">
+                    <v-alert dense text border="left">
+                        <p>
+                            <v-icon>{{ iconType }}</v-icon>
+                            Moonraker reports a disconnection:
+                        </p>
+                        <connection-status :moonraker="true" :klipper="false"></connection-status>
+                        <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
+                        <p class="mb-0 text-center">{{ $t('Panels.KlippyStatePanel.KlipperCheck') }}</p>
+                    </v-alert>
+                </v-container>
+            </template>
+        </div>
     </panel>
 </template>
 
@@ -40,19 +68,37 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import ConnectionStatus from '../ui/ConnectionStatus.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiAlertCircle, mdiRestart } from '@mdi/js'
+import { mdiAlertCircle, mdiRestart, mdiMessageOutline, mdiAlertOutline, mdiRocketLaunch, mdiConnection } from '@mdi/js'
 
 @Component({
     components: { Panel, ConnectionStatus },
 })
 export default class KlippyStatePanel extends Mixins(BaseMixin) {
-    //private timer: number | null = null
-
     mdiAlertCircle = mdiAlertCircle
     mdiRestart = mdiRestart
 
     get klippy_message() {
+        console.log(this.klipperState)
         return this.$store.state.server.klippy_message ?? null
+    }
+
+    get messageType() {
+        let type
+
+        if (this.klipperState === 'startup') type = 'info'
+        if (this.klipperState === 'shutdown') type = 'warning'
+        if (this.klipperState === 'error') type = 'error'
+
+        return type
+    }
+
+    get iconType() {
+        if (this.klipperState === 'startup') return mdiRocketLaunch
+        if (this.klipperState === 'shutdown') return mdiAlertOutline
+        if (this.klipperState === 'error') return mdiAlertOutline
+        if (this.klipperState === 'disconnected') return mdiConnection
+
+        return mdiMessageOutline
     }
 
     restart() {
@@ -62,23 +108,5 @@ export default class KlippyStatePanel extends Mixins(BaseMixin) {
     firmwareRestart() {
         this.$socket.emit('printer.firmware_restart', {}, { loading: 'firmwareRestart' })
     }
-
-    /*requestKlippyState() {
-        this.$socket.emit('printer.info', {}, { action: 'printer/getInfo' })
-    }
-
-    @Watch('klipperState')
-    klipperStateChanged(newVal: string) {
-        if (['ready', 'disconnected'].includes(newVal)) {
-            if (this.timer) {
-                clearInterval(this.timer)
-                this.timer = null
-            }
-        } else if (this.timer === null) {
-            this.timer = setInterval(() => {
-                this.requestKlippyState()
-            }, 2000)
-        }
-    }*/
 }
 </script>

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -3,8 +3,8 @@
         <v-container v-if="klippyIsConnected" class="pa-0 pb-6">
             <v-alert :color="messageType" dense text border="left" class="mb-0">
                 <!-- KLIPPER MESSAGE TITLE -->
-                <p class="font-weight-medium">
-                    <v-icon :color="messageType">{{ iconType }}</v-icon>
+                <p class="font-weight-medium d-flex align-center">
+                    <v-icon :color="messageType" class="pr-2">{{ iconType }}</v-icon>
                     {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Klipper' }) }}:
                     {{ klipperState.toUpperCase() }}
                 </p>
@@ -60,8 +60,8 @@
         <!-- DISCONNECTED INFOGRAPHIC -->
         <v-container v-if="klipperState === 'disconnected'" class="pa-0">
             <v-alert dense text border="left">
-                <p>
-                    <v-icon>{{ iconType }}</v-icon>
+                <p class="font-weight-medium d-flex align-center">
+                    <v-icon class="pr-2">{{ iconType }}</v-icon>
                     {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Moonraker' }) }}:
                     {{ klipperState.toUpperCase() }}
                 </p>

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -5,24 +5,51 @@
                 <!-- KLIPPER MESSAGE TITLE -->
                 <p class="font-weight-medium">
                     <v-icon :color="messageType">{{ iconType }}</v-icon>
-                    <!-- TODO: needs localization -->
-                    Klipper reports: {{ klipperState.toUpperCase() }}
+                    {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Klipper' }) }}:
+                    {{ klipperState.toUpperCase() }}
                 </p>
                 <!-- KLIPPER MESSAGE -->
                 <div v-if="klippy_message !== null">
                     <pre style="white-space: pre-wrap">{{ klippy_message.trim() }}</pre>
-                    <!-- RESTART BUTTONS -->
                     <v-divider class="mt-2 pb-3"></v-divider>
-                    <div class="d-flex justify-center">
-                        <v-btn small :class="`${messageType}--text ml-2`" @click="restart">
-                            <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                            {{ $t('Panels.KlippyStatePanel.Restart') }}
-                        </v-btn>
-                        <v-btn small :class="`${messageType}--text ml-4`" @click="firmwareRestart">
-                            <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                            {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
-                        </v-btn>
-                    </div>
+                    <v-row>
+                        <!-- RESTART BUTTONS -->
+                        <v-col>
+                            <v-btn small :class="`${messageType}--text my-1`" style="width: 100%" @click="restart">
+                                <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                                {{ $t('Panels.KlippyStatePanel.Restart') }}
+                            </v-btn>
+                            <v-btn
+                                small
+                                :class="`${messageType}--text my-1`"
+                                style="width: 100%"
+                                @click="firmwareRestart">
+                                <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                                {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
+                            </v-btn>
+                        </v-col>
+                        <!-- LOG DOWNLOAD BUTTONS -->
+                        <v-col>
+                            <v-btn
+                                :href="apiUrl + '/server/files/klippy.log'"
+                                small
+                                :class="`${messageType}--text my-1`"
+                                style="width: 100%"
+                                @click="downloadLog">
+                                <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
+                                Klipper Log
+                            </v-btn>
+                            <v-btn
+                                :href="apiUrl + '/server/files/moonraker.log'"
+                                small
+                                :class="`${messageType}--text my-1`"
+                                style="width: 100%"
+                                @click="downloadLog">
+                                <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
+                                Moonraker Log
+                            </v-btn>
+                        </v-col>
+                    </v-row>
                 </div>
                 <!-- LOADER -->
                 <v-card-text v-else class="text-center py-3">
@@ -35,8 +62,8 @@
             <v-alert dense text border="left">
                 <p>
                     <v-icon>{{ iconType }}</v-icon>
-                    <!-- TODO: needs localization -->
-                    Moonraker reports: {{ klipperState.toUpperCase() }}
+                    {{ $t('Panels.KlippyStatePanel.ServiceReports', { service: 'Moonraker' }) }}:
+                    {{ klipperState.toUpperCase() }}
                 </p>
                 <connection-status :moonraker="true" :klipper="false"></connection-status>
                 <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
@@ -52,7 +79,15 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import ConnectionStatus from '../ui/ConnectionStatus.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiRestart, mdiMessageOutline, mdiAlertOutline, mdiRocketLaunch, mdiConnection, mdiPrinter3d } from '@mdi/js'
+import {
+    mdiRestart,
+    mdiDownload,
+    mdiMessageOutline,
+    mdiAlertOutline,
+    mdiRocketLaunch,
+    mdiConnection,
+    mdiPrinter3d,
+} from '@mdi/js'
 
 @Component({
     components: { Panel, ConnectionStatus },
@@ -60,10 +95,9 @@ import { mdiRestart, mdiMessageOutline, mdiAlertOutline, mdiRocketLaunch, mdiCon
 export default class KlippyStatePanel extends Mixins(BaseMixin) {
     mdiPrinter3d = mdiPrinter3d
     mdiRestart = mdiRestart
+    mdiDownload = mdiDownload
 
     get klippy_message() {
-        console.log(this.klipperState)
-        console.log(this.$store.state.server.klippy_message)
         return this.$store.state.server.klippy_message ?? null
     }
 
@@ -92,6 +126,15 @@ export default class KlippyStatePanel extends Mixins(BaseMixin) {
 
     firmwareRestart() {
         this.$socket.emit('printer.firmware_restart', {}, { loading: 'firmwareRestart' })
+    }
+
+    downloadLog(event: any) {
+        event.preventDefault()
+        let href = ''
+        if ('href' in event.target.attributes) href = event.target.attributes.href.value
+        if ('href' in event.target.parentElement.attributes) href = event.target.parentElement.attributes.href.value
+
+        window.open(href)
     }
 }
 </script>

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -2,28 +2,17 @@
     <panel
         v-if="klipperState !== 'ready' && socketIsConnected"
         :icon="mdiPrinter3d"
-        :title="$t('Panels.KlippyStatePanel.KlippyState') + ': ' + klipperState"
+        :title="`${$t('Panels.KlippyStatePanel.KlippyState')}: ${klipperState}`"
         card-class="klippy-state-panel">
         <div>
             <template v-if="klippyIsConnected">
                 <!-- KLIPPER MESSAGES -->
                 <v-container v-if="klippy_message !== null" class="py-1 mt-2">
                     <v-alert :color="messageType" dense text border="left" class="mb-0">
-                        <p v-if="klipperState === 'error'" class="font-weight-bold">
+                        <p class="font-weight-medium">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports: ERROR
-                        </p>
-                        <p v-else-if="klipperState === 'shutdown'" class="font-weight-medium">
-                            <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports: SHUTDOWN
-                        </p>
-                        <p v-else-if="klipperState === 'startup'">
-                            <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports: STARTUP
-                        </p>
-                        <p v-else>
-                            <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper is reporting:
+                            <!-- TODO: needs localization -->
+                            Klipper reports: {{ klipperState.toUpperCase() }}
                         </p>
                         <pre style="white-space: pre-wrap">{{ klippy_message }}</pre>
                     </v-alert>
@@ -50,7 +39,8 @@
                     <v-alert dense text border="left">
                         <p>
                             <v-icon>{{ iconType }}</v-icon>
-                            Moonraker reports: DISCONNECTED
+                            <!-- TODO: needs localization -->
+                            Moonraker reports: {{ klipperState.toUpperCase() }}
                         </p>
                         <connection-status :moonraker="true" :klipper="false"></connection-status>
                         <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
@@ -78,7 +68,6 @@ export default class KlippyStatePanel extends Mixins(BaseMixin) {
     mdiRestart = mdiRestart
 
     get klippy_message() {
-        console.log(this.klipperState)
         return this.$store.state.server.klippy_message ?? null
     }
 

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -1,55 +1,49 @@
 <template>
-    <panel
-        v-if="klipperState !== 'ready' && socketIsConnected"
-        :icon="mdiPrinter3d"
-        :title="`${$t('Panels.KlippyStatePanel.KlippyState')}: ${klipperState}`"
-        card-class="klippy-state-panel">
-        <div>
-            <template v-if="klippyIsConnected">
-                <!-- KLIPPER MESSAGES -->
-                <v-container v-if="klippy_message !== null" class="py-1 mt-2">
-                    <v-alert :color="messageType" dense text border="left" class="mb-0">
-                        <p class="font-weight-medium">
-                            <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            <!-- TODO: needs localization -->
-                            Klipper reports: {{ klipperState.toUpperCase() }}
-                        </p>
-                        <pre style="white-space: pre-wrap">{{ klippy_message }}</pre>
-                    </v-alert>
-                </v-container>
+    <div v-if="klipperState !== 'ready' && socketIsConnected">
+        <v-container v-if="klippyIsConnected" class="pa-0 pb-6">
+            <v-alert :color="messageType" dense text border="left" class="mb-0">
+                <!-- KLIPPER MESSAGE TITLE -->
+                <p class="font-weight-medium">
+                    <v-icon :color="messageType">{{ iconType }}</v-icon>
+                    <!-- TODO: needs localization -->
+                    Klipper reports: {{ klipperState.toUpperCase() }}
+                </p>
+                <!-- KLIPPER MESSAGE -->
+                <div v-if="klippy_message !== null">
+                    <pre style="white-space: pre-wrap">{{ klippy_message.trim() }}</pre>
+                    <!-- RESTART BUTTONS -->
+                    <v-divider class="mt-2 pb-3"></v-divider>
+                    <div class="d-flex justify-center">
+                        <v-btn small :class="`${messageType}--text ml-2`" @click="restart">
+                            <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                            {{ $t('Panels.KlippyStatePanel.Restart') }}
+                        </v-btn>
+                        <v-btn small :class="`${messageType}--text ml-4`" @click="firmwareRestart">
+                            <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
+                            {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
+                        </v-btn>
+                    </div>
+                </div>
                 <!-- LOADER -->
                 <v-card-text v-else class="text-center py-3">
-                    <v-progress-circular indeterminate color="primary"></v-progress-circular>
+                    <v-progress-circular indeterminate :color="messageType"></v-progress-circular>
                 </v-card-text>
-                <!-- RESTART BUTTONS -->
-                <v-card-actions class="justify-center">
-                    <v-btn small :class="`${messageType}--text ml-2`" @click="restart">
-                        <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                        {{ $t('Panels.KlippyStatePanel.Restart') }}
-                    </v-btn>
-                    <v-btn small :class="`${messageType}--text ml-4`" @click="firmwareRestart">
-                        <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
-                        {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
-                    </v-btn>
-                </v-card-actions>
-            </template>
-            <!-- DISCONNECTED INFOGRAPHIC -->
-            <template v-else>
-                <v-container class="pt-5 pb-1">
-                    <v-alert dense text border="left">
-                        <p>
-                            <v-icon>{{ iconType }}</v-icon>
-                            <!-- TODO: needs localization -->
-                            Moonraker reports: {{ klipperState.toUpperCase() }}
-                        </p>
-                        <connection-status :moonraker="true" :klipper="false"></connection-status>
-                        <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
-                        <p class="mb-0 text-center">{{ $t('Panels.KlippyStatePanel.KlipperCheck') }}</p>
-                    </v-alert>
-                </v-container>
-            </template>
-        </div>
-    </panel>
+            </v-alert>
+        </v-container>
+        <!-- DISCONNECTED INFOGRAPHIC -->
+        <v-container v-if="klipperState === 'disconnected'" class="pa-0">
+            <v-alert dense text border="left">
+                <p>
+                    <v-icon>{{ iconType }}</v-icon>
+                    <!-- TODO: needs localization -->
+                    Moonraker reports: {{ klipperState.toUpperCase() }}
+                </p>
+                <connection-status :moonraker="true" :klipper="false"></connection-status>
+                <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
+                <p class="mb-0 text-center">{{ $t('Panels.KlippyStatePanel.KlipperCheck') }}</p>
+            </v-alert>
+        </v-container>
+    </div>
 </template>
 
 <script lang="ts">
@@ -68,6 +62,8 @@ export default class KlippyStatePanel extends Mixins(BaseMixin) {
     mdiRestart = mdiRestart
 
     get klippy_message() {
+        console.log(this.klipperState)
+        console.log(this.$store.state.server.klippy_message)
         return this.$store.state.server.klippy_message ?? null
     }
 

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -1,7 +1,7 @@
 <template>
     <panel
         v-if="klipperState !== 'ready' && socketIsConnected"
-        :icon="mdiAlertCircle"
+        :icon="mdiPrinter3d"
         :title="$t('Panels.KlippyStatePanel.KlippyState') + ': ' + klipperState"
         card-class="klippy-state-panel">
         <div>
@@ -11,19 +11,19 @@
                     <v-alert :color="messageType" dense text border="left" class="mb-0">
                         <p v-if="klipperState === 'error'" class="font-weight-bold">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports an error:
+                            Klipper reports: ERROR
                         </p>
                         <p v-else-if="klipperState === 'shutdown'" class="font-weight-medium">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports a shutdown:
+                            Klipper reports: SHUTDOWN
                         </p>
                         <p v-else-if="klipperState === 'startup'">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper is starting up:
+                            Klipper reports: STARTUP
                         </p>
                         <p v-else>
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
-                            Klipper reports:
+                            Klipper is reporting:
                         </p>
                         <pre style="white-space: pre-wrap">{{ klippy_message }}</pre>
                     </v-alert>
@@ -33,7 +33,7 @@
                     <v-progress-circular indeterminate color="primary"></v-progress-circular>
                 </v-card-text>
                 <!-- RESTART BUTTONS -->
-                <v-card-actions class="justify-start">
+                <v-card-actions class="justify-center">
                     <v-btn small :class="`${messageType}--text ml-2`" @click="restart">
                         <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
                         {{ $t('Panels.KlippyStatePanel.Restart') }}
@@ -50,7 +50,7 @@
                     <v-alert dense text border="left">
                         <p>
                             <v-icon>{{ iconType }}</v-icon>
-                            Moonraker reports a disconnection:
+                            Moonraker reports: DISCONNECTED
                         </p>
                         <connection-status :moonraker="true" :klipper="false"></connection-status>
                         <p class="mt-2 mb-0 text-center">{{ $t('Panels.KlippyStatePanel.MoonrakerCannotConnect') }}</p>
@@ -68,13 +68,13 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import ConnectionStatus from '../ui/ConnectionStatus.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiAlertCircle, mdiRestart, mdiMessageOutline, mdiAlertOutline, mdiRocketLaunch, mdiConnection } from '@mdi/js'
+import { mdiRestart, mdiMessageOutline, mdiAlertOutline, mdiRocketLaunch, mdiConnection, mdiPrinter3d } from '@mdi/js'
 
 @Component({
     components: { Panel, ConnectionStatus },
 })
 export default class KlippyStatePanel extends Mixins(BaseMixin) {
-    mdiAlertCircle = mdiAlertCircle
+    mdiPrinter3d = mdiPrinter3d
     mdiRestart = mdiRestart
 
     get klippy_message() {

--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -9,11 +9,11 @@
                 <!-- KLIPPER MESSAGES -->
                 <v-container v-if="klippy_message !== null" class="py-1 mt-2">
                     <v-alert :color="messageType" dense text border="left" class="mb-0">
-                        <p v-if="klipperState === 'error'">
+                        <p v-if="klipperState === 'error'" class="font-weight-bold">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
                             Klipper reports an error:
                         </p>
-                        <p v-else-if="klipperState === 'shutdown'">
+                        <p v-else-if="klipperState === 'shutdown'" class="font-weight-medium">
                             <v-icon :color="messageType">{{ iconType }}</v-icon>
                             Klipper reports a shutdown:
                         </p>
@@ -34,11 +34,11 @@
                 </v-card-text>
                 <!-- RESTART BUTTONS -->
                 <v-card-actions class="justify-start">
-                    <v-btn small class="ml-2 error--text" @click="restart">
+                    <v-btn small :class="`${messageType}--text ml-2`" @click="restart">
                         <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
                         {{ $t('Panels.KlippyStatePanel.Restart') }}
                     </v-btn>
-                    <v-btn small class="ml-4 error--text" @click="firmwareRestart">
+                    <v-btn small :class="`${messageType}--text ml-4`" @click="firmwareRestart">
                         <v-icon class="mr-sm-2">{{ mdiRestart }}</v-icon>
                         {{ $t('Panels.KlippyStatePanel.FirmwareRestart') }}
                     </v-btn>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -487,7 +487,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Genstart alt",
             "KlipperCheck": "Check at Klipper service kører og at en UDS (Unix Domain Socket) er konfigureret.",
-            "KlippyState": "Klippy-Status",
             "MoonrakerCannotConnect": "Moonraker kan ikke forbinde til Klipper!",
             "Restart": "Genstart"
         },

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -498,9 +498,9 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware Neustart",
             "KlipperCheck": "Bitte überprüfen Sie, ob der Klipper-Dienst läuft und ein UDS (Unix Domain Socket) konfiguriert ist.",
-            "KlippyState": "Klippy-Status",
             "MoonrakerCannotConnect": "Moonraker kann keine Verbindung zu Klipper herstellen!",
-            "Restart": "Neustart"
+            "Restart": "Neustart",
+            "ServiceReports": "{service} meldet"
         },
         "MachineSettingsPanel": {
             "Headline": "Maschine",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -498,7 +498,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware Restart",
             "KlipperCheck": "Please check if the Klipper service is running.",
-            "KlippyState": "Klippy-State",
             "MoonrakerCannotConnect": "Moonraker can't connect to Klipper!",
             "Restart": "Restart",
             "ServiceReports": "{service} reports"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -500,7 +500,8 @@
             "KlipperCheck": "Please check if the Klipper service is running.",
             "KlippyState": "Klippy-State",
             "MoonrakerCannotConnect": "Moonraker can't connect to Klipper!",
-            "Restart": "Restart"
+            "Restart": "Restart",
+            "ServiceReports": "{service} reports"
         },
         "MachineSettingsPanel": {
             "Headline": "Machine",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -497,7 +497,7 @@
         },
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware Restart",
-            "KlipperCheck": "Please check if the Klipper service is running and an UDS (Unix Domain Socket) is configured.",
+            "KlipperCheck": "Please check if the Klipper service is running.",
             "KlippyState": "Klippy-State",
             "MoonrakerCannotConnect": "Moonraker can't connect to Klipper!",
             "Restart": "Restart"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -479,7 +479,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Reiniciar Firmware",
             "KlipperCheck": "Verifique que el servicio Klipper está corriendo y que un  UDS (Unix Domain Socket) esta configurado.",
-            "KlippyState": "Estado de Klippy",
             "MoonrakerCannotConnect": "¡Moonraker no se pudo conectar a Klipper!",
             "Restart": "Reiniciar"
         },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -491,7 +491,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Redémarrage Firmware",
             "KlipperCheck": "Contrôlez que le sevice Klipper est actif et qu'un UDS (Unix Domain Socket) est configuré",
-            "KlippyState": "Etat-Klippy",
             "MoonrakerCannotConnect": "Moonraker n'arrive pas à se connecter à Klipper",
             "Restart": "Redémarrage"
         },

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -480,7 +480,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware újraindítása",
             "KlipperCheck": "Kérjük, ellenőrizd, a Klipper szolgáltatás fut-e, konfigurálva van-e UDS (Unix Domain Socket).",
-            "KlippyState": "Klippy-állapota",
             "MoonrakerCannotConnect": "A Moonraker nem tud csatlakozni a Klipperhez!",
             "Restart": "Újraindítás"
         },

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -382,7 +382,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Riavvio Firmware",
             "KlipperCheck": "Controlla se il servizio Klipper è in esecuzione e se è configurato un UDS (Unix Domain Socket).",
-            "KlippyState": "Stato Klippy",
             "MoonrakerCannotConnect": "Moonraker non riesce a connettersi a Klipper!",
             "Restart": "Riavvia"
         },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -490,7 +490,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "ファームウェア再始動",
             "KlipperCheck": "Klipperサービスが動いていて、UDS (Unix Domain Socket)が設定されているかどうか確認してください。",
-            "KlippyState": "Klippy-State",
             "MoonrakerCannotConnect": "MoonrakerはKlipperに接続できません!",
             "Restart": "再始動"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -480,7 +480,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "펌웨어 재시작",
             "KlipperCheck": "Klipper 서비스가 실행 중이고 UDS(Unix Domain Socket)의 구성 확인 또는 클리퍼 재시작을 눌러 주세요",
-            "KlippyState": "Klippy 상태",
             "MoonrakerCannotConnect": "문래커가 클리퍼로 접속할 수 없습니다!",
             "Restart": "재시작"
         },

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -490,7 +490,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware Herstart",
             "KlipperCheck": "Controleer of de Klipper service draait en een UDS (Unix Domain Socket) geconfigureerd is.",
-            "KlippyState": "Klippy-Status",
             "MoonrakerCannotConnect": "Moonraker kan niet met Klipper verbinden!",
             "Restart": "Herstart"
         },

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -479,7 +479,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Ponowne uruchomienie oprogramowania",
             "KlipperCheck": "Sprawdź , czy Klipper jest uruchomiony oraz czy UDS (Unix Domain Socket) został skonfigurowany poprawnie.",
-            "KlippyState": "Status Klippera",
             "MoonrakerCannotConnect": "Moonraker nie może połączyć się z Klipperem!",
             "Restart": "Ponowne uruchomienie"
         },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -479,7 +479,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Перезапуск прошивки",
             "KlipperCheck": "Проверьте, запущена ли служба Klipper и настроен ли UDS (Unix Domain Socket).",
-            "KlippyState": "Klippy-Статус",
             "MoonrakerCannotConnect": "Moonraker не может соединиться с Клиппером!",
             "Restart": "Перезапустить"
         },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -432,7 +432,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Omstart av Firmware",
             "KlipperCheck": "Kontrollera om Klipper-tjänsten körs och en UDS (Unix Domain Socket) är konfigurerad.",
-            "KlippyState": "Klippy-läge",
             "MoonrakerCannotConnect": "Moonraker kan inte ansluta till Klipper!",
             "Restart": "Starta om"
         },

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -489,7 +489,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Firmware Yeniden Başlatma",
             "KlipperCheck": "Lütfen Klipper hizmetinin çalışıp çalışmadığını ve bir UDS'nin (Unix Etki Alanı Soketi) yapılandırılıp yapılandırılmadığını kontrol edin.",
-            "KlippyState": "Klippy-Durumu",
             "MoonrakerCannotConnect": "Moonraker Klipper'a bağlanamıyor!",
             "Restart": "Yeniden Başlat"
         },

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -490,7 +490,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "Перезапуск Прошивки",
             "KlipperCheck": "Будь ласка, перевірте, чи працює служба Klipper та налаштована UDS (UNIX домен).",
-            "KlippyState": "Klippy-Стан",
             "MoonrakerCannotConnect": "Moonraker не може підключитися до Klipper!",
             "Restart": "Перезапустити"
         },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -492,7 +492,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "重启Klipper并重置主控",
             "KlipperCheck": "请检查Klipper服务是否运行并且已经设置UDS(Unix Domain Socket)。",
-            "KlippyState": "Klippy状态",
             "MoonrakerCannotConnect": "Moonraker无法连接到Klipper ！",
             "Restart": "重启Klipper"
         },

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -334,7 +334,6 @@
         "KlippyStatePanel": {
             "FirmwareRestart": "韌體重新啟動",
             "KlipperCheck": "請檢查Klipper服務是否運行並且已經設定UDS（Unix Domain Socket）。",
-            "KlippyState": "Klippy狀態: ",
             "MoonrakerCannotConnect": "Moonraker 不能連接 Klipper!",
             "Restart": "重新啟動"
         },


### PR DESCRIPTION
Often there is quite a bit confusion about error messages. Users often think, those messages come from Mainsail, although they are either directly coming from Klipper or Moonraker. This PR has the goal to make it a bit more clear where the errors come from. For that, the Klippy State Panel was reworked quite drastically. Depending on the status, different colors were choosen. Additionally, it is now possible to directly download the Klipper and/or Moonraker logfiles from that panel.
A simple title should make it more clear, which component is reporting the corresponding message and in turn make it more clear for the user.

## Before:
![image](https://user-images.githubusercontent.com/31533186/194949384-6f11b0f5-3e6c-4d90-8b56-f85961d4d719.png)
![image](https://user-images.githubusercontent.com/31533186/194949417-ebfdcaaa-0c90-4373-a350-c15d9994a1b2.png)
![image](https://user-images.githubusercontent.com/31533186/194949450-19a71397-8744-4ff5-8279-16006794ee71.png)
![image](https://user-images.githubusercontent.com/31533186/194949349-7e6a9bfb-01c5-433f-ac8b-d66522240be5.png)

## After:
![image](https://user-images.githubusercontent.com/31533186/194949202-e4801dc5-9b17-4e33-87b9-b7ccbc8cb447.png)
![image](https://user-images.githubusercontent.com/31533186/194949136-da10b230-812b-4af7-9973-59ec9c24c44a.png)
![image](https://user-images.githubusercontent.com/31533186/194949229-1411ab44-9788-4f4b-b129-556ac612ad0d.png)
![image](https://user-images.githubusercontent.com/31533186/194949295-983a0ae9-24f1-4bdd-af2c-010b71f9230d.png)


Signed-off-by: Dominik Willner <th33xitus@gmail.com>