### PR TITLE
fix: fix navigation to display allPrinters

### DIFF
--- a/src/components/mixins/navigation.ts
+++ b/src/components/mixins/navigation.ts
@@ -34,6 +34,7 @@ export default class NavigationMixin extends Mixins(BaseMixin) {
                 icon: mdiViewDashboardOutline,
                 to: '/allPrinters',
                 position: 0,
+                visible: true,
             } as NaviPoint)
         }
 


### PR DESCRIPTION
## Description

This PR fix the issue to display the `/allPrinters` navigation point in the sidebar again.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/86c09e64-ebdf-4cd0-8919-1f0adf8e9428)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
