### PR TITLE
fix: eta time format detection from browser

### DIFF
--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -152,13 +152,11 @@ export const getters: GetterTree<GuiState, any> = {
         const setting = state.general.timeFormat
         if (setting === '12hours') return true
         if (setting === null) {
-            const timestring = new Date().toLocaleTimeString().split(' ');            
+            const timestring = new Date().toLocaleTimeString().split(' ')
 
-            timestring.map(
-                p => {
-                    if (['AM', 'PM'].includes(p)) return true;
-                }
-             )            
+            timestring.map((p) => {
+                if (['AM', 'PM'].includes(p)) return true
+            })
         }
 
         return false

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -152,10 +152,13 @@ export const getters: GetterTree<GuiState, any> = {
         const setting = state.general.timeFormat
         if (setting === '12hours') return true
         if (setting === null) {
-            const browserLocale =
-                navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language
+            const timestring = new Date().toLocaleTimeString().split(' ');            
 
-            if (browserLocale === 'en_us') return true
+            timestring.map(
+                p => {
+                    if (['AM', 'PM'].includes(p)) return true;
+                }
+             )            
         }
 
         return false

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -153,10 +153,7 @@ export const getters: GetterTree<GuiState, any> = {
         if (setting === '12hours') return true
         if (setting === null) {
             const timestring = new Date().toLocaleTimeString().split(' ')
-
-            timestring.map((p) => {
-                if (['AM', 'PM'].includes(p)) return true
-            })
+            return timestring.includes('AM') || timestring.includes('PM')
         }
 
         return false


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  We use squash-merge to merge PRs, so the commit history is clean, but we use the PR title as the commit message.
  So we recommend you to use the PR title with conventional commits type prefixes. We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Documentation only changes
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can found more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr.
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This PR fixes the time format detection from browser. 
Right now the time format of the ETA time field won't be adjusted to the browser settings and will fallback to default 24hrs format. To fix this we read the `LocaleTimeString()` to determine the current format and adjust the setting accordingly.

## Related Tickets & Documents
https://discord.com/channels/758059413700345988/1139732350515818506
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
