### PR TITLE
feat: add option to hide FPS counter

### DIFF
--- a/src/components/settings/Webcams/WebcamForm.vue
+++ b/src/components/settings/Webcams/WebcamForm.vue
@@ -102,6 +102,15 @@
                                 :label="$t('Settings.WebcamsTab.Rotate')" />
                         </v-col>
                     </v-row>
+                    <v-row v-if="hasFpsCounter">
+                        <v-col class="pt-1 pb-3">
+                            <v-checkbox
+                                v-model="hideFps"
+                                class="mt-1"
+                                hide-details
+                                :label="$t('Settings.WebcamsTab.HideFps')" />
+                        </v-col>
+                    </v-row>
                     <v-row>
                         <v-col class="pt-1 pb-3">
                             <div class="v-label v-label--active theme--dark text-subtitle-1">
@@ -248,6 +257,27 @@ export default class WebcamForm extends Mixins(BaseMixin, WebcamMixin) {
         if (this.selectIcon) classes.push('_rotate-180')
 
         return classes
+    }
+
+    get hasFpsCounter() {
+        return ['mjpegstreamer', 'mjpegstreamer-adaptive'].includes(this.webcam.service)
+    }
+
+    get hideFps() {
+        return this.webcam.extra_data?.hideFps ?? false
+    }
+
+    set hideFps(newVal) {
+        if (!('extra_data' in this.webcam)) {
+            this.webcam.extra_data = {
+                hideFps: newVal,
+            }
+
+            return
+        }
+
+        // @ts-ignore
+        this.webcam.extra_data.hideFps = newVal
     }
 
     mounted() {

--- a/src/components/webcams/Mjpegstreamer.vue
+++ b/src/components/webcams/Mjpegstreamer.vue
@@ -76,7 +76,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     get showFpsCounter() {
         if (!this.showFps) return false
 
-        return this.camSettings.extra_data?.hideFps ?? true
+        return !(this.camSettings.extra_data?.hideFps ?? false)
     }
 
     startStream() {

--- a/src/components/webcams/Mjpegstreamer.vue
+++ b/src/components/webcams/Mjpegstreamer.vue
@@ -6,7 +6,7 @@
             class="webcamImage"
             :style="webcamStyle"
             @load="onload" />
-        <span v-if="showFps" class="webcamFpsOutput">{{ $t('Panels.WebcamPanel.FPS') }}: {{ fpsOutput }}</span>
+        <span v-if="showFpsCounter" class="webcamFpsOutput">{{ $t('Panels.WebcamPanel.FPS') }}: {{ fpsOutput }}</span>
     </div>
 </template>
 
@@ -71,6 +71,12 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
     get fpsOutput() {
         return this.currentFPS < 10 ? '0' + this.currentFPS.toString() : this.currentFPS
+    }
+
+    get showFpsCounter() {
+        if (!this.showFps) return false
+
+        return this.camSettings.extra_data?.hideFps ?? true
     }
 
     startStream() {

--- a/src/components/webcams/MjpegstreamerAdaptive.vue
+++ b/src/components/webcams/MjpegstreamerAdaptive.vue
@@ -10,7 +10,7 @@
             height="400"
             :style="webcamStyle"
             :class="'webcamImage ' + (isLoaded ? '' : 'hiddenWebcam')"></canvas>
-        <span v-if="isLoaded && showFps" class="webcamFpsOutput">
+        <span v-if="isLoaded && showFpsCounter" class="webcamFpsOutput">
             {{ $t('Panels.WebcamPanel.FPS') }}: {{ fpsOutput }}
         </span>
     </div>
@@ -73,6 +73,12 @@ export default class MjpegstreamerAdaptive extends Mixins(BaseMixin) {
 
     get fpsOutput() {
         return this.currentFPS < 10 ? '0' + this.currentFPS.toString() : this.currentFPS
+    }
+
+    get showFpsCounter() {
+        if (!this.showFps) return false
+
+        return !(this.camSettings.extra_data?.hideFps ?? false)
     }
 
     get rotate() {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1097,6 +1097,7 @@
             "EditWebcam": "Webcam bearbeiten",
             "FlipWebcam": "Webcam-Bild spiegeln:",
             "Hlsstream": "HLS-Stream",
+            "HideFps": "FPS-Anzeige verstecken",
             "Horizontally": "horizontal",
             "IconBed": "Bett",
             "IconCam": "Kamera",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1096,6 +1096,7 @@
             "EditCrowsnestConf": "Edit crowsnest.conf",
             "EditWebcam": "Edit Webcam",
             "FlipWebcam": "Flip webcam image:",
+            "HideFps": "Hide FPS counter",
             "Horizontally": "horizontally",
             "IconBed": "Bed",
             "IconCam": "Cam",

--- a/src/store/gui/webcams/types.ts
+++ b/src/store/gui/webcams/types.ts
@@ -25,6 +25,8 @@ export interface GuiWebcamStateWebcam {
     flip_vertical: boolean
     rotation: number
     aspect_ratio?: string
-    extra_data?: {}
+    extra_data?: {
+        hideFps?: boolean
+    }
     source?: 'config' | 'database'
 }


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR add an option for each mjpegstreamer webcam to hide the FPS counter.

## Related Tickets & Documents

fixes #1473

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/78ac1f06-ab3a-49ac-8b4f-3168b534432e)

## [optional] Are there any post-deployment tasks we need to perform?

none
