### PR TITLE
fix: fix thumbnail guide link in settings

### DIFF
--- a/src/components/settings/SettingsUiSettingsTab.vue
+++ b/src/components/settings/SettingsUiSettingsTab.vue
@@ -52,7 +52,7 @@
                         outlined
                         small
                         color="primary"
-                        href="https://docs.mainsail.xyz/quicktips/thumbnails"
+                        href="https://docs.mainsail.xyz/overview/features/thumbnails"
                         target="_blank">
                         {{ $t('Settings.UiSettingsTab.Guide').toString() }}
                     </v-btn>


### PR DESCRIPTION
Current link https://docs.mainsail.xyz/quicktips/thumbnails gives 404, and https://docs.mainsail.xyz/overview/features/thumbnails has links to slicer instructions