### PR TITLE
fix(temperature panel): hide multiple same temp presets in dropdown 

### DIFF
--- a/src/store/gui/presets/getters.ts
+++ b/src/store/gui/presets/getters.ts
@@ -40,9 +40,10 @@ export const getters: GetterTree<GuiPresetsState, any> = {
             const preset = state.presets[id]
 
             if (
-                payload.name in preset.values &&
-                preset.values[payload.name].bool &&
-                output.findIndex((entry: preset) => entry.value === preset.values[payload.name].value) === -1
+                preset.values[payload.name]?.bool &&
+                output.findIndex(
+                    (entry: preset) => entry.value === parseFloat(preset.values[payload.name]?.value?.toString() ?? '0')
+                ) === -1
             ) {
                 output.push({
                     // @ts-ignore


### PR DESCRIPTION
## Description

This PR fix a parsing issue in the compare of preset temp to list only each temp one time in the heater input dropdown.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
