### PR TITLE
Fix: bad printerUrl check in ternary operator

### DIFF
--- a/src/components/webcams/Uv4lMjpeg.vue
+++ b/src/components/webcams/Uv4lMjpeg.vue
@@ -27,7 +27,7 @@ export default class Uv4lMjpeg extends Mixins(BaseMixin) {
     private isVisibleDocument = true
 
     @Prop({ required: true }) declare readonly camSettings: GuiWebcamStateWebcam
-    @Prop({ default: null }) declare readonly printerUrl: string | undefined
+    @Prop() declare printerUrl: string | undefined
 
     declare $refs: {
         webcamUv4lMjpegImage: HTMLImageElement

--- a/src/components/webcams/Uv4lMjpeg.vue
+++ b/src/components/webcams/Uv4lMjpeg.vue
@@ -27,7 +27,7 @@ export default class Uv4lMjpeg extends Mixins(BaseMixin) {
     private isVisibleDocument = true
 
     @Prop({ required: true }) declare readonly camSettings: GuiWebcamStateWebcam
-    @Prop({ default: null }) declare readonly printerUrl: string | null
+    @Prop({ default: null }) declare readonly printerUrl: string | undefined
 
     declare $refs: {
         webcamUv4lMjpegImage: HTMLImageElement
@@ -35,7 +35,7 @@ export default class Uv4lMjpeg extends Mixins(BaseMixin) {
 
     get url() {
         const baseUrl = this.camSettings.urlStream
-        let url = new URL(baseUrl, this.printerUrl === null ? this.hostUrl.toString() : this.printerUrl)
+        let url = new URL(baseUrl, this.printerUrl === undefined ? this.hostUrl.toString() : this.printerUrl)
         url.port = this.hostPort.toString()
 
         if (baseUrl.startsWith('http') || baseUrl.startsWith('://')) url = new URL(baseUrl)

--- a/src/components/webcams/Uv4lMjpeg.vue
+++ b/src/components/webcams/Uv4lMjpeg.vue
@@ -35,7 +35,7 @@ export default class Uv4lMjpeg extends Mixins(BaseMixin) {
 
     get url() {
         const baseUrl = this.camSettings.urlStream
-        let url = new URL(baseUrl, this.printerUrl === undefined ? this.hostUrl.toString() : this.printerUrl)
+        let url = new URL(baseUrl, this.printerUrl === null ? this.hostUrl.toString() : this.printerUrl)
         url.port = this.hostPort.toString()
 
         if (baseUrl.startsWith('http') || baseUrl.startsWith('://')) url = new URL(baseUrl)


### PR DESCRIPTION
This fixes a problem introduced in v2.4.0 for webcams defined with service `Uv4l-Mjpeg`, and will fix #1156.

Signed-off-by: Cor Ruiten <zozo@ruiten.com>