### PR TITLE
fix: Incorrect sum of rest jobs printing time

### DIFF
--- a/src/components/panels/Status/Jobqueue.vue
+++ b/src/components/panels/Status/Jobqueue.vue
@@ -89,7 +89,7 @@ export default class StatusPanelJobqueue extends Mixins(BaseMixin) {
 
             if (item.metadata?.filament_total) filamentLength += item.metadata?.filament_total * count
             if (item.metadata?.filament_weight_total) filamentWeight += item.metadata?.filament_weight_total * count
-            if (item.metadata?.estimated_time) printTime = item.metadata.estimated_time * count
+            if (item.metadata?.estimated_time) printTime += item.metadata.estimated_time * count
         })
 
         let output = ''


### PR DESCRIPTION
## Description

This PR fixes a bug in the Jobs queue, where the "rest of jobs" does not correctly sum up estimated printing time of the rest files. Instead of summing up all of the rest jobs, it takes into account only the last element of the list.

Bug is caused by a simple omission of addition operator in code.

## Steps to reproduce

1. Place 5 random models into the Queue
    - (so that the next item in the queue will not be displayed directly)
1. Add two more DISTINCT models with different estimated times
    1. One with estimated print time of eg. 5h
    1. One with estimated print time of eg. 1h

#### Expected behavior

- Summed up estimation displays "6h of print time"

#### Actual behavior

- Summed up estimation displays "1h of print time"

#### Notes

- Bug does not occur when adding the same model multiple times, that is, when `combinedIds` internal feature is being used.

## Related Tickets & Documents

N/A (no bug report, this PR is both a report and a fix)

Regression caused by: N/A (this never worked correctly, see [blame](https://github.com/mainsail-crew/mainsail/blame/c904b7ba71144236fe3c6dff9fa82d636a1b9bec/src/components/panels/Status/Jobqueue.vue#L147))

## Mobile & Desktop Screenshots/Recordings

N/A

## [optional] Are there any post-deployment tasks we need to perform?

N/A
