### PR TITLE
feat: add minimum_cruise_ratio support in MotionSettingsPanel

### DIFF
--- a/src/components/panels/MachineSettings/MotionSettings.vue
+++ b/src/components/panels/MachineSettings/MotionSettings.vue
@@ -117,8 +117,12 @@ export default class MotionSettings extends Mixins(BaseMixin) {
         return Math.trunc(this.$store.state.printer?.toolhead?.max_accel_to_decel ?? this.accel / 2)
     }
 
-    get minimumCruiseRatio(): number {
-        return this.$store.state.printer?.toolhead?.minimum_cruise_ratio ?? null
+    get minimumCruiseRatio(): number | null {
+        const value = this.$store.state.printer?.toolhead?.minimum_cruise_ratio ?? null
+
+        if (value === null) return null
+
+        return Math.round(value * 100) / 100
     }
 
     get squareCornerVelocity(): number {

--- a/src/components/panels/MachineSettings/MotionSettings.vue
+++ b/src/components/panels/MachineSettings/MotionSettings.vue
@@ -9,7 +9,7 @@
                 <v-row>
                     <v-col :class="{ 'col-12': el.is.small, 'col-6': el.is.medium }">
                         <number-input
-                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.Velocity').toString()"
+                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.Velocity')"
                             param="VELOCITY"
                             :target="velocity"
                             :default-value="defaultVelocity"
@@ -21,11 +21,11 @@
                             :max="null"
                             :dec="0"
                             unit="mm/s"
-                            @submit="sendCmd"></number-input>
+                            @submit="sendCmd" />
                     </v-col>
                     <v-col :class="{ 'col-12': el.is.small, 'col-6': el.is.medium }">
                         <number-input
-                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.SquareCornerVelocity').toString()"
+                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.SquareCornerVelocity')"
                             param="SQUARE_CORNER_VELOCITY"
                             :target="squareCornerVelocity"
                             :default-value="defaultSquareCornerVelocity"
@@ -36,13 +36,13 @@
                             :max="null"
                             :dec="1"
                             unit="mm/s"
-                            @submit="sendCmd"></number-input>
+                            @submit="sendCmd" />
                     </v-col>
                 </v-row>
                 <v-row>
                     <v-col :class="{ 'col-12': el.is.small, 'col-6': el.is.medium }">
                         <number-input
-                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.Acceleration').toString()"
+                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.Acceleration')"
                             param="ACCEL"
                             :target="accel"
                             :default-value="defaultAccel"
@@ -54,11 +54,12 @@
                             :max="null"
                             :dec="0"
                             unit="mm/s²"
-                            @submit="sendCmd"></number-input>
+                            @submit="sendCmd" />
                     </v-col>
                     <v-col :class="{ 'col-12': el.is.small, 'col-6': el.is.medium }">
                         <number-input
-                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.MaxAccelToDecel').toString()"
+                            v-if="minimumCruiseRatio === null"
+                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.MaxAccelToDecel')"
                             param="ACCEL_TO_DECEL"
                             :target="accelToDecel"
                             :default-value="defaultAccelToDecel"
@@ -70,7 +71,21 @@
                             :max="null"
                             :dec="0"
                             unit="mm/s²"
-                            @submit="sendCmd"></number-input>
+                            @submit="sendCmd" />
+                        <number-input
+                            v-else
+                            :label="$t('Panels.MachineSettingsPanel.MotionSettings.MinimumCruiseRatio')"
+                            param="MINIMUM_CRUISE_RATIO"
+                            :target="minimumCruiseRatio"
+                            :default-value="defaultMinimumCruiseRatio"
+                            :output-error-msg="true"
+                            :has-spinner="true"
+                            :spinner-factor="5"
+                            :step="0.01"
+                            :min="0.01"
+                            :max="0.99"
+                            :dec="2"
+                            @submit="sendCmd" />
                     </v-col>
                 </v-row>
             </template>
@@ -102,6 +117,10 @@ export default class MotionSettings extends Mixins(BaseMixin) {
         return Math.trunc(this.$store.state.printer?.toolhead?.max_accel_to_decel ?? this.accel / 2)
     }
 
+    get minimumCruiseRatio(): number {
+        return this.$store.state.printer?.toolhead?.minimum_cruise_ratio ?? null
+    }
+
     get squareCornerVelocity(): number {
         return Math.floor((this.$store.state.printer?.toolhead?.square_corner_velocity ?? 8) * 10) / 10
     }
@@ -118,11 +137,16 @@ export default class MotionSettings extends Mixins(BaseMixin) {
         return Math.trunc(this.$store.state.printer?.configfile?.settings?.printer?.max_accel_to_decel ?? 1500)
     }
 
+    get defaultMinimumCruiseRatio(): number {
+        const value = this.$store.state.printer?.configfile?.settings?.printer?.minimum_cruise_ratio ?? 0.5
+
+        return Math.round(value / 10) * 10
+    }
+
     get defaultSquareCornerVelocity(): number {
-        return (
-            Math.floor((this.$store.state.printer?.configfile?.settings?.printer?.square_corner_velocity ?? 8) * 10) /
-            10
-        )
+        const value = this.$store.state.printer?.configfile?.settings?.printer?.square_corner_velocity ?? 8
+
+        return Math.floor(value * 10) / 10
     }
 
     @Debounce(500)

--- a/src/components/panels/MachineSettings/MotionSettings.vue
+++ b/src/components/panels/MachineSettings/MotionSettings.vue
@@ -82,7 +82,7 @@
                             :has-spinner="true"
                             :spinner-factor="5"
                             :step="0.01"
-                            :min="0.01"
+                            :min="0.0"
                             :max="0.99"
                             :dec="2"
                             @submit="sendCmd" />

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -582,6 +582,7 @@
             "MotionSettings": {
                 "Acceleration": "Beschleunigung",
                 "MaxAccelToDecel": "Max. Beschl. zu Verz.",
+                "MinimumCruiseRatio": "Min. Kreuzfahr Quote",
                 "SquareCornerVelocity": "Eck-Geschwindigkeit",
                 "Velocity": "Geschwindigkeit"
             }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -582,6 +582,7 @@
             "MotionSettings": {
                 "Acceleration": "Acceleration",
                 "MaxAccelToDecel": "Max Accel. to Decel.",
+                "MinimumCruiseRatio": "Min. Cruise Ratio",
                 "SquareCornerVelocity": "Square Corner Velocity",
                 "Velocity": "Velocity"
             }


### PR DESCRIPTION
## Description

This PR switch from `max_accel_to_decel` to `minimum_cruise_ratio`. The old field will be used as fallback, if no `minimum_cruise_ratio` exists.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/d28fa816-c8f0-496a-b904-4090c840aa83)


## [optional] Are there any post-deployment tasks we need to perform?

Klipper PR for this feature: https://github.com/Klipper3d/klipper/pull/6418
