### PR TITLE
fix: fix multiple issues in the refactored update manager

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -19,7 +19,17 @@
                 <span v-else>{{ versionOutput }}</span>
             </v-col>
             <v-col class="col-auto pr-6 text-right" align-self="center">
-                <template v-if="needsRecovery">
+                <v-chip
+                    v-if="anomalies.length > 0"
+                    small
+                    label
+                    outlined
+                    color="primary"
+                    class="minwidth-0 px-1 mr-2"
+                    @click="toggleAnomalies = !toggleAnomalies">
+                    <v-icon small>{{ mdiInformation }}</v-icon>
+                </v-chip>
+                <template v-if="!isValid">
                     <v-menu :offset-y="true">
                         <template #activator="{ on, attrs }">
                             <v-chip
@@ -37,16 +47,16 @@
                             </v-chip>
                         </template>
                         <v-list dense class="py-0">
-                            <v-list-item @click="doRecovery(false)">
-                                <v-list-item-icon class="mr-0">
+                            <v-list-item v-if="!isCorrupt" @click="doRecovery(false)">
+                                <v-list-item-icon class="mr-0 pt-1">
                                     <v-icon small>{{ mdiReload }}</v-icon>
                                 </v-list-item-icon>
                                 <v-list-item-content>
                                     <v-list-item-title>{{ $t('Machine.UpdatePanel.SoftRecovery') }}</v-list-item-title>
                                 </v-list-item-content>
                             </v-list-item>
-                            <v-list-item @click="doRecovery(true)">
-                                <v-list-item-icon class="mr-0">
+                            <v-list-item :disabled="!existsRecoveryUrl" @click="doRecovery(true)">
+                                <v-list-item-icon class="mr-0 pt-1">
                                     <v-icon small>{{ mdiReload }}</v-icon>
                                 </v-list-item-icon>
                                 <v-list-item-content>
@@ -70,33 +80,6 @@
                 </v-chip>
             </v-col>
         </v-row>
-        <v-row v-if="anomalies.length" class="mt-0">
-            <v-col class="px-6 pt-0">
-                <v-alert
-                    v-for="(message, index) in anomalies"
-                    :key="'anomalies_' + index"
-                    text
-                    dense
-                    border="left"
-                    type="info"
-                    :icon="mdiAlertCircle">
-                    {{ message }}
-                </v-alert>
-            </v-col>
-        </v-row>
-        <v-row v-if="gitMessages.length" class="mt-0">
-            <v-col class="px-6 pt-0">
-                <v-alert
-                    v-for="(message, index) in gitMessages"
-                    :key="'message_' + index"
-                    text
-                    dense
-                    border="left"
-                    type="info">
-                    {{ message }}
-                </v-alert>
-            </v-col>
-        </v-row>
         <v-row v-if="warnings.length" class="mt-0">
             <v-col class="px-6 pt-0">
                 <v-alert
@@ -106,7 +89,21 @@
                     dense
                     border="left"
                     color="orange"
-                    :icon="mdiAlertCircle">
+                    :icon="mdiCloseCircle">
+                    {{ message }}
+                </v-alert>
+            </v-col>
+        </v-row>
+        <v-row v-show="toggleAnomalies" class="mt-0">
+            <v-col class="px-6 pt-0">
+                <v-alert
+                    v-for="(message, index) in anomalies"
+                    :key="'anomalies_' + index"
+                    text
+                    dense
+                    border="left"
+                    color="info"
+                    :icon="mdiInformation">
                     {{ message }}
                 </v-alert>
             </v-col>
@@ -130,7 +127,7 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { ServerUpdateManagerStateGitRepo } from '@/store/server/updateManager/types'
 import {
-    mdiAlertCircle,
+    mdiCloseCircle,
     mdiCheck,
     mdiHelpCircleOutline,
     mdiInformation,
@@ -148,10 +145,12 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     mdiInformation = mdiInformation
     mdiMenuDown = mdiMenuDown
     mdiReload = mdiReload
-    mdiAlertCircle = mdiAlertCircle
+    mdiCloseCircle = mdiCloseCircle
 
     boolShowCommitList = false
     boolShowUpdateHint = false
+
+    toggleAnomalies = false
 
     @Prop({ required: true }) readonly repo!: ServerUpdateManagerStateGitRepo
 
@@ -237,6 +236,10 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         return this.repo.is_dirty ?? false
     }
 
+    get isCorrupt() {
+        return this.repo.corrupt ?? false
+    }
+
     get debugEnabled() {
         return this.repo.debug_enabled ?? false
     }
