### PR TITLE
feat: support a color or colour variable from tool change macros

### DIFF
--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -86,7 +86,7 @@
                         attribute-name="S"></tool-slider>
                 </v-container>
                 <!-- PRESSURE ADVANCE SETTINGS -->
-                <template v-if="!extruderSteppers.length > 0">
+                <template v-if="!(extruderSteppers.length > 0)">
                     <v-divider></v-divider>
                     <pressure-advance-settings></pressure-advance-settings>
                 </template>

--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -63,6 +63,7 @@
                             :key="tool.name"
                             :class="tool.active ? 'primary--text' : {}"
                             :disabled="isPrinting"
+                            :style="'background-color: #' + tool.color + ';'"
                             dense
                             class="flex-grow-1 px-0"
                             @click="doSend(tool.name)">

--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -63,7 +63,7 @@
                             :key="tool.name"
                             :class="tool.active ? 'primary--text' : {}"
                             :disabled="isPrinting"
-                            :style="'background-color: #' + tool.color + ';'"
+                            :style="{ 'background-color': '#' + tool.color }"
                             dense
                             class="flex-grow-1 px-0"
                             @click="doSend(tool.name)">

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -1097,7 +1097,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 tools.push({
                     name: macro.name,
                     active: macro.variables.active ?? false,
-                    color: macro.variables.color ?? null,
+                    color: macro.variables.color ?? macro.variables.colour ?? null,
                 })
             )
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -1097,6 +1097,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 tools.push({
                     name: macro.name,
                     active: macro.variables.active ?? false,
+                    color: macro.variables.color ?? macro.variables.colour ?? 'null',
                 })
             )
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -1097,7 +1097,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 tools.push({
                     name: macro.name,
                     active: macro.variables.active ?? false,
-                    color: macro.variables.color ?? macro.variables.colour ?? 'null',
+                    color: macro.variables.colour ?? null,
                 })
             )
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -1097,7 +1097,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 tools.push({
                     name: macro.name,
                     active: macro.variables.active ?? false,
-                    color: macro.variables.colour ?? null,
+                    color: macro.variables.color ?? null,
                 })
             )
 

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -252,6 +252,7 @@ export interface PrinterStateExtruderStepper {
 export interface PrinterStateToolchangeMacro {
     name: string
     active: boolean
+    color: string
 }
 
 export interface PrinterGetterObject {


### PR DESCRIPTION
When set the button color will use that set from the variable.

![image](https://user-images.githubusercontent.com/2081919/213938711-f3b3cd5b-4037-41dd-a7b0-de5e2a4ed727.png)

Example macros

```
############################################################################
# Complementary functions controlling variables used by mainsail for display
############################################################################

# Requires appropriately named variables in your tool change macros (these are used by mainsail)
# [gcode_macro T0]
# variable_active: 0
# variable_color: "undefined"

[gcode_macro _SET_ACTIVE_TOOL]
description: Sets the active tool in mainsail (and all others inactive)
gcode:
  {% set TOOL = params.TOOL|default(-1)|int %}
  {% for T in range(9) %}
    {% if T == TOOL %}
      SET_GCODE_VARIABLE MACRO=T{T} VARIABLE=active VALUE=1
    {% else %}
      SET_GCODE_VARIABLE MACRO=T{T} VARIABLE=active VALUE=0
    {% endif %}
  {% endfor %}

# _SET_TOOL_COLOR TOOL=<id> COLOR=<color>
# e.g. _SET_TOOL_COLOR TOOL=0 COLOR=#112233
[gcode_macro _SET_TOOL_COLOR]
description: Sets a color for mainsail extruder
gcode:
  {% set tool = params.TOOL|default(-1)|int %}
  # get color from rawparams and and remove the # char from the color code if present
  {% set ns = namespace(color="undefined") %}
  {% for param in rawparams.split(' ') %}
    {% if 'COLOR' in param|string|upper %}
      {% set rawcolor = (param.split('='))[1] %}
      {% set ns.color = rawcolor if rawcolor[0]|lower in ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'] else rawcolor[1:] %}
    {% endif %}
  {% endfor %}
  SET_GCODE_VARIABLE MACRO=T{tool} VARIABLE=color VALUE='"{ns.color}"'
  # Requires [save_variables], for me this is provided by ercf
  {% if printer.save_variables is defined %}
    SAVE_VARIABLE VARIABLE=t{tool}_color VALUE='"{ns.color}"'
  {% endif %}

# Reload the colors from the [save_variables] if used
[delayed_gcode _SET_TOOL_COLORS_ON_STARTUP]
initial_duration: 1
gcode:
  {% set svv = printer.save_variables.variables %}
  {% for T in range(9) %}
    _SET_TOOL_COLOR TOOL={T} COLOR={svv['t' + (T|string) + '_color']}
  {% endfor %}
```

Signed-off-by: Richard Mitchell <richardjm+mainsail@gmail.com>