### PR TITLE
feat: Adding logic to the index to handle when the PWA can load the html from disk but not the JS and the JS call fails.

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,36 +24,34 @@
             // need to be pulled from the server. If the server is offline or we can't connect, the JS file load fails,
             // the website just shows a black, blank, screen. The small script below binds to all of the script tags and if
             // any fail to load, add some text to the main body to indicate something is wrong.
-            var hasShownLoadFailedError = false;
-            var hasMainScriptLoaded = false;
-            function OnScriptLoadFailed()
-            {
-                if(hasShownLoadFailedError) {
-                    return;
+            var hasShownLoadFailedError = false
+            var hasMainScriptLoaded = false
+            function OnScriptLoadFailed() {
+                if (hasShownLoadFailedError) {
+                    return
                 }
-                if(hasMainScriptLoaded) {
-                    return;
+                if (hasMainScriptLoaded) {
+                    return
                 }
-                hasShownLoadFailedError = true;
-                var div = document.createElement('div');
-                div.style.cssText = 'color:white; height:100%; width:100%; font-size:20px; text-align:center; padding:20px; padding-top: 100px; font-family:Roboto, sans-serif';
-                div.innerHTML = '<span>Mainsail unable to connect.<br/>Is your Klipper device online?</span>';
-                document.body.appendChild(div);
+                hasShownLoadFailedError = true
+                var div = document.createElement('div')
+                div.style.cssText =
+                    'color:white; height:100%; width:100%; font-size:20px; text-align:center; padding:20px; padding-top: 100px; font-family:Roboto, sans-serif'
+                div.innerHTML = '<span>Mainsail unable to connect.<br/>Is your Klipper device online?</span>'
+                document.body.appendChild(div)
             }
-            var scripts = document.getElementsByTagName("script");
-            for (var i = 0; i < scripts.length; i++)
-            {
-                var scriptTag = scripts[i];
+            var scripts = document.getElementsByTagName('script')
+            for (var i = 0; i < scripts.length; i++) {
+                var scriptTag = scripts[i]
                 // Only target script tags with a src.
-                if(scriptTag.src != undefined && scriptTag.src != null)
-                {
-                    scriptTag.addEventListener('error', function() {
-                        OnScriptLoadFailed();
-                    });
-                    scriptTag.addEventListener('load', function() {
+                if (scriptTag.src != undefined && scriptTag.src != null) {
+                    scriptTag.addEventListener('error', function () {
+                        OnScriptLoadFailed()
+                    })
+                    scriptTag.addEventListener('load', function () {
                         // Once the main script loads, don't do anything for any future failures.
-                        hasMainScriptLoaded = true;
-                    });
+                        hasMainScriptLoaded = true
+                    })
                 }
             }
         </script>

--- a/index.html
+++ b/index.html
@@ -18,8 +18,45 @@
         <link rel="mask-icon" href="img/icons/safari-pinned-tab.svg" color="#d51f26" />
         <meta name="msapplication-TileImage" content="/img/icons/mstile-150x150.png" />
         <meta name="msapplication-TileColor" content="#d51f26" />
-
         <script type="module" src="/src/main.ts"></script>
+        <script>
+            // Since Mainsail installs as a PWA, it's possible for the index to load from disk but the main script files
+            // need to be pulled from the server. If the server is offline or we can't connect, the JS file load fails,
+            // the website just shows a black, blank, screen. The small script below binds to all of the script tags and if
+            // any fail to load, add some text to the main body to indicate something is wrong.
+            var hasShownLoadFailedError = false;
+            var hasMainScriptLoaded = false;
+            function OnScriptLoadFailed()
+            {
+                if(hasShownLoadFailedError) {
+                    return;
+                }
+                if(hasMainScriptLoaded) {
+                    return;
+                }
+                hasShownLoadFailedError = true;
+                var div = document.createElement('div');
+                div.style.cssText = 'color:white; height:100%; width:100%; font-size:20px; text-align:center; padding:20px; padding-top: 100px; font-family:Roboto, sans-serif';
+                div.innerHTML = '<span>Mainsail unable to connect.<br/>Is your Klipper device online?</span>';
+                document.body.appendChild(div);
+            }
+            var scripts = document.getElementsByTagName("script");
+            for (var i = 0; i < scripts.length; i++)
+            {
+                var scriptTag = scripts[i];
+                // Only target script tags with a src.
+                if(scriptTag.src != undefined && scriptTag.src != null)
+                {
+                    scriptTag.addEventListener('error', function() {
+                        OnScriptLoadFailed();
+                    });
+                    scriptTag.addEventListener('load', function() {
+                        // Once the main script loads, don't do anything for any future failures.
+                        hasMainScriptLoaded = true;
+                    });
+                }
+            }
+        </script>
     </head>
     <body style="background-color: #121212">
         <noscript>


### PR DESCRIPTION
## Description

Mainsail uses a PWA so its data can be cached locally and it's super snappy. The PWA caches some resources on disk and is able to load them without network access. However, it doesn't cache the js files. (maybe that's a bug?)

Not caching the JS files means that the website can load from a local disk, make the JS call, and fail. When that happens, the user is left with a blank black screen.

This change adds logic to detect if the main JS file has failed to load and shows the user an error message, so they know what's going on.

To repo the black screen due to JS failing, do the following:

1. Load Mainsail as normal from any local server.
2. Give the page a few seconds to allow the PWA to cache resources locally.
3. Use the browser's debug tools to disable caching to web requests (in the network tab, at the top)
4. Stop the Mainsail server so the browser can't connect to it.
5. Refresh the page.

You will see that the HTML and CSS load from the service worker, but the JS fails to load. If you don't disable the caching of the browser the JS will continue to load due to the browser caching it. But if you were to close and re-open the browser, the browser will no longer have the cache. 

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/7854873/35799619-0318-4e57-a0ab-c175d4ec73a7)

