### PR TITLE
ci(docker): ensure that the docker images are tagged correctly

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['master', 'develop']
     tags:
-      - '*'
+      - 'v*'
   pull_request:
     branches:
       - '*'
@@ -39,7 +39,9 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             type=edge,branch=develop
-            type=ref,event=tag
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -39,7 +39,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             type=edge,branch=develop
-            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
       - name: Set up QEMU


### PR DESCRIPTION
## Description

It seems that the recent version haven't been tagged as Docker images correctly. This PR should resolve that.


See: https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver