### PR TITLE
perf: batch gcode file metadata requests

### DIFF
--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -1235,11 +1235,12 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
 
     refreshMetadata(data: FileStateGcodefile[]) {
         const items = data.filter((file) => !file.isDirectory && !file.metadataRequested && !file.metadataPulled)
-        items.forEach((file: FileStateGcodefile) => {
-            this.$store.dispatch('files/requestMetadata', {
+        this.$store.dispatch(
+            'files/requestMetadata',
+            items.map((file: FileStateGcodefile) => ({
                 filename: 'gcodes' + this.currentPath + '/' + file.filename,
-            })
-        })
+            }))
+        )
     }
 
     clickRow(item: FileStateGcodefile, force = false) {

--- a/src/components/panels/Status/Gcodefiles.vue
+++ b/src/components/panels/Status/Gcodefiles.vue
@@ -343,12 +343,12 @@ export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixi
         const requestItems = gcodes.filter(
             (file: FileStateGcodefile) => !file.metadataRequested && !file.metadataPulled
         )
-        requestItems.forEach((file: FileStateGcodefile) => {
-            this.$store.dispatch('files/requestMetadata', {
+        this.$store.dispatch(
+            'files/requestMetadata',
+            requestItems.map((file: FileStateGcodefile) => ({
                 filename: 'gcodes/' + file.filename,
-            })
-        })
-
+            }))
+        )
         return gcodes
     }
 

