### PR TITLE
refactor(KlippyStatePanel): display buttons as outlined text buttons

### DIFF
--- a/src/components/panels/KlippyStatePanel.vue
+++ b/src/components/panels/KlippyStatePanel.vue
@@ -17,6 +17,8 @@
                         <v-col>
                             <v-btn
                                 small
+                                outlined
+                                text
                                 :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="restart">
@@ -25,6 +27,8 @@
                             </v-btn>
                             <v-btn
                                 small
+                                outlined
+                                text
                                 :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="firmwareRestart">
@@ -37,6 +41,8 @@
                             <v-btn
                                 :href="apiUrl + '/server/files/klippy.log'"
                                 small
+                                outlined
+                                text
                                 :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="downloadLog">
@@ -46,6 +52,8 @@
                             <v-btn
                                 :href="apiUrl + '/server/files/moonraker.log'"
                                 small
+                                outlined
+                                text
                                 :class="`${messageType.color}--text my-1`"
                                 style="width: 100%"
                                 @click="downloadLog">


### PR DESCRIPTION
### Before:
![22-10-10_22-41-58_chrome](https://user-images.githubusercontent.com/31533186/198894415-4e94be79-c947-48a5-a643-df5f3314881c.png)

### After:
![image](https://user-images.githubusercontent.com/31533186/198894424-6d0f5373-1366-4ca2-8706-8ad9b9268042.png)


Signed-off-by: Dominik Willner <th33xitus@gmail.com>