### PR TITLE
feat: add jmuxer-stream webcam type, supporting raw h264

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "echarts": "^5.2.2",
                 "echarts-gl": "^2.0.8",
                 "hls.js": "^1.3.3",
+                "jmuxer": "^2.0.5",
                 "js-sha256": "^0.9.0",
                 "lodash.kebabcase": "^4.1.1",
                 "lodash.throttle": "^4.1.1",
@@ -6777,6 +6778,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/jmuxer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/jmuxer/-/jmuxer-2.0.5.tgz",
+            "integrity": "sha512-4qjXl8JS138WyCZZoOYwXq/qVrHcE0UIpt2lMtGyq2wuBSPMNSzP1K2CEWSrwAMgjZ9jD7Btc0SxMkiLIhoHsg=="
         },
         "node_modules/joi": {
             "version": "17.6.2",
@@ -14836,6 +14842,11 @@
                     }
                 }
             }
+        },
+        "jmuxer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/jmuxer/-/jmuxer-2.0.5.tgz",
+            "integrity": "sha512-4qjXl8JS138WyCZZoOYwXq/qVrHcE0UIpt2lMtGyq2wuBSPMNSzP1K2CEWSrwAMgjZ9jD7Btc0SxMkiLIhoHsg=="
         },
         "joi": {
             "version": "17.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "@intlify/vite-plugin-vue-i18n": "^2.5.0",
                 "@mdi/js": "^7.0.0",
                 "@types/file-saver": "^2.0.5",
+                "@types/jmuxer": "^2.0.3",
                 "@types/lodash.kebabcase": "^4.1.6",
                 "@types/lodash.throttle": "^4.1.6",
                 "@types/semver": "^7.3.8",
@@ -2800,6 +2801,15 @@
             "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
             "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
             "dev": true
+        },
+        "node_modules/@types/jmuxer": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/jmuxer/-/jmuxer-2.0.3.tgz",
+            "integrity": "sha512-jRwZXuPbNRG8wTfJT7gjpZm72EaMzvN3oG7zbFWdW8+OHJmxAhLyqycTd/0GtZ/P8OjKXa1cbyKxQg6coXlERg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.11",
@@ -12037,6 +12047,15 @@
             "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
             "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
             "dev": true
+        },
+        "@types/jmuxer": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/jmuxer/-/jmuxer-2.0.3.tgz",
+            "integrity": "sha512-jRwZXuPbNRG8wTfJT7gjpZm72EaMzvN3oG7zbFWdW8+OHJmxAhLyqycTd/0GtZ/P8OjKXa1cbyKxQg6coXlERg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/json-schema": {
             "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "echarts": "^5.2.2",
         "echarts-gl": "^2.0.8",
         "hls.js": "^1.3.3",
+        "jmuxer": "^2.0.5",
         "js-sha256": "^0.9.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.throttle": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "@intlify/vite-plugin-vue-i18n": "^2.5.0",
         "@mdi/js": "^7.0.0",
         "@types/file-saver": "^2.0.5",
+        "@types/jmuxer": "^2.0.3",
         "@types/lodash.kebabcase": "^4.1.6",
         "@types/lodash.throttle": "^4.1.6",
         "@types/semver": "^7.3.8",

--- a/src/components/panels/WebcamPanel.vue
+++ b/src/components/panels/WebcamPanel.vue
@@ -60,6 +60,9 @@
                     <template v-else-if="currentCam.service === 'hlsstream'">
                         <webcam-hlsstreamer :cam-settings="currentCam" />
                     </template>
+                    <template v-else-if="currentCam.service === 'jmuxer-stream'">
+                        <webcam-jmuxer-stream :cam-settings="currentCam" />
+                    </template>
                     <template v-else-if="currentCam.service === 'webrtc-camerastreamer'">
                         <webcam-webrtc-camerastreamer :cam-settings="currentCam" />
                     </template>
@@ -81,6 +84,7 @@ import MjpegstreamerAdaptive from '@/components/webcams/MjpegstreamerAdaptive.vu
 import Hlsstreamer from '@/components/webcams/Hlsstreamer.vue'
 import Ipstreamer from '@/components/webcams/Ipstreamer.vue'
 import Uv4lMjpeg from '@/components/webcams/Uv4lMjpeg.vue'
+import JMuxerStream from '@/components/webcams/JMuxerStream.vue'
 import WebrtcCameraStreamer from '@/components/webcams/WebrtcCameraStreamer.vue'
 import WebcamGrid from '@/components/webcams/WebcamGrid.vue'
 import Component from 'vue-class-component'
@@ -99,6 +103,7 @@ import WebcamMixin from '@/components/mixins/webcam'
         'webcam-ipstreamer': Ipstreamer,
         'webcam-hlsstreamer': Hlsstreamer,
         'webcam-uv4l-mjpeg': Uv4lMjpeg,
+        'webcam-jmuxer-stream': JMuxerStream,
         'webcam-webrtc-camerastreamer': WebrtcCameraStreamer,
         'webcam-grid': WebcamGrid,
     },

