### PR TITLE
fix: more tolerant with thumbnails sizes

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -1,7 +1,13 @@
 <template>
     <v-dialog v-model="bool" :max-width="400" @click:outside="closeDialog" @keydown.esc="closeDialog">
         <v-card>
-            <v-img v-if="file.big_thumbnail" contain :src="file.big_thumbnail" :style="bigThumbnailStyle" />
+            <div v-if="file.big_thumbnail" class="d-flex align-center justify-center" style="min-height: 200px">
+                <v-img
+                    :src="file.big_thumbnail"
+                    :max-width="maxThumbnailWidth"
+                    class="d-inline-block"
+                    :style="bigThumbnailStyle" />
+            </div>
             <v-card-title class="text-h5">{{ $t('Dialogs.StartPrint.Headline') }}</v-card-title>
             <v-card-text class="pb-0">
                 <p class="body-2">
@@ -106,6 +112,10 @@ export default class StartPrintDialog extends Mixins(BaseMixin) {
             })
 
         return this.$t('Dialogs.StartPrint.DoYouWantToStartFilename', { filename: this.file?.filename ?? 'unknown' })
+    }
+
+    get maxThumbnailWidth() {
+        return this.file?.big_thumbnail_width ?? 400
     }
 
     startPrint(filename = '') {

--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="bool" :max-width="dialogWidth" @click:outside="closeDialog" @keydown.esc="closeDialog">
+    <v-dialog v-model="bool" :max-width="400" @click:outside="closeDialog" @keydown.esc="closeDialog">
         <v-card>
             <v-img v-if="file.big_thumbnail" contain :src="file.big_thumbnail" :style="bigThumbnailStyle" />
             <v-card-title class="text-h5">{{ $t('Dialogs.StartPrint.Headline') }}</v-card-title>
@@ -69,10 +69,6 @@ export default class StartPrintDialog extends Mixins(BaseMixin) {
             { enabled: newVal },
             { action: 'server/timelapse/initSettings' }
         )
-    }
-
-    get dialogWidth() {
-        return this.file.big_thumbnail_width ?? 400
     }
 
     get bigThumbnailBackground() {

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -94,7 +94,7 @@ export const allDashboardPanels = [
 
 export const thumbnailSmallMin = 30
 export const thumbnailSmallMax = 64
-export const thumbnailBigMin = 200
+export const thumbnailBigMin = 128
 
 export const navigationWidth = 220
 export const navigationItemHeight = 48

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -92,9 +92,9 @@ export const allDashboardPanels = [
     'webcam',
 ]
 
-export const thumbnailSmallMin = 32
+export const thumbnailSmallMin = 30
 export const thumbnailSmallMax = 64
-export const thumbnailBigMin = 256
+export const thumbnailBigMin = 200
 
 export const navigationWidth = 220
 export const navigationItemHeight = 48


### PR DESCRIPTION
## Description

Fix a issue with auto generated small thumbnails from Moonraker (some thumbnails only 31px height). Also stretch the large thumbnail in the StartPrintDialog.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
