### PR TITLE
chore: update github issue bot text

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -9,11 +9,9 @@ not an Issue:
       Many helpful people will not see your message here and you are
       unlikely to get a useful response.
 
-      We use the GitHub Issue-Tracker only to handle bug reports,
-      feature requests and planning new releases.
-
-      Please use our Discord-Server or the GitHub Discussion-Forum
-      for help / support:
+      We use the Github Issue-Tracker only for development related
+      topics. Like feature requests, bug reports etc. To get help
+      please us our Discord-Server or Github Discussions:
 
       - [discord.gg/mainsail](https://discord.gg/mainsail)
       - [GitHub Discussions](https://github.com/orgs/mainsail-crew/discussions)

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,6 +1,6 @@
 # Configuration for Label Actions - https://github.com/dessant/label-actions
 
-not on Github:
+not an Issue:
   issues:
     comment: |
       Ahoi!
@@ -9,10 +9,14 @@ not on Github:
       Many helpful people will not see your message here and you are
       unlikely to get a useful response.
 
-      We use github to handle bugreports, feature requests and
-      planning new releases.
+      We use the GitHub Issue-Tracker only to handle bug reports,
+      feature requests and planning new releases.
 
-      Please use our Discord-Server for help: [discord.gg/mainsail](https://discord.gg/mainsail)
+      Please use our Discord-Server or the GitHub Discussion-Forum
+      for help / support:
+
+      - [discord.gg/mainsail](https://discord.gg/mainsail)
+      - [GitHub Discussions](https://github.com/orgs/mainsail-crew/discussions)
 
       This ticket will be automatically closed.
 


### PR DESCRIPTION
## Description

This PR will update the GitHub Issue Tracker bot text for "not on github" to "not an Issue".

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
