### PR TITLE
feat: add sum + eta in jobqueue panel

### DIFF
--- a/src/components/panels/JobqueuePanel.vue
+++ b/src/components/panels/JobqueuePanel.vue
@@ -36,12 +36,13 @@
                 <draggable
                     v-model="joblist"
                     handle=".handle"
-                    class="jobqueue-list"
+                    class="jobqueue-list mb-3"
                     ghost-class="ghost"
                     group="jobs"
                     @end="updateOrder">
                     <jobqueue-entry v-for="job in jobs" :key="job.job_id" :job="job" :show-handle="true" />
                 </draggable>
+                <jobqueue-entry-sum :jobs="jobs" />
             </v-col>
         </v-row>
         <v-card-text v-else>
@@ -57,8 +58,9 @@ import Panel from '@/components/ui/Panel.vue'
 import { mdiPlay, mdiPause, mdiTrayFull } from '@mdi/js'
 import JobqueueEntry from '@/components/panels/Status/JobqueueEntry.vue'
 import draggable from 'vuedraggable'
+import JobqueueEntrySum from '@/components/panels/Status/JobqueueEntrySum.vue'
 @Component({
-    components: { draggable, JobqueueEntry, Panel },
+    components: { JobqueueEntrySum, draggable, JobqueueEntry, Panel },
 })
 export default class JobqueuePanel extends Mixins(BaseMixin) {
     mdiPlay = mdiPlay

--- a/src/components/panels/JobqueuePanel.vue
+++ b/src/components/panels/JobqueuePanel.vue
@@ -93,11 +93,15 @@ export default class JobqueuePanel extends Mixins(BaseMixin) {
 </script>
 
 <style lang="scss">
-.jobqueue-list > div + div {
+.jobqueue-list > .jobqueue-list-entry + .jobqueue-list-entry {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .jobqueue-list > div.ghost {
     background-color: rgba(255, 255, 255, 0.12);
+}
+
+.theme--light .jobqueue-list > .jobqueue-list-entry + .jobqueue-list-entry {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/src/components/panels/Status/Jobqueue.vue
+++ b/src/components/panels/Status/Jobqueue.vue
@@ -51,7 +51,11 @@ export default class StatusPanelJobqueue extends Mixins(BaseMixin) {
 </script>
 
 <style scoped>
-.jobqueue-list > div + div {
+.jobqueue-list .jobqueue-list-entry + .jobqueue-list-entry {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.theme--light .jobqueue-list > .jobqueue-list-entry + .jobqueue-list-entry {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/src/components/panels/Status/JobqueueEntry.vue
+++ b/src/components/panels/Status/JobqueueEntry.vue
@@ -1,7 +1,7 @@
 <template>
     <v-row
         v-longpress:600="(e) => openContextMenu(e)"
-        class="d-flex flex-row flex-nowrap cursor-pointer"
+        class="jobqueue-list-entry d-flex flex-row flex-nowrap cursor-pointer"
         @contextmenu="openContextMenu($event)">
         <v-col v-if="showHandle" class="col-auto d-flex flex-column justify-center pr-0 py-0">
             <v-icon class="handle">{{ mdiDragVertical }}</v-icon>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -198,7 +198,6 @@
         "EditFile": "Datei bearbeiten",
         "Empty": "Leer",
         "ExtruderTemp": "Extruder Temp.",
-        "Filament": "Filament",
         "FilamentName": "Filament Name",
         "FilamentType": "Filament Typ",
         "FilamentUsage": "Filamentverbrauch",
@@ -390,7 +389,6 @@
         "TotalTime": "Gesamtzeit"
     },
     "JobQueue": {
-        "AllJobs": "Alle Aufträge",
         "Cancel": "abbrechen",
         "ChangeCount": "Anzahl ändern",
         "Count": "Anzahl",
@@ -398,10 +396,10 @@
         "InvalidCountEmpty": "Die Eingabe darf nicht leer sein!",
         "InvalidCountGreaterZero": "Die Eingabe muss größer als 0 sein!",
         "JobQueue": "Auftragswarteschlange",
-        "Jobs": "Aufträge",
         "Pause": "Pause",
         "RemoveFromQueue": "Von Auftragswarteschlange entfernen",
-        "Start": "Start"
+        "Start": "Start",
+        "StartPrint": "Auftrag starten"
     },
     "Machine": {
         "ConfigFilesPanel": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -399,8 +399,7 @@
         "Pause": "Pause",
         "RemoveFromQueue": "Remove from Queue",
         "Start": "Start",
-        "StartPrint": "Start Job",
-        "SumFilesHeadline": "no jobs in queue | one job in queue | {count} jobs in queue"
+        "StartPrint": "Start Job"
     },
     "Machine": {
         "ConfigFilesPanel": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -399,7 +399,8 @@
         "Pause": "Pause",
         "RemoveFromQueue": "Remove from Queue",
         "Start": "Start",
-        "StartPrint": "Start Job"
+        "StartPrint": "Start Job",
+        "SumFilesHeadline": "no jobs in queue | one job in queue | {count} jobs in queue"
     },
     "Machine": {
         "ConfigFilesPanel": {


### PR DESCRIPTION
## Description

This PR add a line on the bottom of the JobQueue panel with a sum of filamen, estimated printtime and an ETA.

## Related Tickets & Documents

fixes #1768 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/332c9d8c-0eb8-420c-9215-50a35b4c8769)

## [optional] Are there any post-deployment tasks we need to perform?

none
