### PR TITLE
HLS streamer - improve latency

### DIFF
--- a/src/components/webcams/Hlsstreamer.vue
+++ b/src/components/webcams/Hlsstreamer.vue
@@ -61,7 +61,15 @@ export default class Hlsstreamer extends Mixins(BaseMixin) {
         if (Hls.isSupported()) {
             this.hls?.destroy()
 
-            this.hls = new Hls()
+            this.hls = new Hls(
+                {
+                    "enableWorker": true,
+                    "lowLatencyMode": true,
+                    "maxLiveSyncPlaybackRate": 2,
+                    "liveSyncDurationCount": 1,
+                    "liveMaxLatencyDurationCount": 2
+                }
+            )
             this.hls.loadSource(this.url)
             this.hls.attachMedia(video)
             this.hls.on(Hls.Events.MANIFEST_PARSED, () => {

--- a/src/components/webcams/Hlsstreamer.vue
+++ b/src/components/webcams/Hlsstreamer.vue
@@ -66,8 +66,8 @@ export default class Hlsstreamer extends Mixins(BaseMixin) {
                     "enableWorker": true,
                     "lowLatencyMode": true,
                     "maxLiveSyncPlaybackRate": 2,
-                    "liveSyncDurationCount": 1,
-                    "liveMaxLatencyDurationCount": 2
+                    "liveSyncDuration": 0.5,
+                    "liveMaxLatencyDuration": 2
                 }
             )
             this.hls.loadSource(this.url)

--- a/src/components/webcams/Hlsstreamer.vue
+++ b/src/components/webcams/Hlsstreamer.vue
@@ -67,7 +67,8 @@ export default class Hlsstreamer extends Mixins(BaseMixin) {
                     "lowLatencyMode": true,
                     "maxLiveSyncPlaybackRate": 2,
                     "liveSyncDuration": 0.5,
-                    "liveMaxLatencyDuration": 2
+                    "liveMaxLatencyDuration": 2,
+                    "backBufferLength": 5
                 }
             )
             this.hls.loadSource(this.url)

--- a/src/components/webcams/Hlsstreamer.vue
+++ b/src/components/webcams/Hlsstreamer.vue
@@ -61,16 +61,14 @@ export default class Hlsstreamer extends Mixins(BaseMixin) {
         if (Hls.isSupported()) {
             this.hls?.destroy()
 
-            this.hls = new Hls(
-                {
-                    "enableWorker": true,
-                    "lowLatencyMode": true,
-                    "maxLiveSyncPlaybackRate": 2,
-                    "liveSyncDuration": 0.5,
-                    "liveMaxLatencyDuration": 2,
-                    "backBufferLength": 5
-                }
-            )
+            this.hls = new Hls({
+                enableWorker: true,
+                lowLatencyMode: true,
+                maxLiveSyncPlaybackRate: 2,
+                liveSyncDuration: 0.5,
+                liveMaxLatencyDuration: 2,
+                backBufferLength: 5,
+            })
             this.hls.loadSource(this.url)
             this.hls.attachMedia(video)
             this.hls.on(Hls.Events.MANIFEST_PARSED, () => {


### PR DESCRIPTION
The HLS Streamer's video latency increases over time. By leaving the browser tab open, the latency would add up to a few minutes over time. With the defautl settings, HLS.js never catches up to the edge and continues playing at 1x speed despite being minutes late.

By adding these configuration options, the latency is limited to 2 seconds.

from HLS.js documentation, this is what these changes should achieve:
```
{
                    "enableWorker": true, // actually defaults to true, but hls.js examples typically include this setting anyway. 
                    "lowLatencyMode": true, // Enable Low-Latency HLS part playlist and segment loading, and start live streams at playlist PART-HOLD-BACK rather than HOLD-BACK.
                    "maxLiveSyncPlaybackRate": 2, // Enables catching-up to the edge by enabling up to 2x playback (defaults to 1)
                    "liveSyncDuration": 0.5, // Starts the stream after 0.5 seconds is buffered
                    "liveMaxLatencyDuration": 2 // maximum number of seconds behind the edge, must be greater than the previous setting.
}
```

These settings has target latencies of min 0.5s, max 2s. (at the expense of stalling, but we're not watching a movie here, we're trying to monitor the 3d printing with as much low-latency as possible)

In my testing, I have counted about 2 - 3 seconds of delay using these settings. (with docker-wyze-bridge as my HLS stream source running on the Pi4, and a Wifi Wyze cam v2)