### PR TITLE
fix: allow null as spool id response from spoolman

### DIFF
--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -47,8 +47,8 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
         commit('setActiveSpoolId', payload.spool_id)
         dispatch('socket/removeInitModule', 'server/spoolman/getActiveSpoolId', { root: true })
 
-        // also set active spool to null, if spool_id is 0
-        if (payload.spool_id === 0) {
+        // also set active spool to null, if spool_id is 0 or null
+        if ([null, 0].includes(payload.spool_id)) {
             commit('setActiveSpool', null)
             return
         }


### PR DESCRIPTION
## Description

The example macro from Spoolman send "None" (with the respond NULL) to eject the spool. Allow this to clear the current spool in Mainsail.

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings

None

## [optional] Are there any post-deployment tasks we need to perform?

None
