### PR TITLE
feat: Let macros define display options (WIP)

### DIFF
--- a/src/components/panels/MacrosPanel.vue
+++ b/src/components/panels/MacrosPanel.vue
@@ -40,7 +40,9 @@ export default class MacrosPanel extends Mixins(BaseMixin) {
     get macros() {
         const macros = this.$store.getters['printer/getMacros']
 
-        return macros.filter((macro: PrinterStateMacro) => !this.hiddenMacros.includes(macro.name.toLowerCase()))
+        return macros.filter(
+            (macro: PrinterStateMacro) => !macro.hidden && !this.hiddenMacros.includes(macro.name.toLowerCase())
+        )
     }
 }
 </script>

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -180,8 +180,9 @@ export interface PrinterStateBedMesh {
 }
 
 export interface PrinterStateMacroParam {
-    type: 'int' | 'double' | 'string' | null
+    type: 'int' | 'float' | 'string' | 'select' | 'checkbox' | null
     default: string | null
+    hints?: { [key: string]: any }
 }
 
 export type PrinterStateMacroParams = {
@@ -200,6 +201,7 @@ export interface PrinterStateMacro {
         [key: string]: any
     }
     params: PrinterStateMacroParams
+    hidden: boolean
 }
 
 export interface PrinterStateKlipperConfig {


### PR DESCRIPTION
This is a first pass at what I proposed in #1398. It's also my first time doing anything at all with vue.js, so feedback on any of that would be helpful. Here's a picture of what it looks like, and below is the macro I've been using to test:

![image](https://github.com/mainsail-crew/mainsail/assets/13139373/4fc1f6d4-5836-4f9a-92a9-3587a2fd09a2)

So, it successfully overrides the parsed parameters with the ones from the macro variable. The big things I know I have left are:

- Make it so the macro button is not added at all if marked hidden (rather than just disabled).
- Figure out how to force re-rendering when `front_end_options` updates inside of Klipper.
- Add some documentation for the schema.
- Maybe add a description field that would populate a tooltip for each parameter.
