### PR TITLE
fix: fix round issue in git commit list diff calculation

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
@@ -67,7 +67,7 @@ export default class GitCommitsListDayCommit extends Mixins(BaseMixin) {
         commitDay.setHours(0, 0, 0, 0)
         const todayDay = new Date()
         todayDay.setHours(0, 0, 0, 0)
-        const diff = Math.floor(todayDay.getTime() - commitDay.getTime()) / (1000 * 60 * 60 * 24)
+        const diff = Math.floor((todayDay.getTime() - commitDay.getTime()) / (1000 * 60 * 60 * 24))
 
         if (diff === 0) {
             const diffHours = Math.floor((new Date().getTime() - this.commit.date * 1000) / (1000 * 60 * 60))


### PR DESCRIPTION
## Description

This PR fix a round issue in the diff day calculation in the Update Manger Git list.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/136b3b4e-1c38-452d-9283-885dab685cca)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/3967645c-179a-4144-9d36-1723e304463c)

## [optional] Are there any post-deployment tasks we need to perform?

none
