### PR TITLE
feat: add facility to Scan Metadata from G-code Files

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -1385,35 +1385,9 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     }
 
     scanMeta(item: FileStateFile) {
-        const filepath = this.currentPath + '/' + item.filename
-        const file = filepath.slice(0, 1) === '/' ? filepath.slice(1) : filepath
-        const data = {
-            filename: file,
-        }
-        item.small_thumbnail = undefined
-        axios
-            .post(this.apiUrl + '/server/files/metascan', data, {
-                headers: { 'Content-Type': 'multipart/form-data' },
-            })
-            .then((response) => {
-                const $this = this
-                const text = $this.$t('Files.ScanMetaSuccess').toString()
-                if (response.data.result.thumbnails) {
-                    setTimeout(function () {
-                        if (item.small_thumbnail) {
-                            return true
-                        }
-                        $this.$store.dispatch('files/requestMetadata', {
-                            filename: 'gcodes' + $this.currentPath + '/' + item.filename,
-                        })
-                    }, 500)
-                }
-                this.$toast.success(text)
-            })
-            .catch(() => {
-                const text = this.$t('Files.ScanMetaError').toString()
-                this.$toast.error(text)
-            })
+        this.$store.dispatch('files/scanMetadata', {
+            filename: 'gcodes' + this.currentPath + '/' + item.filename,
+        })
     }
 
     deleteSelectedFiles() {

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -596,7 +596,6 @@ import {
 } from '@mdi/js'
 import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
 import ControlMixin from '@/components/mixins/control'
-import axios from 'axios'
 
 interface contextMenu {
     shown: boolean

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -216,6 +216,8 @@
         "Rename": "Umbenennen",
         "RenameDirectory": "Verzeichnis umbenennen",
         "RenameFile": "Datei umbenennen",
+        "ScanMeta": "Metadaten scannen",
+        "ScanMetaSuccess": "Metadaten von {filename} wurden erfolgreich gescannt.",
         "Search": "Suchen",
         "SetupCurrentList": "Einstellungen",
         "Slicer": "Slicer",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -216,6 +216,8 @@
         "Rename": "Rename",
         "RenameDirectory": "Rename Directory",
         "RenameFile": "Rename File",
+        "ScanMeta": "Scan Metadata",
+        "ScanMetaSuccess": "Successfully scanned metadata from: {filename}.",
         "Search": "Search",
         "SetupCurrentList": "Setup current list",
         "Slicer": "Slicer",
@@ -227,10 +229,7 @@
         "Total": "Total",
         "UploadNewGcode": "Upload new G-Code",
         "Used": "Used",
-        "View3D": "View 3D",
-        "ScanMeta": "Scan Metadata",
-        "ScanMetaSuccess": "Successfully scanned metadata.",
-        "ScanMetaError": "There was an error scanning for metadata."
+        "View3D": "View 3D"
     },
     "FullscreenUpload": {
         "CannotUploadFile": "Cannot upload file!",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -227,7 +227,10 @@
         "Total": "Total",
         "UploadNewGcode": "Upload new G-Code",
         "Used": "Used",
-        "View3D": "View 3D"
+        "View3D": "View 3D",
+        "ScanMeta": "Scan Metadata",
+        "ScanMetaSuccess": "Successfully scanned metadata.",
+        "ScanMetaError": "There was an error scanning for metadata."
     },
     "FullscreenUpload": {
         "CannotUploadFile": "Cannot upload file!",

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -137,6 +137,28 @@ export const actions: ActionTree<FileState, RootState> = {
         }
     },
 
+    scanMetadata({ commit }, payload: { filename: string }) {
+        const rootPath = payload.filename.slice(0, payload.filename.indexOf('/'))
+        if (rootPath === 'gcodes') {
+            const requestFilename = payload.filename.slice(7)
+            commit('setMetadataRequested', { filename: requestFilename })
+            Vue.$socket.emit(
+                'server.files.metascan',
+                { filename: requestFilename },
+                { action: 'files/getScanMetadata' }
+            )
+        }
+    },
+
+    getScanMetadata({ dispatch }, payload: { filename: string }) {
+        if (payload !== undefined && payload.filename !== '') {
+            dispatch('getMetadata', payload)
+
+            const filename = payload.filename
+            Vue.$toast.success(i18n.t('Files.ScanMetaSuccess', { filename }).toString())
+        }
+    },
+
     requestMetadata({ commit }, payload: { filename: string }) {
         const rootPath = payload.filename.slice(0, payload.filename.indexOf('/'))
         if (rootPath === 'gcodes') {


### PR DESCRIPTION
When viewing a mounted network drive gcode files that are added to the network share and not uploaded via Mainsail do not contain any meta data or thumbnails. 
This was originally raised as an issue within Moonraker https://github.com/Arksine/moonraker/issues/614 and determined to be an issue with some mount options, for example cifs, did not properly run inotify events which moonraker relies on. 
There was already a moonraker API endpoint /server/files/metascan that can scan existing files so we just added the option to right click and scan meta data via Mainsail instead of trying to cover every mount type and inotify compatibility issues. 
