### PR TITLE
fix: show extruder extra menu without load/unload_filament macros

### DIFF
--- a/src/components/panels/ExtruderControlPanel.vue
+++ b/src/components/panels/ExtruderControlPanel.vue
@@ -180,7 +180,12 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
     }
 
     get showFilamentMacros(): boolean {
-        return this.loadFilamentMacro !== undefined || this.unloadFilamentMacro !== undefined
+        return (
+            this.loadFilamentMacro !== undefined ||
+            this.unloadFilamentMacro !== undefined ||
+            this.purgeFilamentMacro !== undefined ||
+            this.cleanNozzleMacro !== undefined
+        )
     }
 
     get showTools(): boolean {


### PR DESCRIPTION
## Description

This PR fix a bug in the condition to show the extra menu in the extruder panel. It only check the LOAD/UNLOAD_FILAMENT macro, but doesn't check the PURGE_FILAMENT or CLEAN_NOZZLE macro.

## Related Tickets & Documents

fixes #1744 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
