### PR TITLE
refactor: also allow FILAMENT_LOAD and FILAMENT_UNLOAD macros

### DIFF
--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -99,11 +99,15 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
     }
 
     get loadFilamentMacro(): PrinterStateMacro | undefined {
-        return this.macros.find((macro: PrinterStateMacro) => macro.name.toUpperCase() === 'LOAD_FILAMENT')
+        const macros = ['LOAD_FILAMENT', 'FILAMENT_LOAD']
+
+        return this.macros.find((macro: PrinterStateMacro) => macros.includes(macro.name.toUpperCase()))
     }
 
     get unloadFilamentMacro(): PrinterStateMacro | undefined {
-        return this.macros.find((macro: PrinterStateMacro) => macro.name.toUpperCase() === 'UNLOAD_FILAMENT')
+        const macros = ['UNLOAD_FILAMENT', 'FILAMENT_UNLOAD']
+
+        return this.macros.find((macro: PrinterStateMacro) => macros.includes(macro.name.toUpperCase()))
     }
 
     /**


### PR DESCRIPTION
## Description

Also allow `FILAMENT_LOAD` and `FILAMENT_UNLOAD` instead of `LOAD_FILAMENT` and `UNLOAD_FILAMENT` in the extruder panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
