### PR TITLE
fix: fix adding multiple presets

### DIFF
--- a/src/store/gui/presets/actions.ts
+++ b/src/store/gui/presets/actions.ts
@@ -31,7 +31,7 @@ export const actions: ActionTree<GuiPresetsState, RootState> = {
     store({ commit, dispatch, state }, payload) {
         const id = uuidv4()
 
-        commit('store', { id, values: payload.values })
+        commit('store', { id, values: { ...payload.values } })
         dispatch('upload', {
             id,
             value: state.presets[id],


### PR DESCRIPTION
## Description

This PR fix an issue, when you add multiple presets without a refresh.

## Related Tickets & Documents

maybe this PR will fix #1622 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
