### PR TITLE
build(dependabot): add Dependabot to the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,4 @@ updates:
         update-type: 'semver:non-major'
         dependency-type: 'direct'
     assignees:
-      - "meteyou"
+      - 'meteyou'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    ignore:
+    allow:
       # Ignore major updates to all dependencies. We're using old versions of some packages that are incompatible with newer versions of other packages.
       - dependency-name: '*'
-        update-type: 'semver:major'
+        update-type: 'semver:non-major'
+        dependency-type: 'direct'
+    assignees:
+      - "meteyou"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      # Ignore major updates to all dependencies. We're using old versions of some packages that are incompatible with newer versions of other packages.
+      - dependency-name: '*'
+        update-type: 'semver:major'


### PR DESCRIPTION
## Description

This adds https://docs.github.com/en/code-security/dependabot to the repository to easily update packages.
