### PR TITLE
feat: Add AHT10 to additionalSensors

### DIFF
--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -14,7 +14,7 @@ export const themeDir = '.theme'
 export const datasetInterval = 1000
 export const datasetTypes = ['temperature', 'target', 'power', 'speed']
 export const datasetTypesInPercents = ['power', 'speed']
-export const additionalSensors = ['bme280', 'htu21d']
+export const additionalSensors = ['bme280', 'aht10', 'htu21d']
 
 /*
  * List of valid gcode file extensions


### PR DESCRIPTION
## Description

Adds the AHT10 family of sensors to `additionalSensors`, allowing the humidity reported to be shown.  Tested on an AHT20 sensor, but Klipper treats them all the same, as an AHT10.

## Related Tickets & Documents

https://www.klipper3d.org/Config_Reference.html?h=aht20#aht10aht20aht21-temperature-sensor

## Mobile & Desktop Screenshots/Recordings

<img width="738" alt="Screenshot 2023-05-05 at 7 45 32 PM" src="https://user-images.githubusercontent.com/82196/236517878-a7b8baa9-4f16-4ee1-8228-064f34bfc27e.png">

Signed-off-by: Ben Phelps <ben@phelps.io>