--- a/src/components/settings/SettingsWebcamsTab.vue
+++ b/src/components/settings/SettingsWebcamsTab.vue
@@ -131,7 +131,7 @@
                                         attach></v-select>
                                 </v-col>
                             </v-row>
-                            <v-row v-if="form.service === 'mjpegstreamer-adaptive'">
+                            <v-row v-if="form.service === 'mjpegstreamer-adaptive' || form.service === 'jmuxer-stream'">
                                 <v-col class="py-2 col-6">
                                     <v-text-field
                                         v-model="form.targetFps"
@@ -190,6 +190,9 @@
                             <template v-else-if="form.service === 'hlsstream'">
                                 <webcam-hlsstreamer :cam-settings="form" />
                             </template>
+                            <template v-else-if="form.service === 'jmuxer-stream'">
+                                <webcam-jmuxer-stream :cam-settings="form" />
+                            </template>
                             <template v-else-if="form.service === 'webrtc-camerastreamer'">
                                 <webcam-webrtc-camerastreamer :cam-settings="form" />
                             </template>
@@ -228,6 +231,7 @@ import MjpegstreamerAdaptive from '@/components/webcams/MjpegstreamerAdaptive.vu
 import Uv4lMjpeg from '@/components/webcams/Uv4lMjpeg.vue'
 import WebrtcCameraStreamer from '@/components/webcams/WebrtcCameraStreamer.vue'
 import Ipstreamer from '@/components/webcams/Ipstreamer.vue'
+import JMuxerStream from '@/components/webcams/JMuxerStream.vue'
 import { mdiMenuDown, mdiDelete, mdiPencil, mdiWebcam } from '@mdi/js'
 import WebcamMixin from '@/components/mixins/webcam'
 import { FileStateFile } from '@/store/files/types'
