### PR TITLE
chore: fix ftp upload in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         run: cp ./remote/* ./dist/
 
       - name: Upload to remote server
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
           server: ${{ secrets.REMOTEHOST }}
           username: ${{ secrets.REMOTEUSER }}


### PR DESCRIPTION
## Description

This PR fixes the release workflow. The version number from the FTP step is needed to use this action.

## Related Tickets & Documents

- failed workflow run: https://github.com/mainsail-crew/mainsail/actions/runs/6442825302

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
