### PR TITLE
fix: fix panels squeezed on mobile when navi is open

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -102,8 +102,10 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
         }
 
         // overwrite padding left for the sidebar
-        if (this.naviDrawer && this.navigationStyle === 'iconsAndText') style.paddingLeft = '220px'
-        if (this.naviDrawer && this.navigationStyle === 'iconsOnly') style.paddingLeft = '56px'
+        if (this.naviDrawer && !this.$vuetify.breakpoint.mdAndDown) {
+            if (this.navigationStyle === 'iconsAndText') style.paddingLeft = '220px'
+            if (this.navigationStyle === 'iconsOnly') style.paddingLeft = '56px'
+        }
 
         return style
     }


### PR DESCRIPTION
## Description

This PR fixes a issue with the naviDrawer on tablet and smaller viewports.

## Related Tickets & Documents

fixes #1596

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/52609813-ae13-4636-84d2-886722b92317)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/82995b94-262b-4ed5-bab5-b5c4acfaf3e4)

## [optional] Are there any post-deployment tasks we need to perform?

none
