### PR TITLE
fix: fix zip file timestamp

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -962,8 +962,14 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin) {
         }
 
         await addElementToItems(this.absolutePath, this.selectedFiles)
+
         const date = new Date()
-        const timestamp = `${date.getFullYear()}${date.getMonth()}${date.getDay()}-${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
+        const month = (date.getMonth() + 1).toString().padStart(2, '0')
+        const day = date.getDay().toString().padStart(2, '0')
+        const hours = date.getHours().toString().padStart(2, '0')
+        const minutes = date.getMinutes().toString().padStart(2, '0')
+        const seconds = date.getSeconds().toString().padStart(2, '0')
+        const timestamp = `${date.getFullYear()}${month}${day}-${hours}${minutes}${seconds}`
 
         this.$socket.emit(
             'server.files.zip',


### PR DESCRIPTION
## Description

This PR fixes the timestamp format used for zip downloads. Previously, the date components were not padded with zeroes and the month was off by 1 because ``Date.getMonth()`` reports months from 0 to 11. This PR aligns the used timestamp format with [the one used by Moonraker](https://github.com/Arksine/moonraker/blob/6c7dfe592131eb95fd760ef2db83387966b250f0/moonraker/components/file_manager/file_manager.py#LL601C15-L601C15), making it more readable and also fixing the sorting.

Example for a previous timestamp: ``config-202344-17137.zip``
After change: ``config-20230504-170137.zip``

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings

![](https://user-images.githubusercontent.com/22707808/236255922-d631f274-b746-4425-9575-7d9734a87bca.png)
