### PR TITLE
fix: fix issue on tablet and smaller devices with the sidebar

### DIFF
--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -1,7 +1,7 @@
 <template>
     <v-navigation-drawer
         :key="navigationStyle"
-        :value="naviDrawer"
+        v-model="naviDrawer"
         :src="sidebarBackground"
         :mini-variant="navigationStyle === 'iconsOnly'"
         :width="navigationWidth"
@@ -68,6 +68,10 @@ export default class TheSidebar extends Mixins(NavigationMixin, BaseMixin) {
 
     get naviDrawer(): boolean {
         return this.$store.state.naviDrawer
+    }
+
+    set naviDrawer(newVal) {
+        this.$store.dispatch('setNaviDrawer', newVal)
     }
 
     get navigationStyle() {


### PR DESCRIPTION
## Description

This PR fixes an issue with the sidebar on tablets and smaller devices. If you click a navi point and the sidebar will hide, the space behind the sidebar will not be blank anymore. The sidebar will push the new state to the Vuex store to remove the padding left of the main container.

## Related Tickets & Documents

none open issues

## Mobile & Desktop Screenshots/Recordings

before:
<img width="984" alt="image" src="https://github.com/mainsail-crew/mainsail/assets/8167632/6feb2b6f-4ecc-431f-bca7-752d1e563607">

after:
<img width="982" alt="image" src="https://github.com/mainsail-crew/mainsail/assets/8167632/95b661ac-cd10-4392-ac4d-3ec3fb45c48f">


## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
