### PR TITLE
feat: show filament sensor state even when the sensor is disabled

### DIFF
--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -1,9 +1,3 @@
-<style scoped>
-._filamentRunout-subheader {
-    height: auto;
-}
-</style>
-
 <template>
     <v-container class="px-0 py-2">
         <v-row>
@@ -11,7 +5,7 @@
                 <v-subheader class="_filamentRunout-subheader">
                     <v-icon small class="mr-2">{{ mdiPrinter3dNozzleAlert }}</v-icon>
                     <span>{{ convertName(name) }}</span>
-                    <v-spacer></v-spacer>
+                    <v-spacer />
                     <small :class="'mr-3 ' + statusColor + '--text'">{{ statusText }}</small>
                     <v-icon @click="changeSensor">
                         {{ enabled ? mdiToggleSwitch : mdiToggleSwitchOffOutline }}
@@ -62,3 +56,9 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+._filamentRunout-subheader {
+    height: auto;
+}
+</style>

--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -13,7 +13,6 @@
                     <span>{{ convertName(name) }}</span>
                     <v-spacer></v-spacer>
                     <small :class="'mr-3 ' + statusColor + '--text'">{{ statusText }}</small>
-                    <small v-if="!enabled" :class="'mr-3 ' + statusColor + '--text'">({{ disabledText }})</small>
                     <v-icon @click="changeSensor">
                         {{ enabled ? mdiToggleSwitch : mdiToggleSwitchOffOutline }}
                     </v-icon>
@@ -54,11 +53,6 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
     get statusText() {
         if (this.filament_detected) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Detected')
         else return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Empty')
-    }
-
-    get disabledText() {
-        if (!this.enabled) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Disabled')
-        else return null
     }
 
     changeSensor() {

--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -41,7 +41,8 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
     get statusColor() {
         if (!this.enabled) return 'gray'
         else if (this.filament_detected) return 'success'
-        else return 'danger'
+
+        return 'error'
     }
 
     get statusText() {

--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -42,7 +42,7 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
         if (!this.enabled) return 'gray'
         else if (this.filament_detected) return 'success'
 
-        return 'error'
+        return 'warning'
     }
 
     get statusText() {

--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -13,6 +13,7 @@
                     <span>{{ convertName(name) }}</span>
                     <v-spacer></v-spacer>
                     <small :class="'mr-3 ' + statusColor + '--text'">{{ statusText }}</small>
+                    <small v-if="!enabled" :class="'mr-3 ' + statusColor + '--text'">({{ disabledText }})</small>
                     <v-icon @click="changeSensor">
                         {{ enabled ? mdiToggleSwitch : mdiToggleSwitchOffOutline }}
                     </v-icon>
@@ -51,9 +52,13 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
     }
 
     get statusText() {
-        if (!this.enabled) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Disabled')
-        else if (this.filament_detected) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Detected')
+        if (this.filament_detected) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Detected')
         else return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Empty')
+    }
+
+    get disabledText() {
+        if (!this.enabled) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Disabled')
+        else return null
     }
 
     changeSensor() {

--- a/src/components/inputs/FilamentSensor.vue
+++ b/src/components/inputs/FilamentSensor.vue
@@ -47,7 +47,8 @@ export default class FilamentSensor extends Mixins(BaseMixin) {
 
     get statusText() {
         if (this.filament_detected) return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Detected')
-        else return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Empty')
+
+        return this.$t('Panels.MiscellaneousPanel.RunoutSensor.Empty')
     }
 
     changeSensor() {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -614,7 +614,7 @@
             },
             "RunoutSensor": {
                 "Detected": "erkannt",
-                "Empty": "Leer"
+                "Empty": "leer"
             }
         },
         "PowerControlPanel": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -614,7 +614,6 @@
             },
             "RunoutSensor": {
                 "Detected": "erkannt",
-                "Disabled": "deaktiviert",
                 "Empty": "Leer"
             }
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -614,7 +614,6 @@
             },
             "RunoutSensor": {
                 "Detected": "detected",
-                "Disabled": "disabled",
                 "Empty": "Empty"
             }
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -614,7 +614,7 @@
             },
             "RunoutSensor": {
                 "Detected": "detected",
-                "Empty": "Empty"
+                "Empty": "empty"
             }
         },
         "PowerControlPanel": {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  We use squash-merge to merge PRs, so the commit history is clean, but we use the PR title as the commit message.
  So we recommend you to use the PR title with conventional commits type prefixes. We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Documentation only changes
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can found more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr.
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This PR changes the FilamentSensor view so the filament state (detected or empty) is shown regardless of whether the sensor is enabled or disabled. I added the "disabled" state next to the presence state simply because I'm unaware of an alternative way to show both together, let me know if there is an existing pattern I can re-use here.

I sometimes disable my filament motion sensors but I would still like to see whether the sensor reports motion or not. This can be useful when debugging filament run-out issues, for example when the detection length is too short and the filament sensor keeps triggering but the print is actually going fine.

<!--

## Related Tickets & Documents

Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

![Screenshot from 2023-11-15 16-09-04](https://github.com/mainsail-crew/mainsail/assets/2053039/8c374553-d002-4925-8cee-ecdf071f4b8a)

<!--
## [optional] Are there any post-deployment tasks we need to perform?

 note: PRs with deleted sections will be marked invalid -->
