### PR TITLE
feat: Improve contrast of job queue items count

### DIFF
--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -92,7 +92,7 @@
                 <v-tab v-if="current_filename" href="#status">{{ $t('Panels.StatusPanel.Status') }}</v-tab>
                 <v-tab href="#files">{{ $t('Panels.StatusPanel.Files') }}</v-tab>
                 <v-tab href="#jobqueue">
-                    <v-badge :color="jobQueueBadgeColor" :content="jobsCount.toString()">
+                    <v-badge :color="jobQueueBadgeColor" :content="jobsCount.toString()" :inline="true">
                         {{ $t('Panels.StatusPanel.Jobqueue') }}
                     </v-badge>
                 </v-tab>

--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -92,7 +92,7 @@
                 <v-tab v-if="current_filename" href="#status">{{ $t('Panels.StatusPanel.Status') }}</v-tab>
                 <v-tab href="#files">{{ $t('Panels.StatusPanel.Files') }}</v-tab>
                 <v-tab href="#jobqueue">
-                    <v-badge :color="jobsCount > 0 ? 'blue darken-2' : 'grey darken-2'" :content="jobsCount || '0'">
+                    <v-badge :color="jobQueueBadgeColor" :content="jobsCount.toString()">
                         {{ $t('Panels.StatusPanel.Jobqueue') }}
                     </v-badge>
                 </v-tab>
