### PR TITLE
feat: add moonraker init component check with warning

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -17,7 +17,9 @@
             },
             "MoonrakerWarnings": {
                 "MoonrakerComponent": "Moonraker: {component}",
-                "MoonrakerFailedComponentDescription": "Beim Laden der Moonraker-Komponenten wurde ein Fehler festgestellt. Bitte prüfe die Logdatei und behebe das Problem.",
+                "MoonrakerInitComponent": "Init. Moonraker: {component}",
+                "MoonrakerFailedComponentDescription": "Beim Laden der Moonraker-Komponente '{component}' wurde ein Fehler festgestellt. Bitte prüfe die Logdatei und behebe das Problem.",
+                "MoonrakerFailedInitComponentDescription": "Beim Initialisieren der Moonraker-Komponente '{component}' wurde ein Fehler festgestellt. Bitte prüfe die Logdatei und behebe das Problem.",
                 "MoonrakerWarning": "Moonraker Warnung",
                 "UnparsedConfigOption": "Nicht erkannte Config-Option '{option}: {value}' in Abschnitt [{section}] entdeckt. Dies kann eine Option sein, die nicht mehr verfügbar ist, oder das Ergebnis eines Moduls sein, das nicht geladen werden konnte. In Zukunft wird dies zu einem Startfehler führen.",
                 "UnparsedConfigSection": "Nicht erkannter Config-Abschnitt [{section}] gefunden. Dies kann das Ergebnis einer Komponente sein, die nicht geladen werden konnte. In Zukunft wird dies zu einem Startfehler führen."

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -17,9 +17,9 @@
             },
             "MoonrakerWarnings": {
                 "MoonrakerComponent": "Moonraker: {component}",
-                "MoonrakerInitComponent": "Init. Moonraker: {component}",
                 "MoonrakerFailedComponentDescription": "Beim Laden der Moonraker-Komponente '{component}' wurde ein Fehler festgestellt. Bitte prüfe die Logdatei und behebe das Problem.",
                 "MoonrakerFailedInitComponentDescription": "Beim Initialisieren der Moonraker-Komponente '{component}' wurde ein Fehler festgestellt. Bitte prüfe die Logdatei und behebe das Problem.",
+                "MoonrakerInitComponent": "Init. Moonraker: {component}",
                 "MoonrakerWarning": "Moonraker Warnung",
                 "UnparsedConfigOption": "Nicht erkannte Config-Option '{option}: {value}' in Abschnitt [{section}] entdeckt. Dies kann eine Option sein, die nicht mehr verfügbar ist, oder das Ergebnis eines Moduls sein, das nicht geladen werden konnte. In Zukunft wird dies zu einem Startfehler führen.",
                 "UnparsedConfigSection": "Nicht erkannter Config-Abschnitt [{section}] gefunden. Dies kann das Ergebnis einer Komponente sein, die nicht geladen werden konnte. In Zukunft wird dies zu einem Startfehler führen."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,9 @@
             },
             "MoonrakerWarnings": {
                 "MoonrakerComponent": "Moonraker: {component}",
+                "MoonrakerInitComponent": "Init. Moonraker: {component}",
                 "MoonrakerFailedComponentDescription": "An error was detected while loading the moonraker component '{component}'. Please check the log file and fix the issue.",
+                "MoonrakerFailedInitComponentDescription": "An error was detected during initialization the moonraker component '{component}'. Please check the log file and fix the issue.",
                 "MoonrakerWarning": "Moonraker warning",
                 "UnparsedConfigOption": "Unparsed config option '{option}: {value}' detected in section [{section}]. This may be an option no longer available or could be the result of a module that failed to load. In the future this will result in a startup error.",
                 "UnparsedConfigSection": "Unparsed config section [{section}] detected. This may be the result of a component that failed to load. In the future this will result in a startup error."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,9 +17,9 @@
             },
             "MoonrakerWarnings": {
                 "MoonrakerComponent": "Moonraker: {component}",
-                "MoonrakerInitComponent": "Init. Moonraker: {component}",
                 "MoonrakerFailedComponentDescription": "An error was detected while loading the moonraker component '{component}'. Please check the log file and fix the issue.",
                 "MoonrakerFailedInitComponentDescription": "An error was detected during initialization the moonraker component '{component}'. Please check the log file and fix the issue.",
+                "MoonrakerInitComponent": "Init. Moonraker: {component}",
                 "MoonrakerWarning": "Moonraker warning",
                 "UnparsedConfigOption": "Unparsed config option '{option}: {value}' detected in section [{section}]. This may be an option no longer available or could be the result of a module that failed to load. In the future this will result in a startup error.",
                 "UnparsedConfigSection": "Unparsed config section [{section}] detected. This may be the result of a component that failed to load. In the future this will result in a startup error."

--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -61,10 +61,21 @@ export class WebSocketClient {
 
             // report error messages
             if (data.error?.message) {
-                if (data.error?.message !== 'Klippy Disconnected')
+                // only report errors, if not disconnected and no init component
+                if (data.error?.message !== 'Klippy Disconnected' && !wait?.action?.startsWith('server/')) {
                     window.console.error(`Response Error: ${data.error.message} (${wait?.action ?? 'no action'})`)
+                }
 
-                if (wait?.id) this.removeWaitById(wait.id)
+                if (wait?.id) {
+                    if (wait.action?.startsWith('server/')) {
+                        const component = wait.action.replace('server/', '').split('/')[0]
+                        window.console.error(`init server component ${component} failed`)
+                        this.store?.dispatch('server/addFailedInitComponent', component)
+                        this.store?.dispatch('socket/removeInitComponent', `server/${component}/`)
+                    }
+
+                    this.removeWaitById(wait.id)
+                }
 
                 return
             }

--- a/src/store/gui/notifications/getters.ts
+++ b/src/store/gui/notifications/getters.ts
@@ -28,6 +28,9 @@ export const getters: GetterTree<GuiNotificationState, any> = {
         // moonraker failed components
         notifications = notifications.concat(getters['getNotificationsMoonrakerFailedComponents'])
 
+        // moonraker failed init components
+        notifications = notifications.concat(getters['getNotificationsMoonrakerFailedInitComponents'])
+
         // klipper warnings
         notifications = notifications.concat(getters['getNotificationsKlipperWarnings'])
 
@@ -214,6 +217,44 @@ export const getters: GetterTree<GuiNotificationState, any> = {
                     title: i18n.t('App.Notifications.MoonrakerWarnings.MoonrakerComponent', { component }).toString(),
                     description: i18n
                         .t('App.Notifications.MoonrakerWarnings.MoonrakerFailedComponentDescription', { component })
+                        .toString(),
+                    date,
+                    dismissed: false,
+                } as GuiNotificationStateEntry)
+            })
+        }
+
+        return notifications
+    },
+
+    getNotificationsMoonrakerFailedInitComponents: (state, getters, rootState, rootGetters) => {
+        const notifications: GuiNotificationStateEntry[] = []
+
+        let failedInitCompontents = rootState.server.failed_init_components ?? []
+        if (failedInitCompontents.length) {
+            const date = rootState.server.system_boot_at ?? new Date()
+
+            // get all dismissed failed components and convert it to a string[]
+            const flagDismisses = rootGetters['gui/notifications/getDismissByCategory'](
+                'moonrakerFailedInitComponent'
+            ).map((dismiss: GuiNotificationStateDismissEntry) => {
+                return dismiss.id
+            })
+
+            // filter all dismissed failed init components
+            failedInitCompontents = failedInitCompontents.filter(
+                (component: string) => !flagDismisses.includes(component)
+            )
+
+            failedInitCompontents.forEach((component: string) => {
+                notifications.push({
+                    id: `moonrakerFailedInitComponent/${component}`,
+                    priority: 'high',
+                    title: i18n
+                        .t('App.Notifications.MoonrakerWarnings.MoonrakerInitComponent', { component })
+                        .toString(),
+                    description: i18n
+                        .t('App.Notifications.MoonrakerWarnings.MoonrakerFailedInitComponentDescription', { component })
                         .toString(),
                     date,
                     dismissed: false,

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -292,4 +292,8 @@ export const actions: ActionTree<ServerState, RootState> = {
     serviceStateChanged({ commit }, payload) {
         commit('updateServiceState', payload)
     },
+
+    addFailedInitComponent({ commit }, payload) {
+        commit('addFailedInitComponent', payload)
+    },
 }

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -294,6 +294,7 @@ export const actions: ActionTree<ServerState, RootState> = {
     },
 
     addFailedInitComponent({ commit }, payload) {
+        commit('removeComponent', payload)
         commit('addFailedInitComponent', payload)
     },
 }

--- a/src/store/server/index.ts
+++ b/src/store/server/index.ts
@@ -23,6 +23,7 @@ export const getDefaultState = (): ServerState => {
         klippy_message: '',
         components: [],
         failed_components: [],
+        failed_init_components: [],
         warnings: [],
         registered_directories: [],
         events: [],

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -167,4 +167,14 @@ export const mutations: MutationTree<ServerState> = {
 
         Vue.set(state, 'failed_init_components', failed_init_components)
     },
+
+    removeComponent(state, payload) {
+        const components = state.components
+        const index = components.indexOf(payload)
+
+        if (index === -1) return
+
+        components.splice(index, 1)
+        Vue.set(state, 'components', components)
+    },
 }

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -160,4 +160,11 @@ export const mutations: MutationTree<ServerState> = {
 
         if (state.system_info?.service_state) Vue.set(state.system_info.service_state, name, payload[name])
     },
+
+    addFailedInitComponent(state, payload) {
+        const failed_init_components = state.failed_init_components
+        if (!failed_init_components.includes(payload)) failed_init_components.push(payload)
+
+        Vue.set(state, 'failed_init_components', failed_init_components)
+    },
 }

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -11,6 +11,7 @@ export interface ServerState {
     klippy_message: string
     components: string[]
     failed_components: string[]
+    failed_init_components: string[]
     warnings: string[]
     registered_directories: string[]
     events: ServerStateEvent[]

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -153,8 +153,14 @@ export const actions: ActionTree<SocketState, RootState> = {
         commit('addInitModule', payload)
     },
 
+    // remove only one module from init component like 'server/spoolman/getActiveSpoolId'
     removeInitModule({ commit }, payload: string) {
         commit('removeInitModule', payload)
+    },
+
+    // remove a complete init component like 'server/spoolman'
+    removeInitComponent({ commit }, payload: string) {
+        commit('removeInitComponent', payload)
     },
 
     reportDebug(_, payload) {

--- a/src/store/socket/mutations.ts
+++ b/src/store/socket/mutations.ts
@@ -61,4 +61,22 @@ export const mutations: MutationTree<SocketState> = {
         list.splice(index, 1)
         Vue.set(state, 'initializationList', list)
     },
+
+    removeInitComponent(state, payload) {
+        const list = [...state.initializationList]
+
+        // remove all components witch starts with payload
+        const indexes = list.reduce((acc: number[], item, index) => {
+            if (item.startsWith(payload)) acc.push(index)
+            return acc
+        }, [])
+
+        // stop if no items found
+        if (!indexes.length) return
+
+        // remove all items
+        indexes.forEach((index) => list.splice(index, 1))
+
+        Vue.set(state, 'initializationList', list)
+    },
 }


### PR DESCRIPTION
## Description

This PR adds a check for failed Moonraker components, skip  the Initialization dialog and adds a warning for this component. A typical issue, when you need this feature is, when Moonraker has no connection to spoolman. Then Mainsail has to skip the init process of this module.

## Related Tickets & Documents

fixes: #1633 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/8bd68697-d00e-4185-8db7-d165ff8ea6c4)

## [optional] Are there any post-deployment tasks we need to perform?

none
