### PR TITLE
chore: add PWA caching and cache updater

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,11 +34,12 @@
                     <router-view></router-view>
                 </v-container>
             </v-main>
-            <the-update-dialog></the-update-dialog>
-            <the-editor></the-editor>
-            <the-timelapse-rendering-snackbar></the-timelapse-rendering-snackbar>
-            <the-fullscreen-upload></the-fullscreen-upload>
-            <the-upload-snackbar></the-upload-snackbar>
+            <the-service-worker />
+            <the-update-dialog />
+            <the-editor />
+            <the-timelapse-rendering-snackbar />
+            <the-fullscreen-upload />
+            <the-upload-snackbar />
             <the-manual-probe-dialog />
             <the-bed-screws-dialog />
             <the-screws-tilt-adjust-dialog />

--- a/src/components/TheServiceWorker.vue
+++ b/src/components/TheServiceWorker.vue
@@ -9,7 +9,7 @@
             </v-card-text>
             <v-card-actions>
                 <v-spacer />
-                <v-btn text color="primary" @click="update">update</v-btn>
+                <v-btn text color="primary" @click="update">{{ $t('App.TheServiceWorker.Update') }}</v-btn>
             </v-card-actions>
         </panel>
     </v-dialog>

--- a/src/components/TheServiceWorker.vue
+++ b/src/components/TheServiceWorker.vue
@@ -55,8 +55,6 @@ export default class TheServiceWorker extends Mixins(BaseMixin) {
             onRegistered: this.onRegistered,
             onRegisterError: this.onRegisterError,
         })
-
-        this.showDialog = true
     }
 }
 </script>

--- a/src/components/TheServiceWorker.vue
+++ b/src/components/TheServiceWorker.vue
@@ -1,0 +1,62 @@
+<template>
+    <v-dialog v-model="showDialog" persistent max-width="400" class="mx-0">
+        <panel
+            :title="$t('App.TheServiceWorker.TitleNeedUpdate')"
+            card-class="service-worker-dialog"
+            :margin-bottom="false">
+            <v-card-text>
+                <p>{{ $t('App.TheServiceWorker.DescriptionNeedUpdate') }}</p>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn text color="primary" @click="update">update</v-btn>
+            </v-card-actions>
+        </panel>
+    </v-dialog>
+</template>
+<script lang="ts">
+import Component from 'vue-class-component'
+import { Mixins } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+
+@Component
+export default class TheServiceWorker extends Mixins(BaseMixin) {
+    showDialog = false
+    updateSW: ((reloadPage?: boolean | undefined) => Promise<void>) | null = null
+
+    onOfflineReady() {
+        window.console.info('PWA is offline ready')
+    }
+
+    onNeedRefresh() {
+        window.console.warn('PWA needs to refresh')
+        this.showDialog = true
+    }
+
+    onRegistered() {
+        window.console.debug('PWA is registered')
+    }
+
+    onRegisterError(error: any) {
+        window.console.error('PWA registration error:', error)
+    }
+
+    update() {
+        this.updateSW?.(true)
+        this.showDialog = false
+    }
+
+    async mounted() {
+        const { registerSW } = await import('virtual:pwa-register')
+        this.updateSW = registerSW({
+            immediate: true,
+            onOfflineReady: this.onOfflineReady,
+            onNeedRefresh: this.onNeedRefresh,
+            onRegistered: this.onRegistered,
+            onRegisterError: this.onRegisterError,
+        })
+
+        this.showDialog = true
+    }
+}
+</script>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -31,8 +31,8 @@
         },
         "Printers": "Drucker",
         "TheServiceWorker": {
-            "TitleNeedUpdate": "PWA benötigt ein Update",
             "DescriptionNeedUpdate": "Der lokale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren.",
+            "TitleNeedUpdate": "PWA benötigt ein Update",
             "Update": "aktualisieren"
         },
         "ThrottledStates": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -30,6 +30,10 @@
             "NoEmptyAllowedError": "Feld darf nicht leer sein!"
         },
         "Printers": "Drucker",
