### PR TITLE
refactor: remove unused import from printer/getters

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -10,7 +10,6 @@ import {
     PrinterStateMiscellaneous,
     PrinterStateMcu,
     PrinterStateMacro,
-    PrinterStateToolchangeMacro,
     PrinterGetterObject,
     PrinterStateLight,
 } from '@/store/printer/types'


### PR DESCRIPTION
## Description

Just remove a unused import in the printer/getters.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
