### PR TITLE
fix: fix 12-hour time format in ETA output

### DIFF
--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -157,9 +157,7 @@ export const getters: GetterTree<GuiState, any> = {
         const setting = state.general.timeFormat
         if (setting === '12hours') return true
         if (setting === null) {
-            // create a time string, cut the last 2 chars and check if it contains AM or PM
-            const timeString = new Date().toLocaleString(navigator.language, { timeStyle: 'short' }).slice(-2)
-            if (['AM', 'PM'].includes(timeString)) return true
+            return Intl.DateTimeFormat(navigator.language, { hour: 'numeric' }).resolvedOptions().hour12
         }
 
         return false

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -763,6 +763,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
         if (hours12Format && h > 11) am = false
         if (hours12Format && h > 12) h -= 12
+        if (hours12Format && h == 0) h += 12
         if (h < 10) h = '0' + h
 
         const m = date.getMinutes() >= 10 ? date.getMinutes() : '0' + date.getMinutes()


### PR DESCRIPTION
## Description

Fixes time format in ETA output in the status-panel. This should change 00:10 AM to 12:10 AM.

## Related Tickets & Documents

fixes: https://github.com/mainsail-crew/mainsail/issues/1461#issuecomment-1823767052

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
