### PR TITLE
feat: add option to block autoscroll in console

### DIFF
--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -106,7 +106,7 @@ import BaseMixin from '@/components/mixins/base'
 import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import Panel from '@/components/ui/Panel.vue'
-import {mdiChevronDoubleRight, mdiCog, mdiConsoleLine, mdiSend, mdiTrashCan} from '@mdi/js'
+import { mdiChevronDoubleRight, mdiCog, mdiConsoleLine, mdiSend, mdiTrashCan } from '@mdi/js'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
 
 @Component({

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -159,6 +159,11 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
         }
     }
 
+    @Watch('autoscroll')
+    autoscrollChanged(newVal: boolean) {
+        if (newVal) this.scrollToBottom()
+    }
+
     clearConsole() {
         this.$store.dispatch('gui/console/clear')
     }

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -1,13 +1,3 @@
-<style scoped lang="scss">
-.consoleTable {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.gcode-command-field {
-    font-family: 'Roboto Mono', monospace;
-}
-</style>
-
 <template>
     <panel
         v-if="socketIsConnected && klipperState !== 'disconnected'"
@@ -325,3 +315,13 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+.consoleTable {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.gcode-command-field {
+    font-family: 'Roboto Mono', monospace;
+}
+</style>

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -10,30 +10,37 @@
             <v-btn icon tile @click="clearConsole">
                 <v-icon small>{{ mdiTrashCan }}</v-icon>
             </v-btn>
-            <command-help-modal :in-toolbar="true" @onCommand="gcode = $event"></command-help-modal>
+            <command-help-modal :in-toolbar="true" @onCommand="gcode = $event" />
             <v-menu
                 :offset-y="true"
                 :close-on-content-click="false"
                 :title="$t('Panels.MiniconsolePanel.SetupConsole')">
                 <template #activator="{ on, attrs }">
                     <v-btn icon tile v-bind="attrs" v-on="on">
-                        <v-icon small>{{ mdiFilter }}</v-icon>
+                        <v-icon small>{{ mdiCog }}</v-icon>
                     </v-btn>
                 </template>
                 <v-list>
+                    <v-list-item v-if="consoleDirection === 'shell'" class="minHeight36">
+                        <v-checkbox
+                            v-model="autoscroll"
+                            class="mt-0"
+                            hide-details
+                            :label="$t('Panels.MiniconsolePanel.Autoscroll')" />
+                    </v-list-item>
                     <v-list-item class="minHeight36">
                         <v-checkbox
                             v-model="hideWaitTemperatures"
                             class="mt-0"
                             hide-details
-                            :label="$t('Panels.MiniconsolePanel.HideTemperatures')"></v-checkbox>
+                            :label="$t('Panels.MiniconsolePanel.HideTemperatures')" />
                     </v-list-item>
                     <v-list-item v-if="moonrakerComponents.includes('timelapse')" class="minHeight36">
                         <v-checkbox
                             v-model="hideTlCommands"
                             class="mt-0"
                             hide-details
-                            :label="$t('Panels.MiniconsolePanel.HideTimelapse')"></v-checkbox>
+                            :label="$t('Panels.MiniconsolePanel.HideTimelapse')" />
                     </v-list-item>
                     <v-list-item v-for="(filter, index) in customFilters" :key="index" class="minHeight36">
                         <v-checkbox
@@ -41,7 +48,7 @@
                             class="mt-0"
                             hide-details
                             :label="filter.name"
-                            @change="toggleFilter(filter)"></v-checkbox>
+                            @change="toggleFilter(filter)" />
                     </v-list-item>
                 </v-list>
             </v-menu>
@@ -83,7 +90,7 @@
                                 :events="events"
                                 :is-mini="true"
                                 @command-click="commandClick" />
-                            <v-divider></v-divider>
+                            <v-divider />
                         </overlay-scrollbars>
                     </v-col>
                 </v-row>
@@ -99,7 +106,7 @@ import BaseMixin from '@/components/mixins/base'
 import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiChevronDoubleRight, mdiConsoleLine, mdiFilter, mdiSend, mdiTrashCan } from '@mdi/js'
+import {mdiChevronDoubleRight, mdiCog, mdiConsoleLine, mdiSend, mdiTrashCan} from '@mdi/js'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
 
 @Component({
@@ -112,7 +119,7 @@ import CommandHelpModal from '@/components/CommandHelpModal.vue'
 export default class MiniconsolePanel extends Mixins(BaseMixin) {
     mdiTrashCan = mdiTrashCan
     mdiConsoleLine = mdiConsoleLine
-    mdiFilter = mdiFilter
+    mdiCog = mdiCog
     mdiSend = mdiSend
     mdiChevronDoubleRight = mdiChevronDoubleRight
 
@@ -145,7 +152,7 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
 
     @Watch('events')
     eventsChanged() {
-        if (this.consoleDirection === 'shell') {
+        if (this.consoleDirection === 'shell' && this.autoscroll) {
             setTimeout(() => {
                 this.scrollToBottom()
             }, 50)
@@ -182,6 +189,14 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
 
     get lastCommands(): string[] {
         return this.$store.state.gui.gcodehistory.entries ?? []
+    }
+
+    get autoscroll(): boolean {
+        return this.$store.state.gui.console.autoscroll ?? true
+    }
+
+    set autoscroll(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'console.autoscroll', value: newVal })
     }
 
     commandClick(msg: string): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -133,6 +133,7 @@
         "TryAgain": "try again"
     },
     "Console": {
+        "Autoscroll": "Autoscroll",
         "CommandList": "Command list",
         "Empty": "Empty",
         "HideTemperatures": "Hide temperatures",
@@ -588,6 +589,7 @@
             "Send": "send"
         },
         "MiniconsolePanel": {
+            "Autoscroll": "Autoscroll",
             "Headline": "Console",
             "HideTemperatures": "Hide temperatures",
             "HideTimelapse": "Hide Timelapse",

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -148,6 +148,11 @@ export default class PageConsole extends Mixins(BaseMixin) {
         }
     }
 
+    @Watch('autoscroll')
+    autoscrollChanged(newVal: boolean) {
+        if (newVal) this.scrollToBottom()
+    }
+
     get hideWaitTemperatures(): boolean {
         return this.$store.state.gui.console.hideWaitTemperatures
     }

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -1,14 +1,3 @@
-<style scoped>
-.consoleScrollContainer {
-    min-height: 200px;
-    height: calc(var(--app-height) - 180px);
-}
-
-.gcode-command-field {
-    font-family: 'Roboto Mono', monospace;
-}
-</style>
-
 <template>
     <div class="d-flex flex-column">
         <v-row :class="consoleDirection === 'table' ? 'order-0' : 'order-1 mt-3'">
@@ -304,3 +293,14 @@ export default class PageConsole extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+.consoleScrollContainer {
+    min-height: 200px;
+    height: calc(var(--app-height) - 180px);
+}
+
+.gcode-command-field {
+    font-family: 'Roboto Mono', monospace;
+}
+</style>

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -38,10 +38,17 @@
                     :title="$t('Console.SetupConsole')">
                     <template #activator="{ on, attrs }">
                         <v-btn class="ml-3 px-2 minwidth-0" color="lightgray" v-bind="attrs" v-on="on">
-                            <v-icon>{{ mdiFilter }}</v-icon>
+                            <v-icon>{{ mdiCog }}</v-icon>
                         </v-btn>
                     </template>
                     <v-list>
+                        <v-list-item v-if="consoleDirection === 'shell'" class="minHeight36">
+                            <v-checkbox
+                                v-model="autoscroll"
+                                class="mt-0"
+                                hide-details
+                                :label="$t('Panels.MiniconsolePanel.Autoscroll')" />
+                        </v-list-item>
                         <v-list-item class="minHeight36">
                             <v-checkbox
                                 v-model="hideWaitTemperatures"
@@ -93,7 +100,7 @@ import ConsoleTable from '@/components/console/ConsoleTable.vue'
 import { CommandHelp, VTextareaType } from '@/store/printer/types'
 import { reverseString, strLongestEqual } from '@/plugins/helpers'
 import CommandHelpModal from '@/components/CommandHelpModal.vue'
-import { mdiChevronDoubleRight, mdiFilter, mdiSend, mdiTrashCan } from '@mdi/js'
+import { mdiChevronDoubleRight, mdiCog, mdiSend, mdiTrashCan } from '@mdi/js'
 
 @Component({
     components: {
@@ -111,7 +118,7 @@ export default class PageConsole extends Mixins(BaseMixin) {
      */
     mdiChevronDoubleRight = mdiChevronDoubleRight
     mdiSend = mdiSend
-    mdiFilter = mdiFilter
+    mdiCog = mdiCog
     mdiTrashCan = mdiTrashCan
 
     declare $refs: {
@@ -134,7 +141,7 @@ export default class PageConsole extends Mixins(BaseMixin) {
 
     @Watch('events')
     eventsChanged() {
-        if (this.consoleDirection === 'shell') {
+        if (this.consoleDirection === 'shell' && this.autoscroll) {
             setTimeout(() => {
                 this.scrollToBottom()
             }, 50)
@@ -171,6 +178,14 @@ export default class PageConsole extends Mixins(BaseMixin) {
 
     get lastCommands(): string[] {
         return this.$store.state.gui.gcodehistory.entries ?? []
+    }
+
+    get autoscroll(): boolean {
+        return this.$store.state.gui.console.autoscroll ?? true
+    }
+
+    set autoscroll(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'console.autoscroll', value: newVal })
     }
 
     commandClick(msg: string): void {

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -30,7 +30,7 @@
                 <v-btn class="mr-3 px-2 minwidth-0" color="lightgray" @click="clearConsole">
                     <v-icon>{{ mdiTrashCan }}</v-icon>
                 </v-btn>
-                <command-help-modal @onCommand="gcode = $event"></command-help-modal>
+                <command-help-modal @onCommand="gcode = $event" />
                 <v-menu
                     offset-y
                     :top="consoleDirection === 'shell'"
@@ -47,14 +47,14 @@
                                 v-model="hideWaitTemperatures"
                                 class="mt-0"
                                 hide-details
-                                :label="$t('Console.HideTemperatures')"></v-checkbox>
+                                :label="$t('Console.HideTemperatures')" />
                         </v-list-item>
                         <v-list-item v-if="moonrakerComponents.includes('timelapse')" class="minHeight36">
                             <v-checkbox
                                 v-model="hideTlCommands"
                                 class="mt-0"
                                 hide-details
-                                :label="$t('Console.HideTimelapse')"></v-checkbox>
+                                :label="$t('Console.HideTimelapse')" />
                         </v-list-item>
                         <v-list-item v-for="(filter, index) in customFilters" :key="index" class="minHeight36">
                             <v-checkbox
@@ -62,7 +62,7 @@
                                 class="mt-0"
                                 hide-details
                                 :label="filter.name"
-                                @change="toggleFilter(filter)"></v-checkbox>
+                                @change="toggleFilter(filter)" />
                         </v-list-item>
                     </v-list>
                 </v-menu>

--- a/src/store/gui/console/index.ts
+++ b/src/store/gui/console/index.ts
@@ -11,6 +11,7 @@ export const getDefaultState = (): GuiConsoleState => {
         direction: 'table',
         entryStyle: 'default',
         height: 300,
+        autoscroll: true,
         consolefilters: {},
     }
 }

--- a/src/store/gui/console/types.ts
+++ b/src/store/gui/console/types.ts
@@ -5,6 +5,7 @@ export interface GuiConsoleState {
     direction: 'table' | 'shell'
     entryStyle: 'default' | 'compact'
     height: number
+    autoscroll: boolean
     consolefilters: {
         [key: string]: GuiConsoleStateFilter
     }


### PR DESCRIPTION
Signed-off-by: meteyou <meteyou@gmail.com>

## Description

This PR adds an option to block auto-scroll in the console in the "bash" mode.

## Related Tickets & Documents

This PR fixes #838 

## Mobile & Desktop Screenshots/Recordings

Option in miniconsole panel:
<img width="313" alt="image" src="https://github.com/mainsail-crew/mainsail/assets/8167632/a231cde9-65e2-4cef-9f06-959071422bf4">

Option in the console page:
<img width="439" alt="image" src="https://github.com/mainsail-crew/mainsail/assets/8167632/7231ea3f-6afa-496b-9fec-eb0369d271f9">


## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
