### PR TITLE
fix: fix issue with CSV separator in contents

### DIFF
--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -175,7 +175,7 @@ export default class BaseMixin extends Vue {
     }
 
     get browserLocale() {
-        return navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language
+        return navigator.language
     }
 
     get hours12Format() {

--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -181,7 +181,7 @@ export default class BaseMixin extends Vue {
     get hours12Format() {
         const setting = this.$store.state.gui.general.timeFormat
         if (setting === '12hours') return true
-        if (setting === null && this.browserLocale === 'en_us') return true
+        if (setting === null && this.browserLocale === 'en-US') return true
 
         return false
     }

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -1056,7 +1056,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
                 default:
                     switch (typeof value) {
                         case 'number':
-                            return value?.toLocaleString(undefined, { useGrouping: false }) ?? 0
+                            return value?.toLocaleString(this.browserLocale, { useGrouping: false }) ?? 0
 
                         case 'string':
                             if (escapeChar !== null && value.includes(escapeChar)) value = '"' + value + '"'

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -962,7 +962,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     }
 
     exportHistory() {
-        const checkString = parseFloat('1.23').toLocaleString()
+        const checkString = parseFloat('1.23').toLocaleString(this.browserLocale)
         const decimalSeparator = checkString.indexOf(',') >= 0 ? ',' : '.'
         const csvSeperator = decimalSeparator === ',' ? ';' : ','
 
@@ -1011,7 +1011,19 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
             })
         }
 
-        const csvContent = 'data:text/csv;charset=utf-8,' + content.map((e) => e.join(csvSeperator)).join('\n')
+        const csvContent =
+            'data:text/csv;charset=utf-8,' +
+            content
+                .map((entry) =>
+                    entry
+                        .map((field) => {
+                            if (field.indexOf(csvSeperator) === -1) return field
+
+                            return `"${field}"`
+                        })
+                        .join(csvSeperator)
+                )
+                .join('\n')
         const link = document.createElement('a')
         link.setAttribute('href', encodeURI(csvContent))
         link.setAttribute('download', 'print_history.csv')

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -1011,19 +1011,14 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
             })
         }
 
+        // escape fields with the csvSeperator in the content
+        // prettier-ignore
         const csvContent =
             'data:text/csv;charset=utf-8,' +
-            content
-                .map((entry) =>
-                    entry
-                        .map((field) => {
-                            if (field.indexOf(csvSeperator) === -1) return field
+            content.map((entry) =>
+                entry.map((field) => (field.indexOf(csvSeperator) === -1 ? field : `"${field}"`)).join(csvSeperator)
+            ).join('\n')
 
-                            return `"${field}"`
-                        })
-                        .join(csvSeperator)
-                )
-                .join('\n')
         const link = document.createElement('a')
         link.setAttribute('href', encodeURI(csvContent))
         link.setAttribute('download', 'print_history.csv')


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR escape CSV separator in the content fields

## Related Tickets & Documents

fixes comment issue in #963 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/95fe135d-2cf0-4155-bc04-a152ea4727c9)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
