### PR TITLE
feat: add 12-hour time format in printers overview

### DIFF
--- a/src/store/farm/printer/getters.ts
+++ b/src/store/farm/printer/getters.ts
@@ -166,7 +166,7 @@ export const getters: GetterTree<FarmPrinterState, any> = {
         return []
     },
 
-    getPrinterPreview: (state, getters) => {
+    getPrinterPreview: (state, getters, rootState, rootGetters) => {
         if (!state.server.klippy_connected) return []
 
         const output = []
@@ -215,19 +215,28 @@ export const getters: GetterTree<FarmPrinterState, any> = {
             })
         }
 
-        if (
-            'print_stats' in state.data &&
-            'state' in state.data.print_stats &&
-            state.data.print_stats.state === 'printing' &&
-            getters['getPrintPercent'] > 0
-        ) {
+        if ((state.data?.print_stats?.state ?? '') === 'printing' && getters['getPrintPercent'] > 0) {
+            const hours12Format = rootGetters['gui/getHours12Format'] ?? false
             const eta = new Date(getters.estimated_time_eta)
-            const h = eta.getHours() >= 10 ? eta.getHours() : '0' + eta.getHours()
-            const m = eta.getMinutes() >= 10 ? eta.getMinutes() : '0' + eta.getMinutes()
+
+            const date = new Date(eta)
+            let am = true
+            let h: string | number = date.getHours()
+
+            if (hours12Format && h > 11) am = false
+            if (hours12Format && h > 12) h -= 12
+            if (h < 10) h = '0' + h
+
+            const m = date.getMinutes() >= 10 ? date.getMinutes() : '0' + date.getMinutes()
+
+            const diff = date.getTime() - new Date().getTime()
+            let outputOutput = h + ':' + m
+            if (hours12Format) outputOutput += ` ${am ? 'AM' : 'PM'}`
+            if (diff > 60 * 60 * 24 * 1000) outputOutput += `+${Math.trunc(diff / (60 * 60 * 24 * 1000))}`
 
             output.push({
                 name: 'ETA',
-                value: getters.estimated_time_eta > 0 ? h + ':' + m : '--',
+                value: getters.estimated_time_eta > 0 ? outputOutput : '--',
                 file: getters.estimated_time_file,
                 filament: getters.estimated_time_filament,
                 slicer: getters.estimated_time_slicer,


### PR DESCRIPTION
## Description

Add the 12-hour time format to the printers overview ETA.

## Related Tickets & Documents

fixes: #1570 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/2aa4e50d-81eb-4171-a415-0c40303a6cbf)

## [optional] Are there any post-deployment tasks we need to perform?

none