--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -10,6 +10,7 @@ export class WebSocketClient {
     reconnectInterval = 1000
     reconnects = 0
     keepAliveTimeout = 1000
+    messageId: number = 0
     timerId: number | null = null
     store: Store<RootState> | null = null
     waits: Wait[] = []
@@ -23,6 +24,54 @@ export class WebSocketClient {
 
     setUrl(url: string): void {
         this.url = url
+    }
+
+    handleMessage(data: any) {
+        const wait = this.getWaitById(data.id)
+
+        // report error messages
+        if (data.error?.message) {
+            // only report errors, if not disconnected and no init component
+            if (data.error?.message !== 'Klippy Disconnected' && !wait?.action?.startsWith('server/')) {
+                window.console.error(`Response Error: ${data.error.message} (${wait?.action ?? 'no action'})`)
+            }
+
+            if (wait?.id) {
+                const modulename = wait.action?.split('/')[1] ?? null
+
+                if (modulename && wait.action?.startsWith('server/') && initableServerComponents.includes(modulename)) {
+                    const component = wait.action.replace('server/', '').split('/')[0]
+                    window.console.error(`init server component ${component} failed`)
+                    this.store?.dispatch('server/addFailedInitComponent', component)
+                    this.store?.dispatch('socket/removeInitComponent', `server/${component}/`)
+                }
+
+                this.removeWaitById(wait.id)
+            }
+
+            return
+        }
+
+        // pass it to socket/onMessage, if no wait exists
+        if (!wait) {
+            this.store?.dispatch('socket/onMessage', data)
+            return
+        }
+
+        // pass result to action
+        if (wait?.action) {
+            let result = data.result
+            if (result === 'ok') result = { result: result }
+            if (typeof result === 'string') result = { result: result }
+
+            const preload = {}
+            if (wait.actionPayload) Object.assign(preload, wait.actionPayload)
+            Object.assign(preload, { requestParams: wait.params })
+            Object.assign(preload, result)
+            this.store?.dispatch(wait.action, preload)
+        }
+
+        this.removeWaitById(wait.id)
     }
 
     async connect() {
@@ -58,55 +107,13 @@ export class WebSocketClient {
             if (this.store === null) return
 
             const data = JSON.parse(msg.data)
-            const wait = this.getWaitById(data.id)
-
-            // report error messages
-            if (data.error?.message) {
-                // only report errors, if not disconnected and no init component
-                if (data.error?.message !== 'Klippy Disconnected' && !wait?.action?.startsWith('server/')) {
-                    window.console.error(`Response Error: ${data.error.message} (${wait?.action ?? 'no action'})`)
+            if (Array.isArray(data)) {
+                for (const message of data) {
+                    this.handleMessage(message)
                 }
-
-                if (wait?.id) {
-                    const modulename = wait.action?.split('/')[1] ?? null
-
-                    if (
-                        modulename &&
-                        wait.action?.startsWith('server/') &&
-                        initableServerComponents.includes(modulename)
-                    ) {
-                        const component = wait.action.replace('server/', '').split('/')[0]
-                        window.console.error(`init server component ${component} failed`)
-                        this.store?.dispatch('server/addFailedInitComponent', component)
-                        this.store?.dispatch('socket/removeInitComponent', `server/${component}/`)
-                    }
-
-                    this.removeWaitById(wait.id)
-                }
-
-                return
+            } else {
+                this.handleMessage(data)
             }
-
-            // pass it to socket/onMessage, if no wait exists
-            if (!wait) {
-                this.store?.dispatch('socket/onMessage', data)
-                return
-            }
-
-            // pass result to action
-            if (wait?.action) {
-                let result = data.result
-                if (result === 'ok') result = { result: result }
-                if (typeof result === 'string') result = { result: result }
-
-                const preload = {}
-                if (wait.actionPayload) Object.assign(preload, wait.actionPayload)
-                Object.assign(preload, { requestParams: wait.params })
-                Object.assign(preload, result)
-                this.store?.dispatch(wait.action, preload)
-            }
-
-            this.removeWaitById(wait.id)
         }
     }
 
@@ -130,7 +137,7 @@ export class WebSocketClient {
     emit(method: string, params: Params, options: emitOptions = {}): void {
         if (this.instance?.readyState !== WebSocket.OPEN) return
 
-        const id = Math.floor(Math.random() * 10000) + 1
+        const id = this.messageId++
         this.waits.push({
             id: id,
             params: params,
@@ -149,6 +156,33 @@ export class WebSocketClient {
                 id,
             })
         )
+    }
+
+    emitBatch(messages: BatchMessage[]): void {
+        if (messages.length === 0) return
+        if (this.instance?.readyState !== WebSocket.OPEN) return
+
+        const body = []
+        for (const { method, params, emitOptions = {} } of messages) {
+            const id = this.messageId++
+            this.waits.push({
+                id: id,
+                params: params,
+                action: emitOptions.action ?? null,
+                actionPayload: emitOptions.actionPayload ?? {},
+                loading: emitOptions.loading ?? null,
+            })
+
+            if (emitOptions.loading) this.store?.dispatch('socket/addLoading', { name: emitOptions.loading })
+            body.push({
+                jsonrpc: '2.0',
+                method,
+                params,
+                id,
+            })
+        }
+
+        this.instance.send(JSON.stringify(body))
     }
 }
 
@@ -169,6 +203,13 @@ export interface WebSocketClient {
     connect(): void
     close(): void
     emit(method: string, params: Params, emitOptions: emitOptions): void
+    emitBatch(messages: BatchMessage[]): void
+}
+
+export interface BatchMessage {
+    method: string
+    params: Params
+    emitOptions: emitOptions
 }
 
 export interface Wait {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  We use squash-merge to merge PRs, so the commit history is clean, but we use the PR title as the commit message.
  So we recommend you to use the PR title with conventional commits type prefixes. We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Documentation only changes
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can found more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr.
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

Batch `server.files.metadata` requests to Moonraker, resulting in fewer re-renders of the file table (once per batch, rather than once per file). The performance improvement is especially noticeable with lists of 100+ files.

Moonraker has supported JSON-RPC Batch Requests for [at least 4 years](https://github.com/Arksine/moonraker/blame/96e69240caa3bc6b5a7be93f88ea90a0e8e38035/moonraker/websockets.py#L109), so I don't think backwards incompatibility is a concern.

An alternative approach could be to optimize the GCode Files table itself, which currently re-renders in its entirety when file metadata is updated. However, this approach felt more straightforward (and I'm not super familiar with Vue).

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Before

### After


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Before

https://github.com/mainsail-crew/mainsail/assets/9659564/a6c279bf-5d7f-416a-847a-55fca8b63325

<img width="1840" alt="before" src="https://github.com/mainsail-crew/mainsail/assets/9659564/a87a3b25-1d54-4860-b423-d7b2219c3ea1">

### After

<img width="1840" alt="after" src="https://github.com/mainsail-crew/mainsail/assets/9659564/f502f39f-7469-4f5a-bb1c-c731654510d7">

https://github.com/mainsail-crew/mainsail/assets/9659564/cc1188a9-a1c1-49d9-8cdc-896d4c6d7a65

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
