### PR TITLE
fix: only display section options which exists in ExtruderPanel

### DIFF
--- a/src/components/mixins/extruder.ts
+++ b/src/components/mixins/extruder.ts
@@ -1,7 +1,12 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
+import { PrinterStateExtruder } from '@/store/printer/types'
 @Component
 export default class ExtruderMixin extends Vue {
+    get extruders(): PrinterStateExtruder[] {
+        return this.$store.getters['printer/getExtruders']
+    }
+
     get activeExtruder(): string {
         return this.$store.state.printer.toolhead?.extruder
     }

--- a/src/components/panels/Extruder/ExtruderPanelSettings.vue
+++ b/src/components/panels/Extruder/ExtruderPanelSettings.vue
@@ -6,7 +6,7 @@
             </v-btn>
         </template>
         <v-list>
-            <v-list-item class="minHeight36">
+            <v-list-item v-if="toolchangeMacros.length" class="minHeight36">
                 <v-checkbox
                     v-model="showTools"
                     class="mt-0"
@@ -27,7 +27,7 @@
                     hide-details
                     :label="$t('Panels.ExtruderControlPanel.PressureAdvance')" />
             </v-list-item>
-            <v-list-item class="minHeight36">
+            <v-list-item v-if="existsFirmwareRetraction" class="minHeight36">
                 <v-checkbox
                     v-model="showFirmwareRetraction"
                     class="mt-0"
@@ -50,8 +50,9 @@ import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { mdiCog } from '@mdi/js'
+import ControlMixin from '@/components/mixins/control'
 @Component
-export default class ExtruderPanelSettings extends Mixins(BaseMixin) {
+export default class ExtruderPanelSettings extends Mixins(BaseMixin, ControlMixin) {
     mdiCog = mdiCog
 
     get showTools(): boolean {

--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -81,7 +81,7 @@
             <extruder-panel-settings />
         </template>
         <!-- TOOL SELECTOR BUTTONS -->
-        <extruder-control-panel-tools v-if="showTools" />
+        <extruder-control-panel-tools v-if="showTools && toolchangeMacros.length" />
         <!-- EXTRUSION FACTOR SLIDER -->
         <template v-if="showExtrusionFactor">
             <v-divider v-if="showTools" />
@@ -108,7 +108,7 @@
 <script lang="ts">
 import { mdiPrinter3dNozzle, mdiDotsVertical } from '@mdi/js'
 import { Component, Mixins } from 'vue-property-decorator'
-import { PrinterStateExtruder, PrinterStateMacro } from '@/store/printer/types'
+import { PrinterStateMacro } from '@/store/printer/types'
 import BaseMixin from '@/components/mixins/base'
 import ControlMixin from '@/components/mixins/control'
 import Panel from '@/components/ui/Panel.vue'
@@ -181,10 +181,6 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
 
     get showFilamentMacros(): boolean {
         return this.loadFilamentMacro !== undefined || this.unloadFilamentMacro !== undefined
-    }
-
-    get extruders(): PrinterStateExtruder[] {
-        return this.$store.getters['printer/getExtruders']
     }
 
     get showTools(): boolean {


### PR DESCRIPTION
## Description

Only display existing options in the extruder panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
