### PR TITLE
fix: hide temperature sensors with `_` at first char

### DIFF
--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -303,7 +303,9 @@ export default class TemperaturePanel extends Mixins(BaseMixin, ControlMixin) {
     }
 
     get temperatureObjects() {
-        return this.$store.getters['printer/getTemperatureObjects'] ?? []
+        const sensors = this.$store.getters['printer/getTemperatureObjects'] ?? []
+
+        return sensors.filter((sensor: PrinterStateTemperatureObject) => !sensor.name.startsWith('_'))
     }
 
     preheat(preset: GuiPresetsStatePreset): void {


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>