### PR TITLE
fix: fix missing reset options for print history data

### DIFF
--- a/src/components/settings/General/GeneralReset.vue
+++ b/src/components/settings/General/GeneralReset.vue
@@ -65,7 +65,7 @@ export default class SettingsGeneralTabResetDatabase extends Mixins(BaseMixin, S
     resetCheckboxes: string[] = []
 
     async mounted() {
-        this.resetableNamespaces = await this.loadBackupableNamespaces()
+        await this.loadResetableNamespaces()
     }
 
     onSelectResetCheckboxes(resetCheckboxes: string[]) {
@@ -78,8 +78,24 @@ export default class SettingsGeneralTabResetDatabase extends Mixins(BaseMixin, S
     }
 
     async openDialog() {
-        this.resetableNamespaces = await this.loadBackupableNamespaces()
+        await this.loadResetableNamespaces()
         this.showDialog = true
+    }
+
+    async loadResetableNamespaces() {
+        this.resetableNamespaces = await this.loadBackupableNamespaces()
+
+        if (this.moonrakerComponents.includes('history')) {
+            this.resetableNamespaces.push({
+                value: 'history_jobs',
+                label: this.$t('Settings.GeneralTab.DbHistoryJobs'),
+            })
+
+            this.resetableNamespaces.push({
+                value: 'history_totals',
+                label: this.$t('Settings.GeneralTab.DbHistoryTotals'),
+            })
+        }
     }
 
     closeDialog() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -506,10 +506,6 @@
             "KlipperUpdateQuestionConfig": "This update may also contain changes to config parameters that would need to be modified in the printer.cfg file, see the change log for details.",
             "MoonrakerUpdateQuestion": "This will update the Moonraker API. Changes to the moonraker.conf file may be required to continue using the machine.",
             "MoreCommitsInfo": "A maximum of 30 commits can be displayed here. To see all commits, please click on the following link:",
-            "Notification": {
-                "Detached": "Detached state is not an error nor is it a problem. It only means that additional commits exist in the local repository that do not exist in the remote repository.",
-                "Dirty": "The local repository has been modified and cannot be updated in this state. Please recover this repository."
-            },
             "OSPackages": "OS-Packages",
             "SoftRecovery": "Soft Recovery",
             "StartUpdate": "Start Update",


### PR DESCRIPTION
## Description

This PR adds the options for reset the print history datas again. We lost these options in this PR #1448 

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/5b35c59e-548c-4cf4-9503-33fb8bef4f16)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
