### PR TITLE
fix: fix issue with extruder cannot extrude after a klipper restart

### DIFF
--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -71,6 +71,10 @@ export const actions: ActionTree<PrinterState, RootState> = {
         dispatch('getData', payload)
 
         Vue.$socket.emit('server.temperature_store', {}, { action: 'printer/tempHistory/init' })
+
+        setTimeout(() => {
+            dispatch('initExtruderCanExtrude')
+        }, 200)
     },
 
     getData({ commit, dispatch, state }, payload) {
@@ -123,6 +127,17 @@ export const actions: ActionTree<PrinterState, RootState> = {
         }
 
         commit('setData', payload)
+    },
+
+    initExtruderCanExtrude({ state }) {
+        const extruderList: string[] = Object.keys(state).filter((name) => name.startsWith('extruder'))
+        const reInitList: { [key: string]: string[] } = {}
+
+        extruderList.forEach((extruderName) => {
+            reInitList[extruderName] = ['can_extrude']
+        })
+
+        Vue.$socket.emit('printer.objects.query', { objects: reInitList }, { action: 'printer/getData' })
     },
 
     initHelpList({ commit, dispatch }, payload) {


### PR DESCRIPTION
## Description

After a Klipper firmware_restart/restart and the extruder temp is higher than the min_extrude setting, Moonraker/Klipper only init the extruder with `can_extrude: false` but don't update it. With this PR, i send a delayed reinit request to update this attribute. This is more a "hack" then a fix, because the fix would have to be in Moonraker/Klipper itself.

## Related Tickets & Documents

fixes #1490 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
