### PR TITLE
fix: avoid hitting 100% before print is complete

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -170,7 +170,7 @@ export default class App extends Mixins(BaseMixin) {
     }
 
     get print_percent(): number {
-        return Math.round(this.$store.getters['printer/getPrintPercent'] * 100)
+        return Math.floor(this.$store.getters['printer/getPrintPercent'] * 100)
     }
 
     @Watch('language')

--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -185,7 +185,7 @@ export default class StatusPanel extends Mixins(BaseMixin) {
     }
 
     get printPercent() {
-        return Math.round(this.$store.getters['printer/getPrintPercent'] * 100)
+        return Math.floor(this.$store.getters['printer/getPrintPercent'] * 100)
     }
 
     get printerStateOutput() {

--- a/src/store/farm/printer/getters.ts
+++ b/src/store/farm/printer/getters.ts
@@ -52,7 +52,7 @@ export const getters: GetterTree<FarmPrinterState, any> = {
             if (state.data.print_stats.state === 'printing') {
                 const percent = getters['getPrintPercent']
 
-                return Math.round(percent * 100) + '% Printing'
+                return Math.floor(percent * 100) + '% Printing'
             }
 
             return state.data.print_stats.state.charAt(0).toUpperCase() + state.data.print_stats.state.slice(1)

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -38,7 +38,7 @@ export const getters: GetterTree<RootState, any> = {
         // return printing title
         if (printer_state === 'printing') {
             const eta = getters['printer/getEstimatedTimeETAFormat']
-            const percent = (getters['printer/getPrintPercent'] * 100).toFixed(0)
+            const percent = Math.floor(getters['printer/getPrintPercent'] * 100)
 
             if (eta !== '--') {
                 let output = i18n.t('App.Titles.PrintingETA', {


### PR DESCRIPTION
The existing implementation will report 100% from 99.5% on, due to round(). Switching to floor() instead, which will report 99% until complete.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  We use squash-merge to merge PRs, so the commit history is clean, but we use the PR title as the commit message.
  So we recommend you to use the PR title with conventional commits type prefixes. We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Documentation only changes
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can found more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr.
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This PR fixes a display bug where prints will report 100% anytime they are at 99.5% or higher.

## Related Tickets & Documents

There is a Discord support thread: 
https://discord.com/channels/758059413700345988/1126955424999035061

## Mobile & Desktop Screenshots/Recordings

![2023-05-06_22-41](https://github.com/mainsail-crew/mainsail/assets/1904577/fa368274-acf0-4105-912f-95c8f8ddc0fa)
![mainsail-progress-percent](https://github.com/mainsail-crew/mainsail/assets/1904577/c9ca3da8-bb93-4c78-a65a-e4e1ca66c7c0)




## [optional] Are there any post-deployment tasks we need to perform?

no
