### PR TITLE
feat: add total/selectable print time and filament usage to gcode files panel

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -159,7 +159,7 @@
                         <template v-if="getColumnSum('filament_weight_total')">
                             <v-tooltip top>
                                 <template #activator="{ on, attrs }">
-                                    <span v-bind="attrs" v-on="on" class="filament-weight-sum mr-6">
+                                    <span class="filament-weight-sum mr-6" v-bind="attrs" v-on="on">
                                         <b>{{ $t('Files.FilamentWeight') }}:</b>
                                         {{ getColumnSum('filament_weight_total') }}
                                     </span>

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -719,14 +719,6 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     mdiCheckboxMarked = mdiCheckboxMarked
     mdiDragVertical = mdiDragVertical
 
-    readonly summableColumns = Object.freeze([
-        'filament_total',
-        'filament_weight_total',
-        'estimated_time',
-        'last_total_duration',
-        'last_filament_used',
-    ]);
-
     formatFilesize = formatFilesize
     formatPrintTime = formatPrintTime
     sortFiles = sortFiles

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -1111,17 +1111,17 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     }
 
     getColumnSum(columnValue: string) {
-        const col = this.tableColumns.find(c => c.value == columnValue);
+        const col = this.tableColumns.find((c) => c.value == columnValue)
         if (col && col.outputType) {
-            let files = this.files;
+            let files = this.files
             if (this.selectedFiles && this.selectedFiles.length > 0) {
-                files = this.selectedFiles;
+                files = this.selectedFiles
             }
 
             const sum = files.reduce((sum: number, file: FileStateGcodefile) => {
-                return sum + (file[col.value] || 0);
-            }, 0);
-            return this.formatOutputValue(sum, col.outputType);
+                return sum + (file[col.value] || 0)
+            }, 0)
+            return this.formatOutputValue(sum, col.outputType)
         }
     }
 
@@ -1506,7 +1506,7 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
 
     outputValue(col: any, item: FileStateGcodefile) {
         const value = col.value in item ? item[col.value] : null
-        return this.formatOutputValue(value, col.outputType);
+        return this.formatOutputValue(value, col.outputType)
     }
 
     formatOutputValue(value: any, valueType: string) {
@@ -1603,5 +1603,4 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
         display: block;
     }
 }
-
 </style>


### PR DESCRIPTION
## Description

This PR adds status labels for total print time and total filament usage to the G-Code Files panel. 

- The initial state shows the totals for the entire directory
- Once files are selected, the totals show for only those selected

The purpose of this feature is to make multi-prints projects easier, either by using the totals at the start of a project, or selecting specific files during a project to make sure enough filament remains or to assess how much total time is remaining.

There were several places this data could go, and after 3 iterations and feedback from fellow Mainsail users, I chose to locate it in the top right. The reason for this was twofold:

- There is already an "info bar" atop the files table with a Label: Value format, making this a logical choice
- The buttons in the top right already change based on files selected, so having the totals changed on selection should be more natural as all the things change in the same location

Adding more data to the info bar created a bit of a problem for smaller, mobile screens. In this case I chose to drop the total filament usage data, keeping the total print time, in order to not overly clutter the UI.

## Mobile & Desktop Screenshots/Recordings

Default state, show the total for the entire directory:
![image](https://github.com/mainsail-crew/mainsail/assets/90279/8c81801e-768a-4542-ba86-bf616a20f96d)

Selected state, showing the total for only the selected files:
![image](https://github.com/mainsail-crew/mainsail/assets/90279/4ec352a5-07ca-49a7-a0c1-d7391588b85f)

Landscape mobile, dropping the filament usage to keep the UI clean:
![image](https://github.com/mainsail-crew/mainsail/assets/90279/b35f4277-539a-4da3-a5d1-b1968db3adf2)

Portrait mobile, moving values to be under their label:
![image](https://github.com/mainsail-crew/mainsail/assets/90279/be5d6d97-ed11-4fe2-ab5b-f50d8de79738)

Signed-off-by: Titus Stone <wastingtape+mainsail@gmail.com>