### PR TITLE
fix: add random colors, when colorArray is too small

### DIFF
--- a/src/store/printer/tempHistory/actions.ts
+++ b/src/store/printer/tempHistory/actions.ts
@@ -145,6 +145,12 @@ export const actions: ActionTree<PrinterTempHistoryState, RootState> = {
                     if (!color) {
                         color = colorArray[colorNumber]
                         colorNumber++
+
+                        // fallback -> get random color
+                        if (color === undefined) {
+                            // color generator from https://css-tricks.com/snippets/javascript/random-hex-color/
+                            color = '#' + Math.floor(0xffffff * Math.random()).toString(16)
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description

With this PR, Mainsail will generate random colors, if the colorArray is too small.

## Related Tickets & Documents

fixes #1673 

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/36fd6f97-b9ea-4158-94e6-c868b64da8b3)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/31e2c2ab-bce2-4d43-b73c-8662d38b543b)

## [optional] Are there any post-deployment tasks we need to perform?

none
