### PR TITLE
chore: add dev-dist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ design
 *.log
 packages/test
 dist
+dev-dist
 temp
 .vuerc
 .version


### PR DESCRIPTION
## Description

This commit adds 'dev-dist' directory to .gitignore. 'dev-dist' is a folder that gets created when we build the application in development environment, it's not needed to be tracked as it only contains generated files.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none
