### PR TITLE
fix: fix ETA 12hour detection if the user use default browser settings

### DIFF
--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -183,11 +183,7 @@ export default class BaseMixin extends Vue {
     }
 
     get hours12Format() {
-        const setting = this.$store.state.gui.general.timeFormat
-        if (setting === '12hours') return true
-        if (setting === null && this.browserLocale === 'en-US') return true
-
-        return false
+        return this.$store.getters['gui/getHours12Format']
     }
 
     formatDate(value: number | Date): string {

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -157,8 +157,9 @@ export const getters: GetterTree<GuiState, any> = {
         const setting = state.general.timeFormat
         if (setting === '12hours') return true
         if (setting === null) {
-            const timestring = new Date().toLocaleTimeString().split(' ')
-            return timestring.includes('AM') || timestring.includes('PM')
+            // create a time string, cut the last 2 chars and check if it contains AM or PM
+            const timeString = new Date().toLocaleString(navigator.language, { timeStyle: 'short' }).slice(-2)
+            if (['AM', 'PM'].includes(timeString)) return true
         }
 
         return false

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -747,7 +747,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
             timeCount++
         }
 
-        if (time && timeCount) return Date.now() + (time / timeCount) * 1000
+        if (time && timeCount) return Math.round(Date.now() + (time / timeCount) * 1000)
 
         return 0
     },


### PR DESCRIPTION
## Description

This PR fix the "fallback" detection for 12-hour format. This generate a wrong ETA time format for countries other than en-US in there browser languages and 12-hour time format.

## Related Tickets & Documents

Discord: https://discord.com/channels/758059413700345988/1174115244671504455/1174115244671504455

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
