### PR TITLE
refactor(editor): use the config reference link of a translated version if it exists

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -136,6 +136,7 @@ import {
     mdiRestart,
 } from '@mdi/js'
 import type Codemirror from '@/components/inputs/Codemirror.vue'
+import { availableKlipperConfigReferenceTranslations, klipperConfigReferenceTranslations } from '@/store/variables'
 
 @Component({
     components: { Panel, CodemirrorAsync },
@@ -281,7 +282,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
 
     get klipperConfigReference(): string {
         const currentLanguage = this.currentLanguage
-        const translations = ['it', 'hu', 'zh']
+        const translations = availableKlipperConfigReferenceTranslations
         let url = 'https://www.klipper3d.org/Config_Reference.html'
 
         if (translations.includes(currentLanguage)) {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -124,6 +124,7 @@ import { Component, Mixins, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { capitalize, formatFilesize, windowBeforeUnloadFunction } from '@/plugins/helpers'
 import Panel from '@/components/ui/Panel.vue'
+import { availableKlipperConfigReferenceTranslations } from '@/store/variables'
 import CodemirrorAsync from '@/components/inputs/CodemirrorAsync'
 import {
     mdiClose,
@@ -136,7 +137,6 @@ import {
     mdiRestart,
 } from '@mdi/js'
 import type Codemirror from '@/components/inputs/Codemirror.vue'
-import { availableKlipperConfigReferenceTranslations, klipperConfigReferenceTranslations } from '@/store/variables'
 
 @Component({
     components: { Panel, CodemirrorAsync },

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -17,7 +17,7 @@
                         v-if="restartServiceName === 'klipper'"
                         text
                         tile
-                        href="https://www.klipper3d.org/Config_Reference.html"
+                        :href="klipperConfigReference"
                         target="_blank"
                         class="d-none d-md-flex">
                         <v-icon small class="mr-1">{{ mdiHelp }}</v-icon>
@@ -273,6 +273,22 @@ export default class TheEditor extends Mixins(BaseMixin) {
         if (!this.isWriteable) return `${title} (${this.$t('Editor.FileReadOnly')})`
 
         return `${title} ${this.changedOutput}`
+    }
+
+    get currentLanguage() {
+        return this.$store.state.gui.general.language
+    }
+
+    get klipperConfigReference(): string {
+        const currentLanguage = this.currentLanguage
+        const translations = ['it', 'hu', 'zh']
+        let url = 'https://www.klipper3d.org/Config_Reference.html'
+
+        if (translations.includes(currentLanguage)) {
+            url = `https://www.klipper3d.org/${currentLanguage}/Config_Reference.html`
+        }
+
+        return url
     }
 
     cancelDownload() {

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -106,3 +106,9 @@ export const timelapseConsoleFilters = [
  * List of hidden root directories in config files panel
  */
 export const hiddenRootDirectories = ['gcodes', 'timelapse', 'timelapse_frames']
+
+/*
+ * List of available Klipper config reference translations
+ * https://www.klipper3d.org/Config_Reference.html
+ */
+export const availableKlipperConfigReferenceTranslations = ['it', 'hu', 'zh']


### PR DESCRIPTION
Will fix #1047 

https://github.com/Klipper3d/klipper-translations/blob/translations/active_translations

Signed-off-by: Dominik Willner <th33xitus@gmail.com>