### PR TITLE
chore: fix check-pr-title workflow to allow locale as type

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -10,10 +10,25 @@ on:
 
 jobs:
   lint:
+    name: Validate PR title
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            perf
+            refactor
+            style
+            locale
+            docs
+            test
+            chore
+            build
+          requireScope: false
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -28,6 +28,8 @@ jobs:
             test
             chore
             build
+            ci
+            revert
           requireScope: false
           ignoreLabels: |
             bot


### PR DESCRIPTION
## Description

This PR change the action and settings for the check-pr-title workflow to allow locale as type.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
