### PR TITLE
fix: fix issue with camel-case object names in temperature panel

### DIFF
--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -90,9 +90,12 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
     }
 
     get printerObjectSettings() {
-        if (!(this.objectName in (this.$store.state.printer?.configfile?.settings ?? {}))) return {}
+        // convert objectName to lowercase, because klipper only user lowercase in configfile.settings
+        const lowerCaseObjectName = this.objectName.toLowerCase()
 
-        return this.$store.state.printer?.configfile?.settings[this.objectName]
+        if (!(lowerCaseObjectName in (this.$store.state.printer?.configfile?.settings ?? {}))) return {}
+
+        return this.$store.state.printer?.configfile?.settings[lowerCaseObjectName]
     }
 
     get name() {


### PR DESCRIPTION
## Description

This PR fix the issue with not lowercase object names in temperatur panel

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
