### PR TITLE
refactor: soft down info buttons in update manager

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -85,13 +85,12 @@
                 <v-alert
                     v-for="(message, index) in warnings"
                     :key="'warnings_' + index"
-                    text
                     dense
-                    border="left"
+                    text
                     color="orange"
-                    colored-border
+                    border="left"
                     :icon="mdiCloseCircle">
-                    {{ message }}
+                    <p class="text--disabled mb-0">{{ message }}</p>
                 </v-alert>
             </v-col>
         </v-row>
@@ -100,11 +99,10 @@
                 <v-alert
                     v-for="(message, index) in anomalies"
                     :key="'anomalies_' + index"
-                    text
                     dense
-                    border="left"
+                    text
                     color="grey"
-                    colored-border
+                    border="left"
                     :icon="mdiInformation">
                     {{ message }}
                 </v-alert>

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -5,14 +5,14 @@
                 <strong>{{ repo.name }}</strong>
                 <br />
                 <template v-if="type === 'git_repo' && commitsBehind.length">
-                    <a class="primary--text cursor--pointer" @click="boolShowCommitList = true">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text cursor--pointer" @click="boolShowCommitList = true">
+                        <v-icon small color="info" class="mr-1">{{ mdiUpdate }}</v-icon>
                         {{ versionOutput }}
                     </a>
                 </template>
                 <template v-else-if="type === 'web' && webUpdatable">
-                    <a class="primary--text text-decoration-none" :href="webLinkRelease" target="_blank">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text text-decoration-none" :href="webLinkRelease" target="_blank">
+                        <v-icon small color="info" class="mr-1">{{ mdiUpdate }}</v-icon>
                         {{ versionOutput }}
                     </a>
                 </template>
@@ -23,11 +23,11 @@
                     v-if="anomalies.length > 0"
                     small
                     label
-                    outlined
-                    color="primary"
+                    :outlined="!toggleAnomalies"
+                    color="grey"
                     class="minwidth-0 px-1 mr-2"
                     @click="toggleAnomalies = !toggleAnomalies">
-                    <v-icon small>{{ mdiInformation }}</v-icon>
+                    <v-icon small>{{ toggleAnomalies ? mdiInformationOutline : mdiInformation }}</v-icon>
                 </v-chip>
                 <template v-if="!isValid">
                     <v-menu :offset-y="true">
@@ -89,6 +89,7 @@
                     dense
                     border="left"
                     color="orange"
+                    colored-border
                     :icon="mdiCloseCircle">
                     {{ message }}
                 </v-alert>
@@ -102,7 +103,8 @@
                     text
                     dense
                     border="left"
-                    color="info"
+                    color="grey"
+                    colored-border
                     :icon="mdiInformation">
                     {{ message }}
                 </v-alert>
@@ -131,9 +133,11 @@ import {
     mdiCheck,
     mdiHelpCircleOutline,
     mdiInformation,
+    mdiInformationOutline,
     mdiMenuDown,
     mdiProgressUpload,
     mdiReload,
+    mdiUpdate,
 } from '@mdi/js'
 import semver from 'semver'
 import GitCommitsList from '@/components/panels/Machine/UpdatePanel/GitCommitsList.vue'
@@ -146,6 +150,8 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     mdiMenuDown = mdiMenuDown
     mdiReload = mdiReload
     mdiCloseCircle = mdiCloseCircle
+    mdiUpdate = mdiUpdate
+    mdiInformationOutline = mdiInformationOutline
 
     boolShowCommitList = false
     boolShowUpdateHint = false

--- a/src/components/panels/Machine/UpdatePanel/EntrySystem.vue
+++ b/src/components/panels/Machine/UpdatePanel/EntrySystem.vue
@@ -5,8 +5,8 @@
                 <strong>{{ $t('Machine.UpdatePanel.System') }}</strong>
                 <br />
                 <template v-if="package_count">
-                    <a class="primary--text cursor--pointer" @click="boolShowPackageList = true">
-                        <v-icon small color="primary" class="mr-1">{{ mdiInformation }}</v-icon>
+                    <a class="info--text cursor--pointer" @click="boolShowPackageList = true">
+                        <v-icon small color="info" class="mr-1">{{ mdiInformation }}</v-icon>
                         {{ $t('Machine.UpdatePanel.CountPackagesCanBeUpgraded', { count: package_count }) }}
                     </a>
                 </template>


### PR DESCRIPTION
Signed-off-by: Stefan Dej <meteyou@gmail.com>

## Description

This PR change all version links to info color (blue) and the moonraker anomaly button to gray. also the message will have a gray background.

## Related Tickets & Documents

https://github.com/mainsail-crew/moonraker-timelapse/issues/128

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/d6a86779-c1f1-4930-b106-725818a3e342)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