+        "TheServiceWorker": {
+            "TitleNeedUpdate": "PWA benötigt ein Update",
+            "DescriptionNeedUpdate": "Der locale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren."
+        },
         "ThrottledStates": {
             "DescriptionCurrentlyThrottled": "rPi ARM-Kern(e) sind derzeit gedrosselt.",
             "DescriptionFrequencyCapped": "rPi ARM max Frequenz ist derzeit auf 1,2 GHz begrenzt.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -32,7 +32,7 @@
         "Printers": "Drucker",
         "TheServiceWorker": {
             "TitleNeedUpdate": "PWA benötigt ein Update",
-            "DescriptionNeedUpdate": "Der locale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren."
+            "DescriptionNeedUpdate": "Der lokale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren."
         },
         "ThrottledStates": {
             "DescriptionCurrentlyThrottled": "rPi ARM-Kern(e) sind derzeit gedrosselt.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -32,7 +32,8 @@
         "Printers": "Drucker",
         "TheServiceWorker": {
             "TitleNeedUpdate": "PWA benötigt ein Update",
-            "DescriptionNeedUpdate": "Der lokale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren."
+            "DescriptionNeedUpdate": "Der lokale Cache ist veraltet und muss aktualisiert werden. Bitte klicke auf den Button unten, um den Cache zu aktualisieren.",
+            "Update": "aktualisieren"
         },
         "ThrottledStates": {
             "DescriptionCurrentlyThrottled": "rPi ARM-Kern(e) sind derzeit gedrosselt.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,6 +30,10 @@
             "NoEmptyAllowedError": "Input must not be empty!"
         },
         "Printers": "Printers",
+        "TheServiceWorker": {
+            "TitleNeedUpdate": "PWA needs update",
+            "DescriptionNeedUpdate": "The local cache is outdated and needs to be updated. Please click on the button below to update the cache."
+        },
         "ThrottledStates": {
             "DescriptionCurrentlyThrottled": "rPi ARM core(s) are currently throttled down.",
             "DescriptionFrequencyCapped": "rPi ARM max frequency is currently limited to 1.2 GHz.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,8 +31,8 @@
         },
         "Printers": "Printers",
         "TheServiceWorker": {
-            "TitleNeedUpdate": "PWA needs update",
             "DescriptionNeedUpdate": "The local cache is outdated and needs to be updated. Please click on the button below to update the cache.",
+            "TitleNeedUpdate": "PWA needs update",
             "Update": "update"
         },
         "ThrottledStates": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,8 @@
         "Printers": "Printers",
         "TheServiceWorker": {
             "TitleNeedUpdate": "PWA needs update",
-            "DescriptionNeedUpdate": "The local cache is outdated and needs to be updated. Please click on the button below to update the cache."
+            "DescriptionNeedUpdate": "The local cache is outdated and needs to be updated. Please click on the button below to update the cache.",
+            "Update": "update"
         },
         "ThrottledStates": {
             "DescriptionCurrentlyThrottled": "rPi ARM core(s) are currently throttled down.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,6 @@ import i18n from '@/plugins/i18n'
 import store from '@/store'
 import router from '@/plugins/router'
 import { WebSocketPlugin } from '@/plugins/webSocketClient'
-import { registerSW } from 'virtual:pwa-register'
-
-// noinspection JSUnusedGlobalSymbols
-registerSW({
-    onOfflineReady() {},
-})
 
 Vue.config.productionTip = false
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,9 +40,23 @@ const PWAConfig: Partial<VitePWAOptions> = {
             },
         ],
     },
+    workbox: {
+        globPatterns: ['**/*.{js,css,html,woff,woff2,png,svg}'],
+        navigateFallbackDenylist: [/^\/(access|api|printer|server|websocket)/, /^\/webcam[2-4]?/],
+        runtimeCaching: [
+            {
+                urlPattern: (options) => options.url.pathname.startsWith('/config.json'),
+                handler: 'StaleWhileRevalidate',
+                options: {
+                    cacheName: 'config.json',
+                },
+            },
+        ],
+    },
     /* enable sw on development */
     devOptions: {
         enabled: true,
+        type: 'module',
     },
 }
 


### PR DESCRIPTION
## Description

This PR add PWA workbox to cache all assets to run Mainsail offline and add a updater function/dialog.

## Related Tickets & Documents

no related tickes

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/02aff9ac-71dd-48a9-af57-133b38c2d84c)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
