### PR TITLE
fix: hide rpm in temperature_fans without tachometer_pin

### DIFF
--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -231,7 +231,10 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
     }
 
     get rpm() {
-        if (!('rpm' in this.printerObject)) return null
+        const rpm = this.printerObject.rpm ?? null
+
+        // return null when rpm doesn't exist
+        if (rpm === null) return null
 
         return parseInt(this.printerObject.rpm)
     }


### PR DESCRIPTION
## Description

In the last refactoring of the temperature panel is a bug, which display `NaN RPM` when your temperature_fan has no tachometer.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
