### PR TITLE
fix(console): fix color of autocomplete and command list

### DIFF
--- a/src/components/CommandHelpModal.vue
+++ b/src/components/CommandHelpModal.vue
@@ -54,7 +54,7 @@
                                         two-line>
                                         <v-list-item-content class="px-0">
                                             <v-list-item-title
-                                                class="blue--text font-weight-bold cursor-pointer"
+                                                class="primary--text font-weight-bold cursor-pointer"
                                                 @click="
                                                     $emit('onCommand', cmd.command)
                                                     isOpen = false

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -294,7 +294,7 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
                     commands.forEach(
                         (command) =>
                             (output +=
-                                '<a class="command blue--text font-weight-bold">' +
+                                '<a class="command font-weight-bold">' +
                                 command.command +
                                 '</a>: ' +
                                 command.description +

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -281,7 +281,7 @@ export default class PageConsole extends Mixins(BaseMixin) {
                     commands.forEach(
                         (command) =>
                             (output +=
-                                "<a class='command blue--text'>" +
+                                "<a class='command font-weight-bold'>" +
                                 command.command +
                                 '</a>: ' +
                                 command.description +


### PR DESCRIPTION
## Description

This PR will switch the color of the Command List or Console autocomplete from blue to primary.

## Related Tickets & Documents

fixes: #1730 

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/3ce2b5c8-5c04-4844-9073-151a12ee14e5)
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/ec52b108-1545-4a1b-a74e-818a8b75cd53)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/783a9ddb-3247-494c-984e-2e82a7db61fe)
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/ca3e2f93-30b4-4900-b9e7-81cbc7a47a13)

## [optional] Are there any post-deployment tasks we need to perform?

none
