### PR TITLE
fix: check only not empty filename for metadata in farm printers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -194,8 +194,9 @@ export default class App extends Mixins(BaseMixin) {
 
     @Watch('current_file')
     current_fileChanged(newVal: string): void {
-        if (newVal !== '')
-            this.$socket.emit('server.files.metadata', { filename: newVal }, { action: 'files/getMetadataCurrentFile' })
+        if (newVal === '') return
+
+        this.$socket.emit('server.files.metadata', { filename: newVal }, { action: 'files/getMetadataCurrentFile' })
     }
 
     @Watch('primaryColor')

--- a/src/store/farm/printer/actions.ts
+++ b/src/store/farm/printer/actions.ts
@@ -190,7 +190,7 @@ export const actions: ActionTree<FarmPrinterState, RootState> = {
         const data = 'status' in payload ? { ...payload.status } : { ...payload }
         commit('setData', data)
 
-        if ('print_stats' in data && 'filename' in data.print_stats) {
+        if ((data.print_stats?.filename ?? '') !== '') {
             dispatch('sendObj', {
                 method: 'server.files.metadata',
                 params: { filename: data.print_stats?.filename },

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -91,7 +91,7 @@ export const mutations: MutationTree<FileState> = {
                 parent[indexFile].metadataRequested = false
                 parent[indexFile].metadataPulled = false
 
-                const extension = filename.substr(filename.lastIndexOf('.') + 1)
+                const extension = filename.substring(filename.lastIndexOf('.') + 1)
                 if (payload.item.root === 'gcodes' && extension === 'gcode') {
                     Vue.$socket.emit(
                         'server.files.metadata',


### PR DESCRIPTION
## Description

Mainsail sent empty metadata requests. This PR should fix this bug. This bug was in the farm printers module.

## Related Tickets & Documents

no open issue.

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
