### PR TITLE
fix(exclude objects): fix tooltip position in object map

### DIFF
--- a/src/components/panels/Status/ExcludeObjectDialogMap.vue
+++ b/src/components/panels/Status/ExcludeObjectDialogMap.vue
@@ -1,32 +1,3 @@
-<style scoped>
-svg {
-    border: 2px solid #888;
-}
-
-#tooltipObjectMap {
-    display: none;
-    position: absolute;
-    background: black;
-    border-radius: 3px;
-    color: white;
-    padding: 3px 7px;
-    z-index: 100;
-
-    &:before {
-        display: block;
-        content: ' ';
-        width: 0;
-        height: 0;
-        position: absolute;
-        bottom: -10px;
-        left: 10px;
-        border-top: 10px solid black;
-        border-left: 10px solid transparent;
-        border-right: 10px solid transparent;
-    }
-}
-</style>
-
 <template>
     <div style="position: relative">
         <div id="tooltipObjectMap" ref="tooltipObjectMap"></div>
@@ -250,3 +221,32 @@ export default class StatusPanelObjectsDialogMap extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+svg {
+    border: 2px solid #888;
+}
+
+#tooltipObjectMap {
+    display: none;
+    position: absolute;
+    background: black;
+    border-radius: 3px;
+    color: white;
+    padding: 3px 7px;
+    z-index: 100;
+
+    &:before {
+        display: block;
+        content: ' ';
+        width: 0;
+        height: 0;
+        position: absolute;
+        bottom: -10px;
+        left: 10px;
+        border-top: 10px solid black;
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+    }
+}
+</style>

--- a/src/components/panels/Status/ExcludeObjectDialogMap.vue
+++ b/src/components/panels/Status/ExcludeObjectDialogMap.vue
@@ -220,27 +220,28 @@ export default class StatusPanelObjectsDialogMap extends Mixins(BaseMixin) {
     }
 
     showObjectTooltip(text: string) {
-        if (this.$refs.tooltipObjectMap) {
-            this.$refs.tooltipObjectMap.innerHTML = text
-            this.$refs.tooltipObjectMap.style.display = 'block'
-        }
+        if (!this.$refs.tooltipObjectMap) return
+
+        this.$refs.tooltipObjectMap.innerHTML = text
+        this.$refs.tooltipObjectMap.style.display = 'block'
 
         window.addEventListener('mousemove', this.moveTooltip)
     }
 
     hideObjectTooltip() {
-        if (this.$refs.tooltipObjectMap) {
-            this.$refs.tooltipObjectMap.style.display = 'none'
-        }
+        if (!this.$refs.tooltipObjectMap) return
+
+        this.$refs.tooltipObjectMap.style.display = 'none'
 
         window.removeEventListener('mousemove', this.moveTooltip)
     }
 
-    moveTooltip(event: any) {
-        if (this.$refs.tooltipObjectMap) {
-            this.$refs.tooltipObjectMap.style.left = event.layerX - 20 + 'px'
-            this.$refs.tooltipObjectMap.style.top = event.layerY - 45 + 'px'
-        }
+    moveTooltip(event: MouseEvent) {
+        if (!this.$refs.tooltipObjectMap) return
+
+        const top = event.offsetY - this.$refs.tooltipObjectMap.clientHeight - 15
+        this.$refs.tooltipObjectMap.style.left = `${event.offsetX - 20}px`
+        this.$refs.tooltipObjectMap.style.top = `${top}px`
     }
 
     openExcludeObjectDialog(name: string) {


### PR DESCRIPTION
## Description

This PR fix the position of the tooltip in the exclude objects map.

## Related Tickets & Documents

fixes #1699 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
