### PR TITLE
refactor: remove unused import in store/printer/getters.ts

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -10,7 +10,6 @@ import {
     PrinterStateMiscellaneous,
     PrinterStateMcu,
     PrinterStateMacro,
-    PrinterStateToolchangeMacro,
     PrinterGetterObject,
     PrinterStateLight,
 } from '@/store/printer/types'


### PR DESCRIPTION
## Description

This PR just remove an unused import in store/printer/getters.ts.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
