### PR TITLE
feat: hide screws tilt adjust helper dialog, when using MAX_DEVIATION

### DIFF
--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -65,12 +65,17 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
         return this.$store.state.printer.screws_tilt_adjust?.error ?? false
     }
 
+    get max_diff() {
+        return this.$store.state.printer.screws_tilt_adjust?.max_diff ?? null
+    }
+
     get results() {
         return this.$store.state.printer.screws_tilt_adjust?.results ?? {}
     }
 
     get showDialog() {
         if (!this.boolScrewsTiltAdjustDialog) return false
+        if (this.max_diff !== null) return false
 
         return this.error || Object.keys(this.results).length
     }

--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -65,8 +65,8 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
         return this.$store.state.printer.screws_tilt_adjust?.error ?? false
     }
 
-    get max_diff() {
-        return this.$store.state.printer.screws_tilt_adjust?.max_diff ?? null
+    get max_deviation() {
+        return this.$store.state.printer.screws_tilt_adjust?.max_deviation ?? null
     }
 
     get results() {
@@ -78,7 +78,7 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
         if (!this.boolScrewsTiltAdjustDialog) return false
 
         // don't display the dialog, if the user add the MAX_DEVIATION attribute to the SCREWS_TILT_CALCULATE command
-        if (this.max_diff !== null) return false
+        if (this.max_deviation !== null) return false
 
         return this.error || Object.keys(this.results).length
     }

--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -74,7 +74,10 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
     }
 
     get showDialog() {
+        // don't display the dialog, if the user disabled it in the UI settings
         if (!this.boolScrewsTiltAdjustDialog) return false
+
+        // don't display the dialog, if the user add the MAX_DEVIATION attribute to the SCREWS_TILT_CALCULATE command
         if (this.max_diff !== null) return false
 
         return this.error || Object.keys(this.results).length


### PR DESCRIPTION
## Description

With this PR, Mainsail will hide the SCREWS_TILT_ADJUST helper dialog, when using MAX_DEVIATION

## Related Tickets & Documents

This PR fixes #1472 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

This PR requires a merge of this PR (https://github.com/Klipper3d/klipper/pull/6295) into Klipper.
