### PR TITLE
fix: WebRTC (camera-streamer) port with external mainsail instance

### DIFF
--- a/src/components/webcams/WebrtcCameraStreamer.vue
+++ b/src/components/webcams/WebrtcCameraStreamer.vue
@@ -39,7 +39,6 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
     get url() {
         const baseUrl = this.camSettings.stream_url
         let url = new URL(baseUrl, this.printerUrl === null ? this.hostUrl.toString() : this.printerUrl)
-        url.port = this.hostPort.toString()
 
         if (baseUrl.startsWith('http') || baseUrl.startsWith('://')) url = new URL(baseUrl)
 


### PR DESCRIPTION
## Description

This PR fix the printer URL in webcam settings for external access (or also for debug mode).

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none
