### PR TITLE
feat: hide axis controls during print

### DIFF
--- a/src/components/panels/ToolheadControlPanel.vue
+++ b/src/components/panels/ToolheadControlPanel.vue
@@ -97,9 +97,8 @@
         <v-container v-if="axisControlVisible">
             <component :is="`${controlStyle}-control`"></component>
         </v-container>
-        <v-container v-if="!axisControlVisible" class="py-0 pt-3"></v-container>
         <!-- Z-OFFSET CONTROL -->
-        <v-divider></v-divider>
+        <v-divider :class="{ 'mt-3': !axisControlVisible }"></v-divider>
         <v-container>
             <zoffset-control></zoffset-control>
         </v-container>

--- a/src/components/panels/ToolheadControlPanel.vue
+++ b/src/components/panels/ToolheadControlPanel.vue
@@ -94,9 +94,10 @@
         <!-- MOVE TO CONTROL -->
         <move-to-control class="py-0 pt-3"></move-to-control>
         <!-- AXIS CONTROL -->
-        <v-container>
+        <v-container v-if="axisControlVisible">
             <component :is="`${controlStyle}-control`"></component>
         </v-container>
+        <v-container v-if="!axisControlVisible" class="py-0 pt-3"></v-container>
         <!-- Z-OFFSET CONTROL -->
         <v-divider></v-divider>
         <v-container>
@@ -163,6 +164,14 @@ export default class ToolheadControlPanel extends Mixins(BaseMixin, ControlMixin
 
     get speedFactor(): number {
         return this.$store.state.printer?.gcode_move?.speed_factor ?? 1
+    }
+
+    get isPrinting() {
+        return ['printing'].includes(this.printer_state)
+    }
+
+    get axisControlVisible() {
+        return !(this.isPrinting && (this.$store.state.gui.control.hideDuringPrint ?? false))
     }
 }
 </script>

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -36,6 +36,12 @@
                         <v-divider class="my-2"></v-divider>
                     </template>
                     <settings-row
+                        :title="$t('Settings.ControlTab.HideDuringPrint').toString()"
+                        :dynamic-slot-width="true">
+                        <v-switch v-model="hideDuringPrint" hide-details class="mt-0"></v-switch>
+                    </settings-row>
+                    <v-divider class="my-2"></v-divider>
+                    <settings-row
                         :title="$t('Settings.ControlTab.EnableXYHoming').toString()"
                         :dynamic-slot-width="true">
                         <v-switch v-model="enableXYHoming" hide-details class="mt-0"></v-switch>
@@ -334,6 +340,14 @@ export default class SettingsControlTab extends Mixins(BaseMixin, ControlMixin) 
 
     set controlStyle(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'control.style', value: newVal })
+    }
+
+    get hideDuringPrint(): Boolean {
+        return this.$store.state.gui.control.hideDuringPrint ?? false
+    }
+
+    set hideDuringPrint(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'control.hideDuringPrint', value: newVal })
     }
 
     get actionOptions() {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -770,6 +770,7 @@
             "Circle": "Kreis",
             "Control": "Steuerung",
             "Cross": "Kreuz",
+            "HideDuringPrint": "Achsensteuerung während des Drucks ausblenden",
             "EnableXYHoming": "Aktiviere kombiniertes X & Y homing",
             "EstimatedExtrusionInfo": "Zeige Info zur geschätzten Extrusion",
             "EstimatedExtrusionInfoDescription": "Anzeigen/ausblenden der Info zur geschätzten Extrusion, basierend auf Extrusionmenge und Extrusionsgeschwindigkeit",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -770,6 +770,7 @@
             "Circle": "Circle",
             "Control": "Control",
             "Cross": "Cross",
+            "HideDuringPrint": "Hide axis controls during print",
             "EnableXYHoming": "Enable combined X & Y axes homing",
             "EstimatedExtrusionInfo": "Show estimated extrusion info",
             "EstimatedExtrusionInfoDescription": "Show / Hide info for estimated extrusions based on extrusion amount and feedrate",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -30,6 +30,7 @@ export const getDefaultState = (): GuiState => {
         control: {
             style: 'bars',
             actionButton: null,
+            hideDuringPrint: false,
             enableXYHoming: false,
             feedrateXY: 100,
             stepsXY: [100, 10, 1],

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -20,6 +20,7 @@ export interface GuiState {
     console?: GuiConsoleState
     control: {
         style: 'bars' | 'circle' | 'cross'
+        hideDuringPrint: boolean
         actionButton: null | 'm84' | 'qgl' | 'ztilt'
         enableXYHoming: boolean
         feedrateXY: number


### PR DESCRIPTION
## Description

This PR adds a setting to hide the axis controls (X, Y, Z) instead of only disabling it during a print. The Z-Offset controls are not affected. This saves some space on the screen, especially on mobile devices.

## Mobile & Desktop Screenshots/Recordings
Settings:
<img width="899" alt="Settings" src="https://github.com/mainsail-crew/mainsail/assets/23439221/d9f2a7da-a350-4791-9e9f-363874beb24d">

Toolhead panel in ready state:
<img width="468" alt="Ready" src="https://github.com/mainsail-crew/mainsail/assets/23439221/ea5ac81c-b6ee-416c-9b03-7cdfc1039187">

Toolhead panel in printing state with hiding setting on:
<img width="462" alt="Printing_hide" src="https://github.com/mainsail-crew/mainsail/assets/23439221/50d837b5-92ed-44e0-ba85-b579408a8a9c">

Toolhead panel in printing state with hiding setting off:
<img width="456" alt="Printing_disable" src="https://github.com/mainsail-crew/mainsail/assets/23439221/79026580-0cb4-44cb-b454-1fae1c8b6ef5">

