### PR TITLE
refactor: remove unused icon in SettingsGeneralTab.vue

### DIFF
--- a/src/components/settings/SettingsGeneralTab.vue
+++ b/src/components/settings/SettingsGeneralTab.vue
@@ -61,7 +61,7 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiCloseThick, mdiHelpCircle } from '@mdi/js'
+import { mdiCloseThick } from '@mdi/js'
 import CheckboxList from '@/components/inputs/CheckboxList.vue'
 import SettingsGeneralTabBackupDatabase from '@/components/settings/General/GeneralBackup.vue'
 import SettingsGeneralTabRestoreDatabase from '@/components/settings/General/GeneralRestore.vue'
@@ -79,7 +79,6 @@ import SettingsGeneralDatabase from '@/components/mixins/settingsGeneralDatabase
     },
 })
 export default class SettingsGeneralTab extends Mixins(BaseMixin, SettingsGeneralDatabase) {
-    mdiHelpCircle = mdiHelpCircle
     mdiCloseThick = mdiCloseThick
 
     availableLanguages: { text: string; value: string }[] = []

--- a/src/components/settings/SettingsGeneralTab.vue
+++ b/src/components/settings/SettingsGeneralTab.vue
@@ -61,7 +61,6 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import Panel from '@/components/ui/Panel.vue'
-import { mdiCloseThick } from '@mdi/js'
 import CheckboxList from '@/components/inputs/CheckboxList.vue'
 import SettingsGeneralTabBackupDatabase from '@/components/settings/General/GeneralBackup.vue'
 import SettingsGeneralTabRestoreDatabase from '@/components/settings/General/GeneralRestore.vue'
@@ -79,8 +78,6 @@ import SettingsGeneralDatabase from '@/components/mixins/settingsGeneralDatabase
     },
 })
 export default class SettingsGeneralTab extends Mixins(BaseMixin, SettingsGeneralDatabase) {
-    mdiCloseThick = mdiCloseThick
-
     availableLanguages: { text: string; value: string }[] = []
 
     async created() {


### PR DESCRIPTION
## Description

This PR only remove an unused icon in the SettingsGeneralTab.vue

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
