### PR TITLE
fix: fix macro parameter with spaces

### DIFF
--- a/src/components/inputs/MacroButton.vue
+++ b/src/components/inputs/MacroButton.vue
@@ -199,9 +199,13 @@ export default class MacroButton extends Mixins(BaseMixin) {
     sendWithParams() {
         let params: string[] = []
         this.paramArray.forEach((paramname: string) => {
-            if (this.params[paramname].value !== null && this.params[paramname].value !== '') {
+            let value = (this.params[paramname].value + '').trim()
+
+            if (this.params[paramname].value !== null && value !== '') {
                 let tmp: string = paramname
-                tmp += this.isGcodeStyle ? this.params[paramname].value : `=${this.params[paramname].value}`
+                if (value.includes(' ')) value = `"${value}"`
+
+                tmp += this.isGcodeStyle ? value : `=${value}`
 
                 params.push(tmp)
             }

--- a/src/components/inputs/MacroButton.vue
+++ b/src/components/inputs/MacroButton.vue
@@ -199,11 +199,11 @@ export default class MacroButton extends Mixins(BaseMixin) {
     sendWithParams() {
         let params: string[] = []
         this.paramArray.forEach((paramname: string) => {
-            let value = (this.params[paramname].value + '').trim()
+            let value = this.params[paramname].value?.toString().trim()
 
             if (this.params[paramname].value !== null && value !== '') {
                 let tmp: string = paramname
-                if (value.includes(' ')) value = `"${value}"`
+                if (value?.includes(' ')) value = `"${value}"`
 
                 tmp += this.isGcodeStyle ? value : `=${value}`
 


### PR DESCRIPTION
## Description

This PR fixes an issue, if you try to send a macro parameter via Mainsail, which contain a space in it.

## Related Tickets & Documents

fixes: #1550 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/45a64517-1664-4ec2-bc91-b68553540da1)

## [optional] Are there any post-deployment tasks we need to perform?

none
