### PR TITLE
fix: fix language switch

### DIFF
--- a/src/components/settings/SettingsGeneralTab.vue
+++ b/src/components/settings/SettingsGeneralTab.vue
@@ -89,7 +89,7 @@ export default class SettingsGeneralTab extends Mixins(BaseMixin, SettingsGenera
         const languages: { text: string; value: string }[] = []
 
         for (const file in locales) {
-            const langKey = file.slice(file.lastIndexOf('.') - 2, file.lastIndexOf('.'))
+            const langKey = file.slice(file.lastIndexOf('/') + 1, file.lastIndexOf('.'))
             const title = await locales[file]()
 
             languages.push({


### PR DESCRIPTION
## Description

This PR fix the language switch for languages with files with more than 2 chars (like zh_TW).

## Related Tickets & Documents

fixes #1700 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
