### PR TITLE
fix(Heightmap): save z scale setting

### DIFF
--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -129,7 +129,7 @@
                             <v-row>
                                 <v-col>
                                     <v-slider
-                                        v-model="heightmapScale"
+                                        v-model="scale"
                                         :label="$t('Heightmap.ScaleZMax')"
                                         :min="heightmapRangeLimit[0]"
                                         :max="heightmapRangeLimit[1]"
@@ -493,13 +493,6 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
     private colorVisualMap = 'rgba(255,255,255,0.8)'
     private fontSizeVisualMap = 14
 
-    get heightmapScale(): number {
-        return this.$store.state.gui.view.heightmap.scaleheight ?? 0.5
-    }
-    set heightmapScale(newVal) {
-        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleheight', value: newVal })
-    }
-
     get chartOptions() {
         return {
             tooltip: {
@@ -570,8 +563,8 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
             },
             zAxis3D: {
                 type: 'value',
-                min: this.heightmapScale * -1,
-                max: this.heightmapScale,
+                min: this.scale * -1,
+                max: this.scale,
                 nameTextStyle: {
                     color: this.colorAxisName,
                 },
@@ -677,7 +670,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.wireframe', value: newVal })
     }
 
-    get scale(): boolean {
+    get scale(): number {
         return this.$store.state.gui.view.heightmap.scale ?? true
     }
 

--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -671,7 +671,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
     }
 
     get scale(): number {
-        return this.$store.state.gui.view.heightmap.scale ?? true
+        return this.$store.state.gui.view.heightmap.scale ?? 0.5
     }
 
     set scale(newVal) {

--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -743,7 +743,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         const [min, max] = this.heightmapLimit
 
         const minRange = Math.round(Math.max(Math.abs(min), Math.abs(max)) * 10) / 10
-        const maxRange = Math.max(minRange, 2)
+        const maxRange = Math.max(minRange, 1)
 
         return [minRange, maxRange]
     }

--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -96,7 +96,7 @@
                                 <v-col
                                     class="col-12 col-sm-auto pt-0 pb-0 pl-lg-6 d-flex justify-center justify-sm-start">
                                     <v-switch
-                                        v-model="scaleGradiant"
+                                        v-model="scaleGradient"
                                         :label="$t('Heightmap.ScaleGradient')"
                                         class="mt-0 ml-5"></v-switch>
                                 </v-col>
@@ -670,11 +670,11 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.wireframe', value: newVal })
     }
 
-    get scaleGradiant(): boolean {
+    get scaleGradient(): boolean {
         return this.$store.state.gui.view.heightmap.scaleGradient ?? false
     }
 
-    set scaleGradiant(newVal) {
+    set scaleGradient(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleGradient', value: newVal })
     }
 
@@ -910,7 +910,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
     }
 
     get visualMapRange(): number[] {
-        if (!this.scaleGradiant) return [-0.1, 0.1]
+        if (!this.scaleGradient) return [-0.1, 0.1]
 
         return this.heightmapLimit
     }

--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -96,7 +96,7 @@
                                 <v-col
                                     class="col-12 col-sm-auto pt-0 pb-0 pl-lg-6 d-flex justify-center justify-sm-start">
                                     <v-switch
-                                        v-model="scaleVisualMap"
+                                        v-model="scaleGradiant"
                                         :label="$t('Heightmap.ScaleGradient')"
                                         class="mt-0 ml-5"></v-switch>
                                 </v-col>
@@ -129,7 +129,7 @@
                             <v-row>
                                 <v-col>
                                     <v-slider
-                                        v-model="scale"
+                                        v-model="scaleZMax"
                                         :label="$t('Heightmap.ScaleZMax')"
                                         :min="heightmapRangeLimit[0]"
                                         :max="heightmapRangeLimit[1]"
@@ -563,8 +563,8 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
             },
             zAxis3D: {
                 type: 'value',
-                min: this.scale * -1,
-                max: this.scale,
+                min: this.scaleZMax * -1,
+                max: this.scaleZMax,
                 nameTextStyle: {
                     color: this.colorAxisName,
                 },
@@ -670,20 +670,20 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.wireframe', value: newVal })
     }
 
-    get scale(): number {
-        return this.$store.state.gui.view.heightmap.scale ?? 0.5
+    get scaleGradiant(): boolean {
+        return this.$store.state.gui.view.heightmap.scaleGradient ?? false
     }
 
-    set scale(newVal) {
-        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scale', value: newVal })
+    set scaleGradiant(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleGradient', value: newVal })
     }
 
-    get scaleVisualMap(): boolean {
-        return this.$store.state.gui.view.heightmap.scaleVisualMap ?? false
+    get scaleZMax(): number {
+        return this.$store.state.gui.view.heightmap.scaleZMax ?? 0.5
     }
 
-    set scaleVisualMap(newVal) {
-        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleVisualMap', value: newVal })
+    set scaleZMax(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleZMax', value: newVal })
     }
 
     get rangeX(): number[] {
@@ -910,7 +910,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
     }
 
     get visualMapRange(): number[] {
-        if (!this.scaleVisualMap) return [-0.1, 0.1]
+        if (!this.scaleGradiant) return [-0.1, 0.1]
 
         return this.heightmapLimit
     }

--- a/src/pages/Heightmap.vue
+++ b/src/pages/Heightmap.vue
@@ -478,7 +478,6 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         (value: string) => !this.existsProfileName(value) || this.$t('Heightmap.InvalidNameAlreadyExists'),
     ]
 
-    private heightmapScale = 0.5
     private probedOpacity = 1
     private meshOpacity = 1
     private flatOpacity = 0.5
@@ -493,6 +492,13 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
 
     private colorVisualMap = 'rgba(255,255,255,0.8)'
     private fontSizeVisualMap = 14
+
+    get heightmapScale(): number {
+        return this.$store.state.gui.view.heightmap.scaleheight ?? 0.5
+    }
+    set heightmapScale(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.heightmap.scaleheight', value: newVal })
+    }
 
     get chartOptions() {
         return {
@@ -737,7 +743,7 @@ export default class PageHeightmap extends Mixins(BaseMixin, ControlMixin) {
         const [min, max] = this.heightmapLimit
 
         const minRange = Math.round(Math.max(Math.abs(min), Math.abs(max)) * 10) / 10
-        const maxRange = Math.max(minRange, 1)
+        const maxRange = Math.max(minRange, 2)
 
         return [minRange, maxRange]
     }

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -196,7 +196,6 @@ export const getDefaultState = (): GuiState => {
                 wireframe: true,
                 scale: 0.5,
                 scaleVisualMap: false,
-                heightmapScale: 0.5,
             },
             history: {
                 countPerPage: 10,

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -196,6 +196,7 @@ export const getDefaultState = (): GuiState => {
                 wireframe: true,
                 scale: 0.5,
                 scaleVisualMap: false,
+                heightmapScale: 0.5,
             },
             history: {
                 countPerPage: 10,

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -195,7 +195,6 @@ export const getDefaultState = (): GuiState => {
                 flat: false,
                 wireframe: true,
                 scale: 0.5,
-                scaleVisualMap: false,
             },
             history: {
                 countPerPage: 10,

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -194,7 +194,8 @@ export const getDefaultState = (): GuiState => {
                 mesh: false,
                 flat: false,
                 wireframe: true,
-                scale: 0.5,
+                scaleGradient: false,
+                scaleZMax: 0.5,
             },
             history: {
                 countPerPage: 10,

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -135,7 +135,6 @@ export interface GuiState {
             wireframe: boolean
             scale: number
             scaleVisualMap: boolean
-            heightmapScale: number
         }
         history: {
             countPerPage: number

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -133,7 +133,8 @@ export interface GuiState {
             mesh: boolean
             flat: boolean
             wireframe: boolean
-            scale: number
+            scaleGradient: boolean
+            scaleZMax: number
         }
         history: {
             countPerPage: number

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -134,7 +134,6 @@ export interface GuiState {
             flat: boolean
             wireframe: boolean
             scale: number
-            scaleVisualMap: boolean
         }
         history: {
             countPerPage: number

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -135,6 +135,7 @@ export interface GuiState {
             wireframe: boolean
             scale: number
             scaleVisualMap: boolean
+            heightmapScale: number
         }
         history: {
             countPerPage: number


### PR DESCRIPTION
- saves the z-max heightmapScale. 
- increased the scale size to 2mm. useful for follks with not very flat beds. 

