### PR TITLE
refactor: fix linter issue in SettingsControlTab

### DIFF
--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -178,20 +178,18 @@
                     </settings-row>
                     <v-divider class="my-2" />
                 </template>
-                <template>
-                    <settings-row
-                        :title="$t('Settings.ControlTab.ZOffsetSaveOption')"
-                        :sub-title="$t('Settings.ControlTab.ZOffsetSaveOptionDescription')">
-                        <v-select
-                            v-model="offsetZSaveOption"
-                            :items="offsetZSaveOptions"
-                            class="mt-0"
-                            hide-details
-                            outlined
-                            dense />
-                    </settings-row>
-                    <v-divider class="my-2" />
-                </template>
+                <settings-row
+                    :title="$t('Settings.ControlTab.ZOffsetSaveOption')"
+                    :sub-title="$t('Settings.ControlTab.ZOffsetSaveOptionDescription')">
+                    <v-select
+                        v-model="offsetZSaveOption"
+                        :items="offsetZSaveOptions"
+                        class="mt-0"
+                        hide-details
+                        outlined
+                        dense />
+                </settings-row>
+                <v-divider class="my-2" />
                 <settings-row :title="$t('Settings.ControlTab.ZOffsetIncrements')" :mobile-second-row="true">
                     <v-combobox
                         v-model="offsetsZ"


### PR DESCRIPTION
## Description

This PR only fix a linter issue in the SettingsControlTab.vue

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/bee96e46-6c18-44ad-9bf4-a33b222fa93e)

## [optional] Are there any post-deployment tasks we need to perform?

none