@@ -177,7 +177,11 @@ export default class StatusPanel extends Mixins(BaseMixin) {
     }
 
     get jobsCount() {
-        return this.$store.getters['server/jobQueue/getJobsCount'] ?? 0
+        return this.jobs.length ?? 0
+    }
+
+    get jobQueueBadgeColor() {
+        return this.jobsCount > 0 ? 'primary darken-2' : 'grey darken-2'
     }
 
     get current_filename() {

--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -91,7 +91,11 @@
             <v-tabs v-model="activeTab" fixed-tabs dark>
                 <v-tab v-if="current_filename" href="#status">{{ $t('Panels.StatusPanel.Status') }}</v-tab>
                 <v-tab href="#files">{{ $t('Panels.StatusPanel.Files') }}</v-tab>
-                <v-tab href="#jobqueue">{{ $t('Panels.StatusPanel.Jobqueue', { count: jobsCount }) }}</v-tab>
+                <v-tab href="#jobqueue">
+                    <v-badge :color="jobsCount > 0 ? 'blue darken-2' : 'grey darken-2'" :content="jobsCount || '0'">
+                        {{ $t('Panels.StatusPanel.Jobqueue') }}
+                    </v-badge>
+                </v-tab>
             </v-tabs>
             <v-divider class="my-0"></v-divider>
             <v-tabs-items v-model="activeTab" class="_border-radius">

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -600,7 +600,7 @@
             "Files": "Soubory",
             "Flow": "Průtok",
             "Headline": "Stav",
-            "Jobqueue": "Seznam úloh ({count})",
+            "Jobqueue": "Seznam úloh",
             "JobqueueMoreFiles": "žádné další úlohy | jedna další úloha | {count} dalších úloh",
             "Layer": "Vrstva",
             "Max": "max",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -668,7 +668,7 @@
             "Files": "Filer",
             "Flow": "Flow",
             "Headline": "Status",
-            "Jobqueue": "Jobkø: ({count})",
+            "Jobqueue": "Jobkø",
             "JobqueueMoreFiles": "Ikke flere jobs | Et job til | {count} jobs tilbage",
             "Layer": "Lag",
             "Max": "maks",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -670,7 +670,7 @@
             "Files": "Dateien",
             "Flow": "Fluss",
             "Headline": "Status",
-            "Jobqueue": "Warteschlange ({count})",
+            "Jobqueue": "Warteschlange",
             "JobqueueMoreFiles": "keine weiteren Aufträge | einen weiteren Auftrag | {count} weitere Aufträge",
             "Layer": "Schicht",
             "Max": "max",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -670,7 +670,7 @@
             "Files": "Files",
             "Flow": "Flow",
             "Headline": "Status",
-            "Jobqueue": "Job Queue ({count})",
+            "Jobqueue": "Job Queue",
             "JobqueueMoreFiles": "no more jobs | one more job | {count} more jobs",
             "Layer": "Layer",
             "Max": "max",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -638,7 +638,7 @@
             "Files": "Archivos",
             "Flow": "Flujo",
             "Headline": "Estado",
-            "Jobqueue": "Cola de trabajo ({count})",
+            "Jobqueue": "Cola de trabajo",
             "JobqueueMoreFiles": "no mas trabajos | un trabajo mas | {count} trabajos mas",
             "Layer": "Capa",
             "Max": "max",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -670,7 +670,7 @@
             "Files": "Fichiers",
             "Flow": "Débit",
             "Headline": "Statut",
-            "Jobqueue": "File d'attente ({count})",
+            "Jobqueue": "File d'attente",
             "JobqueueMoreFiles": "pas de travaux | un travail | {count} travaux",
             "Layer": "Couche",
             "Max": "max",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -543,7 +543,7 @@
             "Files": "Fájlok",
             "Flow": "Anyagáramlás",
             "Headline": "Állapot",
-            "Jobqueue": "Várólista ({count})",
+            "Jobqueue": "Várólista",
             "JobqueueMoreFiles": "Nincs több munka | Még egy munka | {count} munka hátra",
             "Layer": "Réteg",
             "Max": "max",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -668,7 +668,7 @@
             "Files": "Files",
             "Flow": "Flusso",
             "Headline": "Stato",
-            "Jobqueue": "Coda di lavoro ({count})",
+            "Jobqueue": "Coda di lavoro",
             "JobqueueMoreFiles": "niente più lavori | resta un lavoro | restano {count} lavori",
             "Layer": "Layer",
             "Max": "max",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -600,7 +600,7 @@
             "Files": "ファイル",
             "Flow": "フロー",
             "Headline": "状態",
-            "Jobqueue": "ジョブキュー ({count})",
+            "Jobqueue": "ジョブキュー",
             "JobqueueMoreFiles": "ジョブなし | あとひとつのジョブ | あと {count}個のジョブ",
             "Layer": "層",
             "Max": "最大",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -601,7 +601,7 @@
             "Files": "파일",
             "Flow": "유량",
             "Headline": "출력 상태",
-            "Jobqueue": "작업 대기열({count})",
+            "Jobqueue": "작업 대기열",
             "JobqueueMoreFiles": "더 이상 작업 없음 | 1개 이상의 작업 | {count}개 이상의 작업",
             "Layer": "레이어",
             "Max": "최대",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -600,7 +600,7 @@
             "Files": "Bestanden",
             "Flow": "Flow",
             "Headline": "Status",
-            "Jobqueue": "Wachtrij ({count})",
+            "Jobqueue": "Wachtrij",
             "JobqueueMoreFiles": "geen jobs meer | nog een job |  {count} jobs",
             "Layer": "Laag",
             "Max": "max",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -668,7 +668,7 @@
             "Files": "Pliki",
             "Flow": "Przepływ",
             "Headline": "Status",
-            "Jobqueue": "W kolejce ({count})",
+            "Jobqueue": "W kolejce",
             "JobqueueMoreFiles": "brak więcej wydruków | jeszcze jeden wydruk | {count} więcej wydruków",
             "Layer": "Warstwa",
             "Max": "Maks.",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -607,7 +607,7 @@
             "Files": "Arquivos",
             "Flow": "Fluxo",
             "Headline": "Status",
-            "Jobqueue": "Fila de trabalhos ({count})",
+            "Jobqueue": "Fila de trabalhos",
             "JobqueueMoreFiles": "nenhum trabalho | mais um trabalho | {count} mais trabalhos",
             "Layer": "Camada",
             "Max": "max",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -607,7 +607,7 @@
             "Files": "Файлы",
             "Flow": "Поток",
             "Headline": "Статус",
-            "Jobqueue": "Очередь ({count})",
+            "Jobqueue": "Очередь",
             "JobqueueMoreFiles": "Нет больше задач | Еще одна задача | Еще {count} задач(и)",
             "Layer": "Слой",
             "Max": "макс.",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -639,7 +639,7 @@
             "Files": "Dosyalar",
             "Flow": "Akış",
             "Headline": "Durum",
-            "Jobqueue": "İş Kuyruğu ({count})",
+            "Jobqueue": "İş Kuyruğu",
             "JobqueueMoreFiles": "daha fazla iş yok | bir iş daha var | {count} iş daha var",
             "Layer": "Katman",
             "Max": "maks.",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -553,7 +553,7 @@
             "Files": "Файли",
             "Flow": "Потік",
             "Headline": "Статус",
-            "Jobqueue": "Черга робіт ({count})",
+            "Jobqueue": "Черга робіт",
             "JobqueueMoreFiles": "більше нема робіт | ще одна робота | {count} більше робіт",
             "Layer": "Шар",
             "Max": "макс",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -668,7 +668,7 @@
             "Files": "文件",
             "Flow": "流量",
             "Headline": "状态",
-            "Jobqueue": "任务队列({count})",
+            "Jobqueue": "任务队列",
             "JobqueueMoreFiles": "没有任务 | 一个任务 | {count}个任务",
             "Layer": "打印层",
             "Max": "最高",

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -579,7 +579,7 @@
             "Files": "檔案",
             "Flow": "流量",
             "Headline": "狀態",
-            "Jobqueue": "任務隊列({count})",
+            "Jobqueue": "任務隊列",
             "JobqueueMoreFiles": "沒有任務 | 一個任務 | {count}個任務",
             "Layer": "層",
             "Max": "最高",


### PR DESCRIPTION
## Description

Job queue tab has a counter displaying current items count. The counter itself works fine, however it's presented as a gray text, which blends with the background and neighboring text. This quite poor contrast might lead to poor reception of the counter functionality (eg. for me, I usually forget that I've put something in the queue, because the counter is nearly indistinguishable from the tab's label).

To improve the "contrast" (so to speak) of the feature, a simple Badge component can be used instead of text interpolation with the tab's title, allowing it to be displayed slightly different than the neighboring text (the "contrast" improvement comes mainly from the different element being used rather than just color change). This approach also allows it to change its background depending on how many items we've placed in the queue (`gray` for `0`, `blue` for `1+`; `blue` chosen as information color).

This proposal (in a form of a ready made Pull Request) implements this change and cleans up any localisation files from previous interpolation formatting.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings

### Before:

![before_empty_queue](https://github.com/mainsail-crew/mainsail/assets/4425221/ec77ece5-caea-4725-a595-3047f2d20d8e)
![before_populated_queue](https://github.com/mainsail-crew/mainsail/assets/4425221/2a742bd9-1d52-4018-b46a-05c40bb6fa7a)
![before_populated_queue_open](https://github.com/mainsail-crew/mainsail/assets/4425221/9f74d735-0ffa-4a18-b921-67e5b9260faa)

### After:

![after_empty_queue](https://github.com/mainsail-crew/mainsail/assets/4425221/0a88ead4-e66b-4cc3-8c56-01edf8623ff7)
![after_empty_queue_open](https://github.com/mainsail-crew/mainsail/assets/4425221/08a95f4b-bb7a-4a22-bf73-5bc985cd67af)
![after_populated_queue](https://github.com/mainsail-crew/mainsail/assets/4425221/59a5452a-d569-400e-b464-c6a5d2506b8b)
![after_populated_queue_open](https://github.com/mainsail-crew/mainsail/assets/4425221/3b1006a6-47e2-46a6-927e-8d36f2e6b513)


## [optional] Are there any post-deployment tasks we need to perform?

No
