### PR TITLE
refactor: replace emergency stop icon

### DIFF
--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -329,6 +329,7 @@ export default class TheTopbar extends Mixins(BaseMixin) {
 </script>
 
 <style>
+/*noinspection CssUnusedSymbol*/
 .topbar .v-toolbar__content {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
@@ -338,13 +339,16 @@ export default class TheTopbar extends Mixins(BaseMixin) {
 .button-min-width-auto {
     min-width: auto !important;
 }
+/*noinspection CssUnusedSymbol*/
 .topbar .v-btn {
     height: 100% !important;
     max-height: none;
 }
+/*noinspection CssUnusedSymbol*/
 .topbar .v-btn.v-btn--icon {
     width: var(--topbar-icon-btn-width) !important;
 }
+/*noinspection CssUnusedSymbol*/
 @media (min-width: 768px) {
     header.topbar {
         z-index: 8 !important;

--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -256,14 +256,14 @@ export default class TheTopbar extends Mixins(BaseMixin) {
 
     async uploadAndStart() {
         if (this.$refs.fileUploadAndStart?.files.length) {
-            this.$store.dispatch('socket/addLoading', { name: 'btnUploadAndStart' })
+            await this.$store.dispatch('socket/addLoading', { name: 'btnUploadAndStart' })
             let successFiles = []
             for (const file of this.$refs.fileUploadAndStart?.files || []) {
                 const result = await this.doUploadAndStart(file)
                 successFiles.push(result)
             }
 
-            this.$store.dispatch('socket/removeLoading', { name: 'btnUploadAndStart' })
+            await this.$store.dispatch('socket/removeLoading', { name: 'btnUploadAndStart' })
             for (const file of successFiles) {
                 const text = this.$t('App.TopBar.UploadOfFileSuccessful', { file: file }).toString()
                 this.$toast.success(text)

--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -84,7 +84,7 @@
         </v-snackbar>
         <v-dialog v-model="showEmergencyStopDialog" width="400" :fullscreen="isMobile">
             <panel
-                :title="$t('EmergencyStopDialog.EmergencyStop')"
+                :title="$t('EmergencyStopDialog.EmergencyStop').toString()"
                 toolbar-color="error"
                 card-class="emergency-stop-dialog"
                 :icon="mdiAlertOctagonOutline"

--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -346,6 +346,7 @@ export default class TheTopbar extends Mixins(BaseMixin) {
 }
 /*noinspection CssUnusedSymbol*/
 .topbar .v-btn.v-btn--icon {
+    /*noinspection CssUnresolvedCustomProperty*/
     width: var(--topbar-icon-btn-width) !important;
 }
 /*noinspection CssUnusedSymbol*/

--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -63,7 +63,7 @@
                 class="button-min-width-auto px-3 emergency-button"
                 :loading="loadings.includes('topbarEmergencyStop')"
                 @click="btnEmergencyStop">
-                <v-icon class="mr-md-2">{{ mdiAlertCircleOutline }}</v-icon>
+                <v-icon class="mr-md-2">{{ mdiAlertOctagonOutline }}</v-icon>
                 <span class="d-none d-md-inline">{{ $t('App.TopBar.EmergencyStop') }}</span>
             </v-btn>
             <the-notification-menu></the-notification-menu>
@@ -87,7 +87,7 @@
                 :title="$t('EmergencyStopDialog.EmergencyStop')"
                 toolbar-color="error"
                 card-class="emergency-stop-dialog"
-                :icon="mdiAlertCircleOutline"
+                :icon="mdiAlertOctagonOutline"
                 :margin-bottom="false">
                 <template #buttons>
                     <v-btn icon tile @click="showEmergencyStopDialog = false">
@@ -119,7 +119,7 @@ import PrinterSelector from '@/components/ui/PrinterSelector.vue'
 import MainsailLogo from '@/components/ui/MainsailLogo.vue'
 import TheNotificationMenu from '@/components/notifications/TheNotificationMenu.vue'
 import { topbarHeight } from '@/store/variables'
-import { mdiAlertCircleOutline, mdiContentSave, mdiFileUpload, mdiClose, mdiCloseThick } from '@mdi/js'
+import { mdiAlertOctagonOutline, mdiContentSave, mdiFileUpload, mdiClose, mdiCloseThick } from '@mdi/js'
 
 type uploadSnackbar = {
     status: boolean
@@ -145,7 +145,7 @@ type uploadSnackbar = {
     },
 })
 export default class TheTopbar extends Mixins(BaseMixin) {
-    mdiAlertCircleOutline = mdiAlertCircleOutline
+    mdiAlertOctagonOutline = mdiAlertOctagonOutline
     mdiContentSave = mdiContentSave
     mdiFileUpload = mdiFileUpload
     mdiClose = mdiClose


### PR DESCRIPTION
### Before:
![image](https://user-images.githubusercontent.com/31533186/204059069-5dbaebd5-8b09-46d9-b0de-fcc78fc0ab09.png)

### After:
![22-11-25_22-47-14_chrome](https://user-images.githubusercontent.com/31533186/204059077-03a7d048-6865-4235-b248-c63727cad3b7.png)

Fixes #932
Not sure if people now will suddenly stop misinterpreting this icon as a notification icon on mobile view. But there was the request, so lets try it. _shrug_


Signed-off-by: Dominik Willner <th33xitus@gmail.com>