### PR TITLE
feat: add option to hide MCU & Host sensors in the temperature panel

### DIFF
--- a/src/components/panels/Temperature/TemperaturePanelList.vue
+++ b/src/components/panels/Temperature/TemperaturePanelList.vue
@@ -65,11 +65,18 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
             .sort(this.sortObjectName)
     }
 
+    get hideMcuHostSensors(): boolean {
+        return this.$store.state.gui.view.tempchart.hideMcuHostSensors ?? false
+    }
+
     get temperature_sensors() {
         return this.available_sensors
             .filter((fullName: string) => {
                 if (this.available_heaters.includes(fullName)) return false
                 if (this.temperature_fans.includes(fullName)) return false
+
+                // hide MCU & Host sensors, if the function is enabled
+                if (this.hideMcuHostSensors && this.checkMcuHostSensor(fullName)) return false
 
                 const splits = fullName.split(' ')
                 let name = splits[0]
@@ -82,6 +89,17 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
 
     get tempObjects() {
         return [...this.filteredHeaters, ...this.temperature_fans, ...this.temperature_sensors]
+    }
+
+    get settings() {
+        return this.$store.state.printer?.configfile?.settings ?? {}
+    }
+
+    checkMcuHostSensor(fullName: string) {
+        const settingsObject = this.settings[fullName.toLowerCase()] ?? {}
+        const sensor_type = settingsObject.sensor_type ?? ''
+
+        return ['temperature_mcu', 'temperature_host'].includes(sensor_type)
     }
 
     sortObjectName(a: string, b: string) {

--- a/src/components/panels/Temperature/TemperaturePanelSettings.vue
+++ b/src/components/panels/Temperature/TemperaturePanelSettings.vue
@@ -15,6 +15,13 @@
             </v-list-item>
             <v-list-item class="minHeight36">
                 <v-checkbox
+                    v-model="hideMcuHostSensors"
+                    class="mt-0"
+                    hide-details
+                    :label="$t('Panels.TemperaturePanel.HideMcuHostSensors')" />
+            </v-list-item>
+            <v-list-item class="minHeight36">
+                <v-checkbox
                     v-model="autoscaleTempchart"
                     class="mt-0"
                     hide-details
@@ -48,6 +55,14 @@ export default class TemperaturePanelSettings extends Mixins(BaseMixin) {
 
     set autoscaleTempchart(newVal: boolean) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.tempchart.autoscale', value: newVal })
+    }
+
+    get hideMcuHostSensors(): boolean {
+        return this.$store.state.gui.view.tempchart.hideMcuHostSensors ?? false
+    }
+
+    set hideMcuHostSensors(newVal: boolean) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.tempchart.hideMcuHostSensors', value: newVal })
     }
 }
 </script>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -680,6 +680,7 @@
                 "Temperature": "Aktuelle Temperatur"
             },
             "Headline": "Temperaturen",
+            "HideMcuHostSensors": "Host/MCU Sensoren ausblenden",
             "Max": "max",
             "Min": "min",
             "Name": "Name",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -680,6 +680,7 @@
                 "Temperature": "current temperature"
             },
             "Headline": "Temperatures",
+            "HideMcuHostSensors": "Hide Host/MCU Sensors",
             "Max": "max",
             "Min": "min",
             "Name": "Name",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -236,6 +236,7 @@ export const getDefaultState = (): GuiState => {
             tempchart: {
                 boolTempchart: true,
                 hiddenDataset: [],
+                hideMcuHostSensors: false,
                 autoscale: false,
                 datasetSettings: {},
             },

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -162,6 +162,7 @@ export interface GuiState {
         tempchart: {
             boolTempchart: boolean
             hiddenDataset: string[]
+            hideMcuHostSensors: boolean
             autoscale: boolean
             datasetSettings: any
         }


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

Add an option to hide all MCU or Host temperature sensors in the temperature panel.

## Related Tickets & Documents

fixes #1464 

## Mobile & Desktop Screenshots/Recordings

option disabled:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/3f738191-cab2-47c2-ade9-4e9d1c6d328f)

option enabled:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/15b183cd-fb7b-482c-84dc-721e2f4a3b3c)

## [optional] Are there any post-deployment tasks we need to perform?

none
