### PR TITLE
refactor: build version file for moonraker

### DIFF
--- a/src/plugins/build-release_info.ts
+++ b/src/plugins/build-release_info.ts
@@ -1,0 +1,31 @@
+import fs from 'fs'
+import path from 'path'
+import { version } from '../../package.json'
+import { PluginOption } from 'vite'
+
+/**
+ * Custom build plugin to write the version in a dedicated release_info.json file after bundling
+ */
+
+export default function buildReleaseInfo(): PluginOption {
+    return {
+        name: 'build-release_info',
+        writeBundle: () => {
+            setImmediate(async () => {
+                const versionIdentifier = version.toString()
+                const releaseInfoFile = await fs.promises.open(
+                    path.resolve(__dirname, '../../dist/release_info.json'),
+                    'w'
+                )
+                await releaseInfoFile.writeFile(
+                    JSON.stringify({
+                        project_name: 'mainsail',
+                        project_owner: 'mainsail-crew',
+                        version: `v${versionIdentifier}`,
+                    })
+                )
+                await releaseInfoFile.close()
+            })
+        },
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import checker from 'vite-plugin-checker'
 
 import path from 'path'
 import buildVersion from './src/plugins/build-version'
+import buildReleaseInfo from './src/plugins/build-release_info'
 import { VitePWA, VitePWAOptions } from 'vite-plugin-pwa'
 
 const PWAConfig: Partial<VitePWAOptions> = {
@@ -66,6 +67,7 @@ export default defineConfig({
     plugins: [
         VitePWA(PWAConfig),
         buildVersion(),
+        buildReleaseInfo(),
         vue(),
         loadVersion(),
         checker({ typescript: true }),


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR adds a release_info.json file in the /dist directory. 

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/6ddd9d18-6637-4553-a6c0-7282c86e3c29)

with this content:
```json
{"project_name":"mainsail","project_owner":"mainsail-crew","version":"v2.6.0"}
```

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
