### PR TITLE
fix: fix wrong output in temp chart tooltip

### DIFF
--- a/src/components/charts/TempChart.vue
+++ b/src/components/charts/TempChart.vue
@@ -319,7 +319,7 @@ export default class TempChart extends Mixins(BaseMixin) {
             }
             if (seriesNameTarget in dataset.value) {
                 output += ' / '
-                const value = dataset.value[seriesNameTemperature]
+                const value = dataset.value[seriesNameTarget]
                 output += value !== null ? value.toFixed(1) : '--'
             }
             output += '°C'


### PR DESCRIPTION
## Description

This PR fix the tooltip in the tempchart. Right now, there are only the current temp and no target temp in it.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/fec07f25-d06d-4bb4-a666-788b19571313)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/1c8ba521-13eb-40a2-bedb-c6501ec18880)

## [optional] Are there any post-deployment tasks we need to perform?

none
