### PR TITLE
fix: file upload rate displays `NaN` instead of an actual value

### DIFF
--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -110,7 +110,7 @@ import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { validGcodeExtensions } from '@/store/variables'
 import Component from 'vue-class-component'
-import axios from 'axios'
+import axios, { AxiosProgressEvent } from 'axios'
 import { formatFilesize } from '@/plugins/helpers'
 import TheTopCornerMenu from '@/components/TheTopCornerMenu.vue'
 import TheSettingsMenu from '@/components/TheSettingsMenu.vue'
@@ -128,10 +128,6 @@ type uploadSnackbar = {
     speed: number
     total: number
     cancelTokenSource: any
-    lastProgress: {
-        time: number
-        loaded: number
-    }
 }
 
 @Component({
@@ -162,10 +158,6 @@ export default class TheTopbar extends Mixins(BaseMixin) {
         speed: 0,
         total: 0,
         cancelTokenSource: null,
-        lastProgress: {
-            time: 0,
-            loaded: 0,
-        },
     }
 
     formatFilesize = formatFilesize
@@ -317,8 +309,6 @@ export default class TheTopbar extends Mixins(BaseMixin) {
         this.uploadSnackbar.status = true
         this.uploadSnackbar.percent = 0
         this.uploadSnackbar.speed = 0
-        this.uploadSnackbar.lastProgress.loaded = 0
-        this.uploadSnackbar.lastProgress.time = 0
 
         formData.append('file', file, filename)
         formData.append('print', 'true')
@@ -329,18 +319,10 @@ export default class TheTopbar extends Mixins(BaseMixin) {
                 .post(this.apiUrl + '/server/files/upload', formData, {
                     cancelToken: this.uploadSnackbar.cancelTokenSource.token,
                     headers: { 'Content-Type': 'multipart/form-data' },
-                    onUploadProgress: (progressEvent: ProgressEvent) => {
-                        this.uploadSnackbar.percent = (progressEvent.loaded * 100) / progressEvent.total
-                        if (this.uploadSnackbar.lastProgress.time) {
-                            const time = progressEvent.timeStamp - this.uploadSnackbar.lastProgress.time
-                            const data = progressEvent.loaded - this.uploadSnackbar.lastProgress.loaded
-
-                            if (time) this.uploadSnackbar.speed = data / (time / 1000)
-                        }
-
-                        this.uploadSnackbar.lastProgress.time = progressEvent.timeStamp
-                        this.uploadSnackbar.lastProgress.loaded = progressEvent.loaded
-                        this.uploadSnackbar.total = progressEvent.total
+                    onUploadProgress: (progressEvent: AxiosProgressEvent) => {
+                        this.uploadSnackbar.percent = (progressEvent.progress ?? 0) * 100
+                        this.uploadSnackbar.speed = progressEvent.rate ?? 0
+                        this.uploadSnackbar.total = progressEvent.total ?? 0
                     },
                 })
                 .then((result) => {

--- a/src/components/gcodeviewer/Viewer.vue
+++ b/src/components/gcodeviewer/Viewer.vue
@@ -277,7 +277,7 @@
 import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import GCodeViewer from '@sindarius/gcodeviewer'
-import axios from 'axios'
+import axios, { AxiosProgressEvent } from 'axios'
 import { formatFilesize } from '@/plugins/helpers'
 import Panel from '@/components/ui/Panel.vue'
 import CodeStream from '@/components/gcodeviewer/CodeStream.vue'
@@ -304,10 +304,6 @@ interface downloadSnackbar {
     speed: number
     total: number
     cancelTokenSource: any
-    lastProgress: {
-        time: number
-        loaded: number
-    }
 }
 
 let viewer: any = null
@@ -357,10 +353,6 @@ export default class Viewer extends Mixins(BaseMixin) {
         speed: 0,
         total: 0,
         cancelTokenSource: {},
-        lastProgress: {
-            time: 0,
-            loaded: 0,
-        },
     }
 
     private excludeObject = {
@@ -634,7 +626,6 @@ export default class Viewer extends Mixins(BaseMixin) {
     async loadFile(filename: string) {
         this.downloadSnackbar.status = true
         this.downloadSnackbar.speed = 0
-        this.downloadSnackbar.lastProgress.time = 0
         this.downloadSnackbar.filename = filename.startsWith('gcodes/') ? filename.slice(7) : filename
         const CancelToken = axios.CancelToken
         this.downloadSnackbar.cancelTokenSource = CancelToken.source()
@@ -642,20 +633,10 @@ export default class Viewer extends Mixins(BaseMixin) {
             .get(this.apiUrl + '/server/files/' + encodeURI(filename), {
                 cancelToken: this.downloadSnackbar.cancelTokenSource.token,
                 responseType: 'blob',
-                onDownloadProgress: (progressEvent) => {
-                    this.downloadSnackbar.percent = (progressEvent.loaded * 100) / progressEvent.total
-                    if (this.downloadSnackbar.lastProgress.time) {
-                        const time = progressEvent.timeStamp - this.downloadSnackbar.lastProgress.time
-                        const data = progressEvent.loaded - this.downloadSnackbar.lastProgress.loaded
-
-                        if (time > 1000 || this.downloadSnackbar.speed === 0) {
-                            this.downloadSnackbar.speed = data / (time / 1000)
-                            this.downloadSnackbar.lastProgress.time = progressEvent.timeStamp
-                            this.downloadSnackbar.lastProgress.loaded = progressEvent.loaded
-                        }
-                    } else this.downloadSnackbar.lastProgress.time = progressEvent.timeStamp
-
-                    this.downloadSnackbar.total = progressEvent.total
+                onDownloadProgress: (progressEvent: AxiosProgressEvent) => {
+                    this.downloadSnackbar.percent = (progressEvent.progress ?? 0) * 100
+                    this.downloadSnackbar.speed = progressEvent.rate ?? 0
+                    this.downloadSnackbar.total = progressEvent.total ?? 0
                 },
             })
             .then((res) => res.data.text())

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -601,10 +601,6 @@ interface uploadSnackbar {
     number: number
     max: number
     cancelTokenSource: any
-    lastProgress: {
-        time: number
-        loaded: number
-    }
 }
 
 interface draggingFile {
@@ -719,10 +715,6 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
         number: 0,
         max: 0,
         cancelTokenSource: {},
-        lastProgress: {
-            time: 0,
-            loaded: 0,
-        },
     }
     private draggingFile: draggingFile = {
         item: {


### PR DESCRIPTION
## Description

This PR fixes incorrect upload (and download in GCode viewer, although barely noticeable) rate being displayed as `NaN`, instead of an actual value.

Problem is caused by an incorrectly used `progressEvent` argument of Axios'es `onUploadProgress` callback, which exposes its own event object wrapper, instead the raw browser event (as I think someone has assumed, or maybe was the case in the past). Now, with Axios 1.x being used, `onUploadProgress` callback exposes `AxiosProgressEvent`-typed interface (this PR also corrects typings usage, instead of the nasty implicit `any`).

[`AxiosProgressEvent` "documentation"](https://github.com/axios/axios/blob/v1.6.0/index.d.ts#L287-L297) for reference (typings, their official documentation does not seem to describe the relevant interface).

Problem occurs on Firefox & Chromium based browsers.

Problem has been fixed for:
- File explorer upload
- "Upload & Print" topnav functionality
- GCode viewer ("Current file" download snackbar)

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings

_Note: upload artificially slowed down for testing purposes_

### Before

![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/5d022426-8ec0-4bf7-abc3-0894a37a9fc5)

### After

![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/6f8ec4c9-ebe5-4be6-a56a-8e9cedfe32fd)