@@ -247,19 +250,21 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         return !this.debugEnabled && (this.repo.detached ?? false)
     }
 
-    get needsRecovery() {
-        return !this.isValid || this.isDirty
+    get existsRecoveryUrl() {
+        const url = this.repo.recovery_url ?? '?'
+
+        return url !== '?'
     }
 
     get btnDisabled() {
         if (['printing', 'paused'].includes(this.printer_state)) return true
-        if (!this.isValid || this.isDirty || this.commitsBehind.length) return false
+        if (!this.isValid || this.isCorrupt || this.isDirty || this.commitsBehind.length) return false
 
         return !(this.localVersion && this.remoteVersion && semver.gt(this.remoteVersion, this.localVersion))
     }
 
     get btnIcon() {
-        if (this.isDetached || !this.isValid || this.isDirty) return mdiAlertCircle
+        if (this.isDetached || !this.isValid || this.isCorrupt || this.isDirty) return mdiCloseCircle
 
         if (
             this.commitsBehind.length ||
@@ -273,8 +278,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     }
 
     get btnColor() {
-        if (this.isDetached || !this.isValid) return 'orange'
-        if (this.isDirty) return 'red'
+        if (this.isCorrupt || this.isDetached || this.isDirty || !this.isValid) return 'orange'
 
         if (
             this.commitsBehind.length ||
@@ -286,9 +290,10 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     }
 
     get btnText() {
+        if (this.isCorrupt) return this.$t('Machine.UpdatePanel.Corrupt')
         if (this.isDetached) return this.$t('Machine.UpdatePanel.Detached')
-        if (!this.isValid) return this.$t('Machine.UpdatePanel.Invalid')
         if (this.isDirty) return this.$t('Machine.UpdatePanel.Dirty')
+        if (!this.isValid) return this.$t('Machine.UpdatePanel.Invalid')
         if (
             this.commitsBehind.length ||
             (this.localVersion && this.remoteVersion && semver.gt(this.remoteVersion, this.localVersion))
@@ -298,10 +303,6 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (this.localVersion === null || this.remoteVersion === null) return this.$t('Machine.UpdatePanel.Unknown')
 
         return this.$t('Machine.UpdatePanel.UpToDate')
-    }
-
-    get gitMessages() {
-        return this.repo.git_messages ?? []
     }
 
     get anomalies() {

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -70,13 +70,6 @@
                 </v-chip>
             </v-col>
         </v-row>
-        <v-row v-if="notificationText" class="mt-0">
-            <v-col class="px-6 pt-0">
-                <v-alert text dense :color="notificationColor" :icon="notificationIcon" border="left">
-                    {{ notificationText }}
-                </v-alert>
-            </v-col>
-        </v-row>
         <v-row v-if="gitMessages.length" class="mt-0">
             <v-col class="px-6 pt-0">
                 <v-alert
@@ -291,21 +284,6 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (this.localVersion === null || this.remoteVersion === null) return this.$t('Machine.UpdatePanel.Unknown')
 
         return this.$t('Machine.UpdatePanel.UpToDate')
-    }
-
-    get notificationText() {
-        if (this.isDetached) return this.$t('Machine.UpdatePanel.Notification.Detached')
-        if (this.isDirty) return this.$t('Machine.UpdatePanel.Notification.Dirty')
-
-        return null
-    }
-
-    get notificationColor() {
-        return this.btnColor
-    }
-
-    get notificationIcon() {
-        return this.btnIcon
     }
 
     get gitMessages() {

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -70,6 +70,20 @@
                 </v-chip>
             </v-col>
         </v-row>
+        <v-row v-if="anomalies.length" class="mt-0">
+            <v-col class="px-6 pt-0">
+                <v-alert
+                    v-for="(message, index) in anomalies"
+                    :key="'anomalies_' + index"
+                    text
+                    dense
+                    border="left"
+                    type="info"
+                    :icon="mdiAlertCircle">
+                    {{ message }}
+                </v-alert>
+            </v-col>
+        </v-row>
         <v-row v-if="gitMessages.length" class="mt-0">
             <v-col class="px-6 pt-0">
                 <v-alert
@@ -288,6 +302,10 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
 
     get gitMessages() {
         return this.repo.git_messages ?? []
+    }
+
+    get anomalies() {
+        return this.repo.anomalies ?? []
     }
 
     get warnings() {

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -320,8 +320,12 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         return semver.gt(this.remoteVersion, this.localVersion)
     }
 
+    get repo_name() {
+        return this.repo.repo_name ?? this.repo.name ?? ''
+    }
+
     get webLinkRelease() {
-        return `https://github.com/${this.repo.owner}/${this.repo.name}/releases/tag/${this.repo.remote_version}`
+        return `https://github.com/${this.repo.owner}/${this.repo_name}/releases/tag/${this.repo.remote_version}`
     }
 
     get hideUpdateWarning() {

--- a/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
@@ -85,8 +85,12 @@ export default class GitCommitsListDayCommit extends Mixins(BaseMixin) {
             })
     }
 
+    get repo_name() {
+        return this.repo.repo_name ?? this.repo.name ?? ''
+    }
+
     get commitHref() {
-        return `https://github.com/${this.repo.owner}/${this.repo.name}/commit/${this.commit.sha}`
+        return `https://github.com/${this.repo.owner}/${this.repo_name}/commit/${this.commit.sha}`
     }
 
     get commitShortSha() {

--- a/src/components/panels/Machine/UpdatePanel/UpdateHintAlert.vue
+++ b/src/components/panels/Machine/UpdatePanel/UpdateHintAlert.vue
@@ -69,13 +69,17 @@ export default class UpdateHintAlert extends Mixins(BaseMixin) {
         return null
     }
 
+    get repo_name() {
+        return this.repo.repo_name ?? this.repo.name ?? ''
+    }
+
     get externalLink() {
         if (this.name === 'klipper') return '//www.klipper3d.org/Config_Changes.html'
         if (this.name === 'moonraker') return '//moonraker.readthedocs.io/en/latest/changelog/'
         if (this.repo?.configured_type === 'web')
-            return `//github.com/${this.repo.owner}/${this.repo.name}/releases/tag/${this.repo.remote_version}`
+            return `//github.com/${this.repo.owner}/${this.repo_name}/releases/tag/${this.repo.remote_version}`
 
-        return `//github.com/${this.repo.owner}/${this.repo.name}`
+        return `//github.com/${this.repo.owner}/${this.repo_name}`
     }
 
     get externalLinkText() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -490,6 +490,7 @@
             "CommittedHoursAgo": "committed {hours} hours ago",
             "CommittedOnDate": "committed on {date}",
             "CommittedYesterday": "committed yesterday",
+            "Corrupt": "corrupt",
             "ConfigChanges": "Config Changes",
             "CountPackagesCanBeUpgraded": "{count} packages can be upgraded",
             "Detached": "detached",

--- a/src/store/server/updateManager/types.ts
+++ b/src/store/server/updateManager/types.ts
@@ -32,6 +32,7 @@ export interface ServerUpdateManagerStateGitRepoCommit {
 
 export interface ServerUpdateManagerStateGitRepo {
     name: string
+    repo_name?: string
     configured_type: string
     detected_type?: string
     channel?: string

--- a/src/store/server/updateManager/types.ts
+++ b/src/store/server/updateManager/types.ts
@@ -51,6 +51,7 @@ export interface ServerUpdateManagerStateGitRepo {
     debug_enabled?: boolean
     commits_behind?: ServerUpdateManagerStateGitRepoCommit[]
     git_messages?: string[]
+    anomalies?: string[]
     warnings?: string[]
     info_tags?: string[]
 }

--- a/src/store/server/updateManager/types.ts
+++ b/src/store/server/updateManager/types.ts
@@ -47,6 +47,7 @@ export interface ServerUpdateManagerStateGitRepo {
     remote_hash?: string
     is_valid?: boolean
     is_dirty?: boolean
+    corrupt?: boolean
     detached?: boolean
     debug_enabled?: boolean
     commits_behind?: ServerUpdateManagerStateGitRepoCommit[]
@@ -54,6 +55,7 @@ export interface ServerUpdateManagerStateGitRepo {
     anomalies?: string[]
     warnings?: string[]
     info_tags?: string[]
+    recovery_url?: string
 }
 
 export interface ServerUpdateManagerStateGitRepoGroupedCommits {


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR fixes multiple issues in the update manager:
- remove warnings from mainsail, because moonraker post the same one
- add anomalies to each entry (if exists)
- fix issues with wrong links to github pages
- fix button text when the state is dirty

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/c7836158-f034-456a-b28b-b1b9da2113cc)

## [optional] Are there any post-deployment tasks we need to perform?

- it would be nice to have a PR to moonraker to add more informations to the default corrupt, detached and dirty messages (like the old one before from mainsail)
