### PR TITLE
feat: hide Moonraker power devices with a `_` as first char

### DIFF
--- a/src/components/TheTopCornerMenu.vue
+++ b/src/components/TheTopCornerMenu.vue
@@ -238,7 +238,9 @@ export default class TheTopCornerMenu extends Mixins(BaseMixin) {
     }
 
     get powerDevices() {
-        return this.$store.getters['server/power/getDevices']
+        const devices = this.$store.getters['server/power/getDevices'] ?? []
+
+        return devices.filter((device: ServerPowerStateDevice) => !device.device.startsWith('_'))
     }
 
     get service_states() {


### PR DESCRIPTION
## Description

This PR add a filter to hide all Moonraker power devices with a `_` as first char.

## Related Tickets & Documents

fixes: #1543 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
