### PR TITLE
feat: add retry button to ScrewsTiltAdjust helper dialog

### DIFF
--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -30,6 +30,9 @@
             </v-card-text>
             <v-card-actions>
                 <v-spacer />
+                <v-btn text @click="retryScrewsTiltAdjust">
+                    {{ $t('ScrewsTiltAdjust.Retry') }}
+                </v-btn>
                 <v-btn color="primary" text @click="clearScrewsTiltAdjust">
                     {{ $t('ScrewsTiltAdjust.Accept') }}
                 </v-btn>
@@ -78,6 +81,12 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
 
     clearScrewsTiltAdjust() {
         this.$store.dispatch('printer/clearScrewsTiltAdjust')
+    }
+
+    async retryScrewsTiltAdjust() {
+        await this.$store.dispatch('printer/clearScrewsTiltAdjust')
+
+        this.doSend('SCREWS_TILT_CALCULATE')
     }
 }
 </script>

--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog :value="showDialog" width="400" persistent :fullscreen="isMobile">
         <panel
-            :title="$t('ScrewsTiltAdjust.Headline').toString()"
+            :title="$t('ScrewsTiltAdjust.Headline')"
             :icon="mdiArrowCollapseDown"
             card-class="manual_probe-dialog"
             :margin-bottom="false"
@@ -24,12 +24,12 @@
                     <v-divider v-if="index" :key="`result-divider-${name}`" class="my-1" />
                     <the-screws-tilt-adjust-dialog-entry
                         :key="`result-${name}-${name}`"
-                        :name="name"
+                        :name="name.toString()"
                         :result="result" />
                 </template>
             </v-card-text>
             <v-card-actions>
-                <v-spacer></v-spacer>
+                <v-spacer />
                 <v-btn color="primary" text @click="clearScrewsTiltAdjust">
                     {{ $t('ScrewsTiltAdjust.Accept') }}
                 </v-btn>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1101,7 +1101,8 @@
         "Accept": "akzeptieren",
         "Base": "Basis",
         "ErrorText": "Ein Fehler ist beim Abtasten aufgetreten.",
-        "Headline": "Neigungsverstellung"
+        "Headline": "Neigungsverstellung",
+        "Retry": "wiederholen"
     },
     "Timelapse": {
         "AllFiles": "Alle",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1101,7 +1101,8 @@
         "Accept": "accept",
         "Base": "Base",
         "ErrorText": "Something went wrong during the probing process.",
-        "Headline": "Screws tilt adjust"
+        "Headline": "Screws tilt adjust",
+        "Retry": "retry"
     },
     "Timelapse": {
         "AllFiles": "All",


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR adds a button "retry" to the ScrewsTiltAdjust helper dialog to rerun `SCREWS_TILT_CALCULATE`.

## Related Tickets & Documents

fixes #1414 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/2ff4579b-bf4e-4ceb-8e7f-c4e71d8ccadc)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
