### PR TITLE
fix: fix condition in restartServiceNameExists check

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -251,7 +251,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     }
 
     get restartServiceNameExists() {
-        if (this.restartServiceName) return true
+        if (!this.restartServiceName) return true
 
         return this.availableServices.includes(this.restartServiceName)
     }


### PR DESCRIPTION
## Description

Updated the condition in the restartServiceNameExists getter in TheEditor.vue component. Previously, it was returning true if 'restartServiceName' exists. However, this was incorrect as the function should return true only when 'restartServiceName' does not exist. This change fixes an issue where the available services were not correctly checked if 'restartServiceName' existed.

## Related Tickets & Documents

This PR fixes #1432 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
