### PR TITLE
fix: only check initableServerComponents for init moonraker check

### DIFF
--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -1,6 +1,7 @@
 import { Store } from 'vuex'
 import _Vue from 'vue'
 import { RootState } from '@/store/types'
+import { initableServerComponents } from '@/store/variables'
 
 export class WebSocketClient {
     url = ''
@@ -67,7 +68,13 @@ export class WebSocketClient {
                 }
 
                 if (wait?.id) {
-                    if (wait.action?.startsWith('server/')) {
+                    const modulename = wait.action?.split('/')[1] ?? null
+
+                    if (
+                        modulename &&
+                        wait.action?.startsWith('server/') &&
+                        initableServerComponents.includes(modulename)
+                    ) {
                         const component = wait.action.replace('server/', '').split('/')[0]
                         window.console.error(`init server component ${component} failed`)
                         this.store?.dispatch('server/addFailedInitComponent', component)


### PR DESCRIPTION
## Description

Before this PR, all requests with a return action which starts with `server/` could added to "init. Moonraker notification" (check the screenshot below. With this PR, it will be checked, if it is a initable Moonraker module, or another Moonraker/server module.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before this PR:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/45b75ad1-010b-47d8-b7c9-2835a2f4bc5f)

## [optional] Are there any post-deployment tasks we need to perform?

none
