### PR TITLE
fix: Make the correct notification appear on gcode file move

### DIFF
--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -222,7 +222,7 @@ export const actions: ActionTree<FileState, RootState> = {
             const filename = payload.requestParams.dest
                 .substr(payload.requestParams.dest.lastIndexOf('/'))
                 .replace('/', '')
-            const sourceDir = payload.requestParams.dest.substr(0, payload.requestParams.source.lastIndexOf('/'))
+            const sourceDir = payload.requestParams.source.substr(0, payload.requestParams.source.lastIndexOf('/'))
             const destDir = payload.requestParams.dest.substr(0, payload.requestParams.dest.lastIndexOf('/'))
 
             if (sourceDir === destDir) Vue.$toast.success(<string>i18n.t('Files.SuccessfullyRenamed', { filename }))

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -222,7 +222,7 @@ export const actions: ActionTree<FileState, RootState> = {
             const filename = payload.requestParams.dest
                 .substr(payload.requestParams.dest.lastIndexOf('/'))
                 .replace('/', '')
-            const sourceDir = payload.requestParams.dest.substr(0, payload.requestParams.dest.lastIndexOf('/'))
+            const sourceDir = payload.requestParams.dest.substr(0, payload.requestParams.source.lastIndexOf('/'))
             const destDir = payload.requestParams.dest.substr(0, payload.requestParams.dest.lastIndexOf('/'))
 
             if (sourceDir === destDir) Vue.$toast.success(<string>i18n.t('Files.SuccessfullyRenamed', { filename }))


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  We use squash-merge to merge PRs, so the commit history is clean, but we use the PR title as the commit message.
  So we recommend you to use the PR title with conventional commits type prefixes. We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Documentation only changes
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can found more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr.
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

The wrong notification was being shown when moving a file, this PR makes sure that the "file move" toast shows when we move a file instead of the rename toast.

## Mobile & Desktop Screenshots/Recordings

**Before**

https://user-images.githubusercontent.com/15934114/236298842-801fef15-c3b2-4f71-a6cd-7aa4e3017efa.mov

**After**

https://user-images.githubusercontent.com/15934114/236298867-29985bd1-417f-457e-9143-ab8f11ba620f.mov


## [optional] Are there any post-deployment tasks we need to perform?

No post deployment tasks.
