### PR TITLE
fix: change info buttons in update manager to color info

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -5,14 +5,14 @@
                 <strong>{{ repo.name }}</strong>
                 <br />
                 <template v-if="type === 'git_repo' && commitsBehind.length">
-                    <a class="primary--text cursor--pointer" @click="boolShowCommitList = true">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text cursor--pointer" @click="boolShowCommitList = true">
+                        <v-icon small color="info" class="mr-1">{{ mdiInformation }}</v-icon>
                         {{ versionOutput }}
                     </a>
                 </template>
                 <template v-else-if="type === 'web' && webUpdatable">
-                    <a class="primary--text text-decoration-none" :href="webLinkRelease" target="_blank">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text text-decoration-none" :href="webLinkRelease" target="_blank">
+                        <v-icon small color="info" class="mr-1">{{ mdiInformation }}</v-icon>
                         {{ versionOutput }}
                     </a>
                 </template>
@@ -24,7 +24,7 @@
                     small
                     label
                     outlined
-                    color="primary"
+                    color="info"
                     class="minwidth-0 px-1 mr-2"
                     @click="toggleAnomalies = !toggleAnomalies">
                     <v-icon small>{{ mdiInformation }}</v-icon>

--- a/src/components/panels/Machine/UpdatePanel/EntrySystem.vue
+++ b/src/components/panels/Machine/UpdatePanel/EntrySystem.vue
@@ -5,8 +5,8 @@
                 <strong>{{ $t('Machine.UpdatePanel.System') }}</strong>
                 <br />
                 <template v-if="package_count">
-                    <a class="primary--text cursor--pointer" @click="boolShowPackageList = true">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text cursor--pointer" @click="boolShowPackageList = true">
+                        <v-icon small color="info" class="mr-1">{{ mdiInformation }}</v-icon>
                         {{ $t('Machine.UpdatePanel.CountPackagesCanBeUpgraded', { count: package_count }) }}
                     </a>
                 </template>


### PR DESCRIPTION
## Description

This PR should fix issues, when the user use the color red as primary color.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/4594a414-211a-4b44-a28c-93e2b2a84caf)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/da06a9da-482b-4f1d-84d7-f6a6036d1110)

## [optional] Are there any post-deployment tasks we need to perform?

none