@@ -257,6 +261,7 @@ interface webcamForm {
         'webcam-ipstreamer': Ipstreamer,
         'webcam-webrtc-camerastreamer': WebrtcCameraStreamer,
         'webcam-hlsstreamer': Hlsstreamer,
+        'webcam-jmuxer-stream': JMuxerStream,
     },
 })
 export default class SettingsWebcamsTab extends Mixins(BaseMixin, WebcamMixin) {
@@ -322,6 +327,7 @@ export default class SettingsWebcamsTab extends Mixins(BaseMixin, WebcamMixin) {
             { value: 'ipstream', text: this.$t('Settings.WebcamsTab.Ipstream') },
             { value: 'webrtc-camerastreamer', text: this.$t('Settings.WebcamsTab.WebrtcCameraStreamer') },
             { value: 'hlsstream', text: this.$t('Settings.WebcamsTab.Hlsstream') },
+            { value: 'jmuxer-stream', text: this.$t('Settings.WebcamsTab.JMuxerStream') },
         ]
     }
 

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -84,9 +84,14 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         const ws = new WebSocket(this.url)
         ws.binaryType = 'arraybuffer'
         ws.addEventListener('message', (event) => {
-            this.jmuxer.feed({
+            this.jmuxer?.feed({
                 video: new Uint8Array(event.data),
             })
+        })
+
+        ws.addEventListener('error', (event) => {
+            this.status = 'error'
+            console.log('jmuxer ws error:', event)
         })
     }
 

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -54,7 +54,7 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         const video = this.$refs.video
         const targetFps = this.camSettings.targetFps || 10
 
-        var jmuxer = (this.jmuxer = new JMuxer({
+        this.jmuxer = new JMuxer({
             node: video,
             mode: 'video',
             flushingTime: 0,
@@ -66,13 +66,12 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
             onError: (data: any) => {
                 console.log('jmuxer error:', data)
             },
-        }))
-        var url = this.url
+        })
 
-        var ws = new WebSocket(url)
+        const ws = new WebSocket(this.url)
         ws.binaryType = 'arraybuffer'
-        ws.addEventListener('message', function (event) {
-            jmuxer.feed({
+        ws.addEventListener('message', (event) => {
+            this.jmuxer.feed({
                 video: new Uint8Array(event.data),
             })
         })

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -1,0 +1,97 @@
+<style scoped>
+ .webcamImage {
+     width: 100%;
+ }
+</style>
+
+<template>
+  <video v-observe-visibility="visibilityChanged" ref="video" autoplay :style="webcamStyle" class="webcamImage" />
+</template>
+
+<script lang="ts">
+import JMuxer from "jmuxer"
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+
+@Component
+export default class JMuxerStreamer extends Mixins(BaseMixin) {
+    private isVisible = true
+    private jmuxer: JMuxer | null = null
+
+    @Prop({ required: true })
+    camSettings: any
+
+    @Prop()
+    printerUrl: string | undefined
+
+    declare $refs: {
+        video: HTMLVideoElement
+    }
+
+    get url() {
+        if (!this.isVisible) return ''
+
+        return this.camSettings.urlStream || ''
+    }
+
+    get webcamStyle() {
+        let transforms = ''
+        if ('flipX' in this.camSettings && this.camSettings.flipX) transforms += ' scaleX(-1)'
+        if ('flipX' in this.camSettings && this.camSettings.flipY) transforms += ' scaleY(-1)'
+        if (transforms.trimLeft().length) return { transform: transforms.trimLeft() }
+
+        return ''
+    }
+
+    visibilityChanged(isVisible: boolean) {
+        this.isVisible = isVisible
+    }
+
+    mounted() {
+        this.play()
+    }
+
+    updated() {
+        this.play()
+    }
+
+    play() {
+        this.jmuxer?.destroy()
+
+        const video = this.$refs.video
+        const targetFps = this.camSettings.targetFps || 10
+
+        var jmuxer = this.jmuxer = new JMuxer({
+            node: video,
+            mode: 'video',
+            flushingTime: 0,
+            fps: targetFps,
+            // debug: true,
+            onReady: function(data) {
+                console.log("jmuxer ready:", data);
+            },
+            onError: function(data) {
+                console.log("jmuxer error:", data);
+            }
+        })
+        var url = this.url
+
+        if (url.startsWith("ws://") || url.startsWith("wss://")) {
+            var ws = new WebSocket(url);
+            ws.binaryType = 'arraybuffer';
+            ws.addEventListener('message', function(event) {
+                jmuxer.feed({
+                    video: new Uint8Array(event.data)
+                });
+            });
+        } else {
+            console.error("jmuxer error: only websocket streams supported (ws://.. or wss://..)");
+        }
+
+    }
+
+    beforeUnmount() {
+        this.jmuxer?.destroy()
+    }
+}
+</script>

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -1,5 +1,5 @@
 <template>
-    <video ref="video" v-observe-visibility="visibilityChanged" autoplay :style="webcamStyle" class="webcamImage" />
+    <video ref="video" autoplay :style="webcamStyle" class="webcamImage" />
 </template>
 
 <script lang="ts">
@@ -9,7 +9,6 @@ import BaseMixin from '@/components/mixins/base'
 
 @Component
 export default class JMuxerStreamer extends Mixins(BaseMixin) {
-    private isVisible = true
     private jmuxer: JMuxer | null = null
 
     @Prop({ required: true })
@@ -23,8 +22,6 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     get url() {
-        if (!this.isVisible) return ''
-
         return this.camSettings.urlStream || ''
     }
 
@@ -35,10 +32,6 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         if (transforms.trimLeft().length) return { transform: transforms.trimLeft() }
 
         return ''
-    }
-
-    visibilityChanged(isVisible: boolean) {
-        this.isVisible = isVisible
     }
 
     mounted() {

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -1,15 +1,15 @@
 <style scoped>
- .webcamImage {
-     width: 100%;
- }
+.webcamImage {
+    width: 100%;
+}
 </style>
 
 <template>
-  <video ref="video" v-observe-visibility="visibilityChanged" autoplay :style="webcamStyle" class="webcamImage" />
+    <video ref="video" v-observe-visibility="visibilityChanged" autoplay :style="webcamStyle" class="webcamImage" />
 </template>
 
 <script lang="ts">
-import JMuxer from "jmuxer"
+import JMuxer from 'jmuxer'
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 
@@ -61,33 +61,32 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         const video = this.$refs.video
         const targetFps = this.camSettings.targetFps || 10
 
-        var jmuxer = this.jmuxer = new JMuxer({
+        var jmuxer = (this.jmuxer = new JMuxer({
             node: video,
             mode: 'video',
             flushingTime: 0,
             fps: targetFps,
             // debug: true,
-            onReady: function(data) {
-                console.log("jmuxer ready:", data);
+            onReady: function (data) {
+                console.log('jmuxer ready:', data)
             },
-            onError: function(data) {
-                console.log("jmuxer error:", data);
-            }
-        })
+            onError: function (data) {
+                console.log('jmuxer error:', data)
+            },
+        }))
         var url = this.url
 
-        if (url.startsWith("ws://") || url.startsWith("wss://")) {
-            var ws = new WebSocket(url);
-            ws.binaryType = 'arraybuffer';
-            ws.addEventListener('message', function(event) {
+        if (url.startsWith('ws://') || url.startsWith('wss://')) {
+            var ws = new WebSocket(url)
+            ws.binaryType = 'arraybuffer'
+            ws.addEventListener('message', function (event) {
                 jmuxer.feed({
-                    video: new Uint8Array(event.data)
-                });
-            });
+                    video: new Uint8Array(event.data),
+                })
+            })
         } else {
-            console.error("jmuxer error: only websocket streams supported (ws://.. or wss://..)");
+            console.error('jmuxer error: only websocket streams supported (ws://.. or wss://..)')
         }
-
     }
 
     beforeUnmount() {

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import JMuxer from 'jmuxer'
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 
 @Component
@@ -93,6 +93,12 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
 
     beforeUnmount() {
         this.jmuxer?.destroy()
+    }
+
+    @Watch('camSettings', { deep: true })
+    onCamSettingsChanged() {
+        // restart stream, when camSettings change
+        this.play()
     }
 }
 </script>

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -29,7 +29,7 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         let transforms = ''
         if ('flipX' in this.camSettings && this.camSettings.flipX) transforms += ' scaleX(-1)'
         if ('flipX' in this.camSettings && this.camSettings.flipY) transforms += ' scaleY(-1)'
-        if (transforms.trimLeft().length) return { transform: transforms.trimLeft() }
+        if (transforms.trimStart().length) return { transform: transforms.trimStart() }
 
         return ''
     }

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -1,9 +1,3 @@
-<style scoped>
-.webcamImage {
-    width: 100%;
-}
-</style>
-
 <template>
     <video ref="video" v-observe-visibility="visibilityChanged" autoplay :style="webcamStyle" class="webcamImage" />
 </template>
@@ -94,3 +88,9 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+.webcamImage {
+    width: 100%;
+}
+</style>

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -44,12 +44,10 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     mounted() {
-        window.console.log('jmuxer mounted')
         this.play()
     }
 
     play() {
-        window.console.log('jmuxer play')
         this.status = 'connecting'
         this.jmuxer?.destroy()
 
@@ -94,7 +92,6 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     beforeUnmount() {
-        window.console.log('jmuxer beforeUnmount')
         this.jmuxer?.destroy()
     }
 }

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <video v-observe-visibility="visibilityChanged" ref="video" autoplay :style="webcamStyle" class="webcamImage" />
+  <video ref="video" v-observe-visibility="visibilityChanged" autoplay :style="webcamStyle" class="webcamImage" />
 </template>
 
 <script lang="ts">

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -48,11 +48,6 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
         this.play()
     }
 
-    updated() {
-        window.console.log('jmuxer updated')
-        this.play()
-    }
-
     play() {
         window.console.log('jmuxer play')
         this.status = 'connecting'

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -1,5 +1,13 @@
 <template>
-    <video ref="video" autoplay :style="webcamStyle" class="webcamImage" />
+    <div>
+        <video ref="video" autoplay :style="webcamStyle" class="webcamImage" />
+        <v-row v-if="status !== 'connected'">
+            <v-col class="_webcam_jmuxer_output text-center d-flex flex-column justify-center align-center">
+                <v-progress-circular v-if="status === 'connecting'" indeterminate color="primary" class="mb-3" />
+                <span class="mt-3">{{ status }}</span>
+            </v-col>
+        </v-row>
+    </div>
 </template>
 
 <script lang="ts">
@@ -10,6 +18,7 @@ import BaseMixin from '@/components/mixins/base'
 @Component
 export default class JMuxerStreamer extends Mixins(BaseMixin) {
     private jmuxer: JMuxer | null = null
+    private status: string = 'connecting'
 
     @Prop({ required: true })
     camSettings: any
@@ -43,11 +52,13 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     play() {
+        this.status = 'connecting'
         this.jmuxer?.destroy()
 
         // Only websocket streams supported
         if (!this.url.startsWith('ws://') && !this.url.startsWith('wss://')) {
             console.error('jmuxer error: only websocket streams supported (ws://.. or wss://..)')
+            this.status = 'error'
             return
         }
 
@@ -61,9 +72,11 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
             fps: targetFps,
             // debug: true,
             onReady: (data: any) => {
+                this.status = 'connected'
                 console.log('jmuxer ready:', data)
             },
             onError: (data: any) => {
+                this.status = 'error'
                 console.log('jmuxer error:', data)
             },
         })
@@ -86,5 +99,9 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
 <style scoped>
 .webcamImage {
     width: 100%;
+}
+
+._webcam_jmuxer_output {
+    aspect-ratio: calc(3 / 2);
 }
 </style>

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -45,6 +45,12 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     play() {
         this.jmuxer?.destroy()
 
+        // Only websocket streams supported
+        if (!this.url.startsWith('ws://') && !this.url.startsWith('wss://')) {
+            console.error('jmuxer error: only websocket streams supported (ws://.. or wss://..)')
+            return
+        }
+
         const video = this.$refs.video
         const targetFps = this.camSettings.targetFps || 10
 
@@ -54,26 +60,22 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
             flushingTime: 0,
             fps: targetFps,
             // debug: true,
-            onReady: function (data) {
+            onReady: (data: any) => {
                 console.log('jmuxer ready:', data)
             },
-            onError: function (data) {
+            onError: (data: any) => {
                 console.log('jmuxer error:', data)
             },
         }))
         var url = this.url
 
-        if (url.startsWith('ws://') || url.startsWith('wss://')) {
-            var ws = new WebSocket(url)
-            ws.binaryType = 'arraybuffer'
-            ws.addEventListener('message', function (event) {
-                jmuxer.feed({
-                    video: new Uint8Array(event.data),
-                })
+        var ws = new WebSocket(url)
+        ws.binaryType = 'arraybuffer'
+        ws.addEventListener('message', function (event) {
+            jmuxer.feed({
+                video: new Uint8Array(event.data),
             })
-        } else {
-            console.error('jmuxer error: only websocket streams supported (ws://.. or wss://..)')
-        }
+        })
     }
 
     beforeUnmount() {

--- a/src/components/webcams/JMuxerStream.vue
+++ b/src/components/webcams/JMuxerStream.vue
@@ -44,14 +44,17 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     mounted() {
+        window.console.log('jmuxer mounted')
         this.play()
     }
 
     updated() {
+        window.console.log('jmuxer updated')
         this.play()
     }
 
     play() {
+        window.console.log('jmuxer play')
         this.status = 'connecting'
         this.jmuxer?.destroy()
 
@@ -96,6 +99,7 @@ export default class JMuxerStreamer extends Mixins(BaseMixin) {
     }
 
     beforeUnmount() {
+        window.console.log('jmuxer beforeUnmount')
         this.jmuxer?.destroy()
     }
 }

--- a/src/components/webcams/WebcamGrid.vue
+++ b/src/components/webcams/WebcamGrid.vue
@@ -22,6 +22,9 @@
                 <template v-else-if="webcam.service === 'webrtc-camerastreamer'">
                     <webcam-webrtc-camerastreamer :cam-settings="webcam" />
                 </template>
+                <template v-else-if="webcam.service === 'jmuxer'">
+                    <webcam-jmuxer :cam-settings="webcam" />
+                </template>
                 <template v-else>
                     <p class="text-center py-3 font-italic">{{ $t('Panels.WebcamPanel.UnknownWebcamService') }}</p>
                 </template>

--- a/src/components/webcams/WebcamGrid.vue
+++ b/src/components/webcams/WebcamGrid.vue
@@ -22,8 +22,8 @@
                 <template v-else-if="webcam.service === 'webrtc-camerastreamer'">
                     <webcam-webrtc-camerastreamer :cam-settings="webcam" />
                 </template>
-                <template v-else-if="webcam.service === 'jmuxer'">
-                    <webcam-jmuxer :cam-settings="webcam" />
+                <template v-else-if="webcam.service === 'jmuxer-stream'">
+                    <webcam-jmuxer-stream :cam-settings="webcam" />
                 </template>
                 <template v-else>
                     <p class="text-center py-3 font-italic">{{ $t('Panels.WebcamPanel.UnknownWebcamService') }}</p>
@@ -41,6 +41,7 @@ import MjpegstreamerAdaptive from '@/components/webcams/MjpegstreamerAdaptive.vu
 import Uv4lMjpeg from '@/components/webcams/Uv4lMjpeg.vue'
 import Ipstreamer from '@/components/webcams/Ipstreamer.vue'
 import Hlsstreamer from '@/components/webcams/Hlsstreamer.vue'
+import JMuxerStream from '@/components/webcams/JMuxerStream.vue'
 import WebrtcCameraStreamer from '@/components/webcams/WebrtcCameraStreamer.vue'
 import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
 
@@ -51,6 +52,7 @@ import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
         'webcam-uv4l-mjpeg': Uv4lMjpeg,
         'webcam-ipstreamer': Ipstreamer,
         'webcam-hlsstreamer': Hlsstreamer,
+        'webcam-jmuxer-stream': JMuxerStream,
         'webcam-webrtc-camerastreamer': WebrtcCameraStreamer,
     },
 })

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -1055,6 +1055,7 @@
             "Hlsstream": "HLS Stream",
             "Mjpegstreamer": "MJPEG-Streamer",
             "MjpegstreamerAdaptive": "Adaptiv MJPEG-Streamer (eksperimental)",
+            "JMuxerStream": "Rå h264 stream (jmuxer)",
             "Name": "Navn",
             "NameAlreadyExists": "Navnet bruges allerede",
             "Required": "Krævet",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1058,6 +1058,7 @@
             "Ipstream": "IP Kamera",
             "Mjpegstreamer": "MJPEG-Streamer",
             "MjpegstreamerAdaptive": "Adaptive MJPEG-Streamer (experimental)",
+            "JMuxerStream": "Roher h264 stream (jmuxer)",
             "Name": "Name",
             "NameAlreadyExists": "Name existiert bereits",
             "Required": "benötigt",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1059,6 +1059,7 @@
             "Hlsstream": "HLS Stream",
             "Mjpegstreamer": "MJPEG-Streamer",
             "MjpegstreamerAdaptive": "Adaptive MJPEG-Streamer (experimental)",
+            "JMuxerStream": "Raw h264 stream (jmuxer)",
             "Name": "Name",
             "NameAlreadyExists": "Name already exists",
             "Required": "required",


### PR DESCRIPTION
This PR implements a new webcam type: jmuxer-stream.

This type of webcam uses JMuxer.js (https://github.com/samirkumardas/jmuxer) to support streaming a "raw" h264 stream (h264 Elementary Stream).

The patch is tested, and works locally. Translations are added for English, Danish and German.

The new webcam type integrates fully with the existing webcam settings panels, etc, although advanced features on jmuxer do not have a ui control.

Certain printers, like AnkerMake M5, need this camera type, to support streaming.

If you're wondering how AnkerMake M5 comes into the picture (no pun intended..), it's because we (https://github.com/ankermgmt/) are working on a Moonraker API implementation, allowing Mainsail to serve as a frontend for the printer.

All that is needed, is this webcam type.

This is my first time with Vue code, so I hope I got it somewhat right. Please let me know what you think.