### PR TITLE
fix: fix autorestart of webcam camerastreamer

### DIFF
--- a/src/components/webcams/WebrtcCameraStreamer.vue
+++ b/src/components/webcams/WebrtcCameraStreamer.vue
@@ -30,6 +30,7 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
     private remote_pc_id: string | null = null
     private aspectRatio: null | number = null
     private status: string = 'connecting'
+    private restartTimer: number | null = null
 
     @Prop({ required: true }) readonly camSettings!: GuiWebcamStateWebcam
     @Prop({ default: null }) declare readonly printerUrl: string | null
@@ -99,11 +100,15 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
                 )
                 this.pc.addEventListener('connectionstatechange', () => {
                     this.status = (this.pc?.connectionState ?? '').toString()
+
+                    // clear restartTimer if it is set
+                    if (this.restartTimer) window.clearTimeout(this.restartTimer)
+
                     if (['failed', 'disconnected'].includes(this.status)) {
-                        setTimeout(async () => {
-                            await this.pc?.close()
-                            this.startStream()
-                        }, 500)
+                        // set restartTimer to restart stream after 5 seconds
+                        this.restartTimer = window.setTimeout(() => {
+                            this.restartStream()
+                        }, 5000)
                     }
                 })
                 this.pc.addEventListener('icecandidate', (e) => {
@@ -147,8 +152,16 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
                 if (isFirefox) this.status = 'connected'
                 return response.json()
             })
-            .catch(function (e) {
+            .catch((e) => {
                 window.console.error(e)
+
+                // clear restartTimer if it is set
+                if (this.restartTimer) window.clearTimeout(this.restartTimer)
+
+                // set restartTimer to restart stream after 5 seconds
+                this.restartTimer = window.setTimeout(() => {
+                    this.restartStream()
+                }, 5000)
             })
     }
 
@@ -160,10 +173,16 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
         this.pc?.close()
     }
 
+    restartStream() {
+        this.pc?.close()
+        setTimeout(async () => {
+            this.startStream()
+        }, 500)
+    }
+
     @Watch('url')
     async changedUrl() {
-        await this.pc?.close()
-        this.startStream()
+        this.restartStream()
     }
 }
 </script>


### PR DESCRIPTION
## Description

This webcam mode should restart after 5 seconds, if the connection is failed or disconnected, but there was a bug, that it only restart one time.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
