### PR TITLE
fix: fix webcam (camera-streamer) stop autorestart beforeDestory

### DIFF
--- a/src/components/webcams/WebrtcCameraStreamer.vue
+++ b/src/components/webcams/WebrtcCameraStreamer.vue
@@ -171,6 +171,7 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
 
     beforeDestroy() {
         this.pc?.close()
+        if (this.restartTimer) window.clearTimeout(this.restartTimer)
     }
 
     restartStream() {


### PR DESCRIPTION
## Description

This PR fix the autorestart mechanism of the webcam client camera-streamer.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
