### PR TITLE
feat: add ability to add history items to job queue

### DIFF
--- a/src/components/dialogs/AddBatchToQueueDialog.vue
+++ b/src/components/dialogs/AddBatchToQueueDialog.vue
@@ -67,6 +67,7 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
      * Should there be a toast message after the file was added to the queue?
      */
     @Prop({ type: Boolean, default: false }) declare readonly showToast: boolean
+
     /**
      * Filename of the model to be added to the Queue.
      */

--- a/src/components/dialogs/AddBatchToQueueDialog.vue
+++ b/src/components/dialogs/AddBatchToQueueDialog.vue
@@ -74,7 +74,8 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
     @Prop({ type: String, required: true }) declare readonly filename: string
 
     isValid = false
-    input: number = 1
+    // because of the text field, the input is always a string
+    input: string = '1'
 
     rules = {
         count: [
@@ -84,7 +85,7 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
     }
 
     async addBatchToQueueAction() {
-        const array: string[] = new Array(this.input).fill(this.filename)
+        const array = Array(parseInt(this.input)).fill(this.filename)
 
         await this.$store.dispatch('server/jobQueue/addToQueue', array)
 
@@ -99,7 +100,7 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
     }
 
     resetFormState() {
-        this.input = 1
+        this.input = '1'
     }
 
     @Watch('isVisible')

--- a/src/components/dialogs/AddBatchToQueueDialog.vue
+++ b/src/components/dialogs/AddBatchToQueueDialog.vue
@@ -55,6 +55,10 @@ export interface addBatchToQueueDialogProps {
     filename: string
 }
 
+export interface addBatchToQueueEventData {
+    filename: string
+}
+
 const defaultCount = 1
 
 @Component
@@ -90,7 +94,12 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
 
         await this.$store.dispatch('server/jobQueue/addToQueue', array)
 
+        this.emitAddToQueueEvent({ filename })
         this.closeDialog()
+    }
+
+    emitAddToQueueEvent(eventData: addBatchToQueueEventData) {
+        this.$emit('addToQueue', eventData)
     }
 
     closeDialog() {

--- a/src/components/dialogs/AddBatchToQueueDialog.vue
+++ b/src/components/dialogs/AddBatchToQueueDialog.vue
@@ -1,0 +1,116 @@
+<template>
+    <v-dialog v-model="isVisible" max-width="400" @click:outside="closeDialog" @keydown.esc="closeDialog">
+        <panel
+            :title="$t('Dialogs.AddBatchToQueue.AddToQueue')"
+            card-class="gcode-files-add-to-queue-dialog"
+            :icon="mdiPlaylistPlus"
+            :margin-bottom="false">
+            <template #buttons>
+                <v-btn icon tile @click="closeDialog">
+                    <v-icon>{{ mdiCloseThick }}</v-icon>
+                </v-btn>
+            </template>
+
+            <v-card-text>
+                <v-text-field
+                    ref="inputFieldAddToQueueCount"
+                    v-model="count"
+                    :label="$t('Dialogs.AddBatchToQueue.Count')"
+                    required
+                    hide-spin-buttons
+                    type="number"
+                    :rules="countInputRules"
+                    @keyup.enter="addBatchToQueueAction">
+                    <template #append-outer>
+                        <div class="_spin_button_group">
+                            <v-btn class="mt-n3" icon plain small @click="count++">
+                                <v-icon>{{ mdiChevronUp }}</v-icon>
+                            </v-btn>
+                            <v-btn :disabled="count <= 1" class="mb-n3" icon plain small @click="count--">
+                                <v-icon>{{ mdiChevronDown }}</v-icon>
+                            </v-btn>
+                        </div>
+                    </template>
+                </v-text-field>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn color="" text @click="closeDialog">{{ $t('Dialogs.AddBatchToQueue.Cancel') }}</v-btn>
+                <v-btn color="primary" text @click="addBatchToQueueAction">
+                    {{ $t('Dialogs.AddBatchToQueue.AddToQueue') }}
+                </v-btn>
+            </v-card-actions>
+        </panel>
+    </v-dialog>
+</template>
+
+<script lang="ts">
+import Component from 'vue-class-component'
+import { Mixins, Prop, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import { mdiChevronDown, mdiChevronUp, mdiPlaylistPlus, mdiCloseThick } from '@mdi/js'
+
+export interface addBatchToQueueDialogProps {
+    isVisible: boolean
+    filename: string
+}
+
+const defaultCount = 1
+
+@Component
+export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
+    mdiChevronDown = mdiChevronDown
+    mdiChevronUp = mdiChevronUp
+    mdiPlaylistPlus = mdiPlaylistPlus
+    mdiCloseThick = mdiCloseThick
+
+    /**
+     * Is dialog currently visible?
+     */
+    @Prop({ default: false }) declare readonly isVisible: addBatchToQueueDialogProps['isVisible']
+    /**
+     * Filename of the model to be added to the Queue.
+     */
+    @Prop({ required: true }) declare readonly filename: addBatchToQueueDialogProps['filename']
+
+    private count: number = defaultCount
+
+    private countInputRules = [
+        (value: string) => !!value || this.$t('JobQueue.InvalidCountEmpty'),
+        (value: string) => parseInt(value, 10) > 0 || this.$t('JobQueue.InvalidCountGreaterZero'),
+    ]
+
+    async addBatchToQueueAction() {
+        const filename = this.filename
+
+        const array: string[] = []
+        for (let i = 0; i < this.count; i++) {
+            array.push(filename)
+        }
+
+        await this.$store.dispatch('server/jobQueue/addToQueue', array)
+
+        this.closeDialog()
+    }
+
+    closeDialog() {
+        this.$emit('closeDialog')
+    }
+
+    @Watch('isVisible')
+    isVisibleChanged(newIsVisible: boolean) {
+        if (newIsVisible) {
+            this.count = defaultCount
+        }
+    }
+}
+</script>
+
+<style scoped>
+._spin_button_group {
+    width: 24px;
+    margin-top: -6px;
+    margin-left: -6px;
+    margin-bottom: -6px;
+}
+</style>

--- a/src/components/dialogs/AddBatchToQueueDialog.vue
+++ b/src/components/dialogs/AddBatchToQueueDialog.vue
@@ -11,35 +11,42 @@
                 </v-btn>
             </template>
 
-            <v-card-text>
-                <v-text-field
-                    ref="inputFieldAddToQueueCount"
-                    v-model="count"
-                    :label="$t('Dialogs.AddBatchToQueue.Count')"
-                    required
-                    hide-spin-buttons
-                    type="number"
-                    :rules="countInputRules"
-                    @keyup.enter="addBatchToQueueAction">
-                    <template #append-outer>
-                        <div class="_spin_button_group">
-                            <v-btn class="mt-n3" icon plain small @click="count++">
-                                <v-icon>{{ mdiChevronUp }}</v-icon>
-                            </v-btn>
-                            <v-btn :disabled="count <= 1" class="mb-n3" icon plain small @click="count--">
-                                <v-icon>{{ mdiChevronDown }}</v-icon>
-                            </v-btn>
-                        </div>
-                    </template>
-                </v-text-field>
-            </v-card-text>
-            <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="" text @click="closeDialog">{{ $t('Dialogs.AddBatchToQueue.Cancel') }}</v-btn>
-                <v-btn color="primary" text @click="addBatchToQueueAction">
-                    {{ $t('Dialogs.AddBatchToQueue.AddToQueue') }}
-                </v-btn>
-            </v-card-actions>
+            <v-form v-model="form.isValid" @submit.prevent="addBatchToQueueAction">
+                <v-card-text>
+                    <v-text-field
+                        ref="inputFieldAddToQueueCount"
+                        v-model="form.inputs.count"
+                        :label="$t('Dialogs.AddBatchToQueue.Count')"
+                        required
+                        hide-spin-buttons
+                        type="number"
+                        :rules="rules.count">
+                        <template #append-outer>
+                            <div class="_spin_button_group">
+                                <v-btn class="mt-n3" icon plain small @click="form.inputs.count++">
+                                    <v-icon>{{ mdiChevronUp }}</v-icon>
+                                </v-btn>
+                                <v-btn
+                                    :disabled="form.inputs.count <= 1"
+                                    class="mb-n3"
+                                    icon
+                                    plain
+                                    small
+                                    @click="form.inputs.count--">
+                                    <v-icon>{{ mdiChevronDown }}</v-icon>
+                                </v-btn>
+                            </div>
+                        </template>
+                    </v-text-field>
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn color="" text @click="closeDialog">{{ $t('Dialogs.AddBatchToQueue.Cancel') }}</v-btn>
+                    <v-btn color="primary" text type="submit" :disabled="!form.isValid">
+                        {{ $t('Dialogs.AddBatchToQueue.AddToQueue') }}
+                    </v-btn>
+                </v-card-actions>
+            </v-form>
         </panel>
     </v-dialog>
 </template>
@@ -59,7 +66,23 @@ export interface addBatchToQueueEventData {
     filename: string
 }
 
-const defaultCount = 1
+interface formState {
+    isValid: boolean
+    inputs: {
+        count: number
+    }
+}
+
+const defaultFormInputs: formState['inputs'] = {
+    count: 1,
+}
+
+const defaultFormState: formState = {
+    isValid: false,
+    inputs: {
+        ...defaultFormInputs,
+    },
+}
 
 @Component
 export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
@@ -77,18 +100,20 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
      */
     @Prop({ required: true }) declare readonly filename: addBatchToQueueDialogProps['filename']
 
-    private count: number = defaultCount
+    private form: formState = defaultFormState
 
-    private countInputRules = [
-        (value: string) => !!value || this.$t('JobQueue.InvalidCountEmpty'),
-        (value: string) => parseInt(value, 10) > 0 || this.$t('JobQueue.InvalidCountGreaterZero'),
-    ]
+    private rules = {
+        count: [
+            (value: string) => !!value || this.$t('JobQueue.InvalidCountEmpty'),
+            (value: string) => parseInt(value, 10) > 0 || this.$t('JobQueue.InvalidCountGreaterZero'),
+        ],
+    }
 
     async addBatchToQueueAction() {
         const filename = this.filename
 
         const array: string[] = []
-        for (let i = 0; i < this.count; i++) {
+        for (let i = 0; i < this.form.inputs.count; i++) {
             array.push(filename)
         }
 
@@ -106,10 +131,19 @@ export default class AddBatchToQueueDialog extends Mixins(BaseMixin) {
         this.$emit('closeDialog')
     }
 
+    resetFormState() {
+        this.form = {
+            ...defaultFormState,
+            inputs: {
+                ...defaultFormInputs,
+            },
+        }
+    }
+
     @Watch('isVisible')
     isVisibleChanged(newIsVisible: boolean) {
         if (newIsVisible) {
-            this.count = defaultCount
+            this.resetFormState()
         }
     }
 }

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -1219,8 +1219,11 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     }
 
     openAddBatchToQueueDialog(item: FileStateGcodefile) {
+        let filename = [this.currentPath, item.filename].join('/')
+        if (filename.startsWith('/')) filename = filename.slice(1)
+
         this.dialogAddBatchToQueue.isVisible = true
-        this.dialogAddBatchToQueue.filename = item.filename
+        this.dialogAddBatchToQueue.filename = filename
     }
 
     closeAddBatchToQueueDialog() {
@@ -1484,15 +1487,6 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     }
 }
 </script>
-
-<style scoped>
-._spin_button_group {
-    width: 24px;
-    margin-top: -6px;
-    margin-left: -6px;
-    margin-bottom: -6px;
-}
-</style>
 
 <style>
 /*noinspection CssUnusedSymbol*/

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -571,7 +571,7 @@
         <add-batch-to-queue-dialog
             :is-visible="dialogAddBatchToQueue.isVisible"
             :filename="dialogAddBatchToQueue.filename"
-            @closeDialog="closeAddBatchToQueueDialog" />
+            @close="closeAddBatchToQueueDialog" />
     </div>
 </template>
 
@@ -609,7 +609,7 @@ import {
     mdiContentCopy,
 } from '@mdi/js'
 import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
-import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
+import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 import ControlMixin from '@/components/mixins/control'
 import PathNavigation from '@/components/ui/PathNavigation.vue'
 
@@ -727,7 +727,7 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
         item: { ...this.contextMenu.item },
     }
 
-    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+    dialogAddBatchToQueue: { isVisible: boolean; filename: string } = {
         isVisible: false,
         filename: '',
     }

--- a/src/components/panels/GcodefilesPanel.vue
+++ b/src/components/panels/GcodefilesPanel.vue
@@ -568,53 +568,10 @@
                 </v-card-actions>
             </panel>
         </v-dialog>
-        <v-dialog v-model="dialogAddBatchToQueue.show" max-width="400">
-            <panel
-                :title="$t('Files.AddToQueue')"
-                card-class="gcode-files-add-to-queue-dialog"
-                :icon="mdiPlaylistPlus"
-                :margin-bottom="false">
-                <template #buttons>
-                    <v-btn icon tile @click="dialogAddBatchToQueue.show = false">
-                        <v-icon>{{ mdiCloseThick }}</v-icon>
-                    </v-btn>
-                </template>
-
-                <v-card-text>
-                    <v-text-field
-                        ref="inputFieldAddToQueueCount"
-                        v-model="dialogAddBatchToQueue.count"
-                        :label="$t('Files.Count')"
-                        required
-                        hide-spin-buttons
-                        type="number"
-                        :rules="countInputRules"
-                        @keyup.enter="addBatchToQueueAction">
-                        <template #append-outer>
-                            <div class="_spin_button_group">
-                                <v-btn class="mt-n3" icon plain small @click="dialogAddBatchToQueue.count++">
-                                    <v-icon>{{ mdiChevronUp }}</v-icon>
-                                </v-btn>
-                                <v-btn
-                                    :disabled="dialogAddBatchToQueue.count <= 1"
-                                    class="mb-n3"
-                                    icon
-                                    plain
-                                    small
-                                    @click="dialogAddBatchToQueue.count--">
-                                    <v-icon>{{ mdiChevronDown }}</v-icon>
-                                </v-btn>
-                            </div>
-                        </template>
-                    </v-text-field>
-                </v-card-text>
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn color="" text @click="dialogAddBatchToQueue.show = false">{{ $t('Files.Cancel') }}</v-btn>
-                    <v-btn color="primary" text @click="addBatchToQueueAction">{{ $t('Files.AddToQueue') }}</v-btn>
-                </v-card-actions>
-            </panel>
-        </v-dialog>
+        <add-batch-to-queue-dialog
+            :is-visible="dialogAddBatchToQueue.isVisible"
+            :filename="dialogAddBatchToQueue.filename"
+            @closeDialog="closeAddBatchToQueueDialog" />
     </div>
 </template>
 
@@ -628,8 +585,6 @@ import Panel from '@/components/ui/Panel.vue'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import draggable from 'vuedraggable'
 import {
-    mdiChevronDown,
-    mdiChevronUp,
     mdiDragVertical,
     mdiCheckboxBlankOutline,
     mdiCheckboxMarked,
@@ -654,6 +609,7 @@ import {
     mdiContentCopy,
 } from '@mdi/js'
 import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
+import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
 import ControlMixin from '@/components/mixins/control'
 import PathNavigation from '@/components/ui/PathNavigation.vue'
 
@@ -675,12 +631,6 @@ interface dialogPrintFile {
     item: FileStateGcodefile
 }
 
-interface dialogAddBatchToQueue {
-    show: boolean
-    count: number
-    item: FileStateGcodefile
-}
-
 interface dialogRenameObject {
     show: boolean
     newName: string
@@ -698,11 +648,9 @@ interface tableColumnSetting {
 }
 
 @Component({
-    components: { StartPrintDialog, Panel, SettingsRow, PathNavigation, draggable },
+    components: { StartPrintDialog, AddBatchToQueueDialog, Panel, SettingsRow, PathNavigation, draggable },
 })
 export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
-    mdiChevronDown = mdiChevronDown
-    mdiChevronUp = mdiChevronUp
     mdiContentCopy = mdiContentCopy
     mdiFile = mdiFile
     mdiFileDocumentMultipleOutline = mdiFileDocumentMultipleOutline
@@ -779,10 +727,9 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
         item: { ...this.contextMenu.item },
     }
 
-    private dialogAddBatchToQueue: dialogAddBatchToQueue = {
-        show: false,
-        count: 1,
-        item: { ...this.contextMenu.item },
+    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+        isVisible: false,
+        filename: '',
     }
 
     private dialogRenameFile: dialogRenameObject = {
@@ -1272,23 +1219,12 @@ export default class GcodefilesPanel extends Mixins(BaseMixin, ControlMixin) {
     }
 
     openAddBatchToQueueDialog(item: FileStateGcodefile) {
-        this.dialogAddBatchToQueue.show = true
-        this.dialogAddBatchToQueue.count = 1
-        this.dialogAddBatchToQueue.item = item
+        this.dialogAddBatchToQueue.isVisible = true
+        this.dialogAddBatchToQueue.filename = item.filename
     }
 
-    async addBatchToQueueAction() {
-        let filename = [this.currentPath, this.dialogAddBatchToQueue.item.filename].join('/')
-        if (filename.startsWith('/')) filename = filename.slice(1)
-
-        const array: string[] = []
-        for (let i = 0; i < this.dialogAddBatchToQueue.count; i++) {
-            array.push(filename)
-        }
-
-        await this.$store.dispatch('server/jobQueue/addToQueue', array)
-
-        this.dialogAddBatchToQueue.show = false
+    closeAddBatchToQueueDialog() {
+        this.dialogAddBatchToQueue.isVisible = false
     }
 
     changeMetadataVisible(name: string, value: boolean) {

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -229,6 +229,12 @@
                     <v-icon class="mr-1">{{ mdiPlaylistPlus }}</v-icon>
                     {{ $t('History.AddToQueue') }}
                 </v-list-item>
+                <v-list-item
+                    v-if="contextMenu.item.exists && isJobQueueAvailable"
+                    @click="openAddBatchToQueueDialog(contextMenu.item)">
+                    <v-icon class="mr-1">{{ mdiPlaylistPlus }}</v-icon>
+                    {{ $t('History.AddBatchToQueue') }}
+                </v-list-item>
                 <v-list-item class="red--text" @click="deleteDialog = true">
                     <v-icon class="mr-1" color="error">{{ mdiDelete }}</v-icon>
                     {{ $t('History.Delete') }}
@@ -499,6 +505,10 @@
                 </v-card-actions>
             </panel>
         </v-dialog>
+        <add-batch-to-queue-dialog
+            :is-visible="dialogAddBatchToQueue.isVisible"
+            :filename="dialogAddBatchToQueue.filename"
+            @closeDialog="closeAddBatchToQueueDialog" />
     </div>
 </template>
 
@@ -527,8 +537,10 @@ import {
     mdiNotebook,
     mdiFileCancel,
 } from '@mdi/js'
+import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
+
 @Component({
-    components: { Panel },
+    components: { Panel, AddBatchToQueueDialog },
 })
 export default class HistoryListPanel extends Mixins(BaseMixin) {
     mdiDatabaseExportOutline = mdiDatabaseExportOutline
@@ -565,6 +577,11 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     private detailsDialog = {
         item: {},
         boolShow: false,
+    }
+
+    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+        isVisible: false,
+        filename: '',
     }
 
     private noteDialog: {
@@ -961,6 +978,15 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
         await this.$store.dispatch('server/jobQueue/addToQueue', [item.filename])
 
         this.$toast.info(this.$t('History.AddToQueueSuccessful', { filename: item.filename }).toString())
+    }
+
+    openAddBatchToQueueDialog(item: ServerHistoryStateJob) {
+        this.dialogAddBatchToQueue.isVisible = true
+        this.dialogAddBatchToQueue.filename = item.filename
+    }
+
+    closeAddBatchToQueueDialog() {
+        this.dialogAddBatchToQueue.isVisible = false
     }
 
     deleteJob() {

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -508,7 +508,8 @@
         <add-batch-to-queue-dialog
             :is-visible="dialogAddBatchToQueue.isVisible"
             :filename="dialogAddBatchToQueue.filename"
-            @closeDialog="closeAddBatchToQueueDialog" />
+            @closeDialog="closeAddBatchToQueueDialog"
+            @addToQueue="showAddBatchToQueueFeedbackToast" />
     </div>
 </template>
 
@@ -537,7 +538,10 @@ import {
     mdiNotebook,
     mdiFileCancel,
 } from '@mdi/js'
-import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
+import AddBatchToQueueDialog, {
+    addBatchToQueueDialogProps,
+    addBatchToQueueEventData,
+} from '@/components/dialogs/AddBatchToQueueDialog.vue'
 
 @Component({
     components: { Panel, AddBatchToQueueDialog },
@@ -983,6 +987,10 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     openAddBatchToQueueDialog(item: ServerHistoryStateJob) {
         this.dialogAddBatchToQueue.isVisible = true
         this.dialogAddBatchToQueue.filename = item.filename
+    }
+
+    showAddBatchToQueueFeedbackToast(eventData: addBatchToQueueEventData) {
+        this.$toast.info(this.$t('History.AddToQueueSuccessful', { filename: eventData.filename }).toString())
     }
 
     closeAddBatchToQueueDialog() {

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -227,13 +227,13 @@
                     v-if="contextMenu.item.exists && isJobQueueAvailable"
                     @click="addToQueue(contextMenu.item)">
                     <v-icon class="mr-1">{{ mdiPlaylistPlus }}</v-icon>
-                    {{ $t('History.AddToQueue') }}
+                    {{ $t('Files.AddToQueue') }}
                 </v-list-item>
                 <v-list-item
                     v-if="contextMenu.item.exists && isJobQueueAvailable"
                     @click="openAddBatchToQueueDialog(contextMenu.item)">
                     <v-icon class="mr-1">{{ mdiPlaylistPlus }}</v-icon>
-                    {{ $t('History.AddBatchToQueue') }}
+                    {{ $t('Files.AddBatchToQueue') }}
                 </v-list-item>
                 <v-list-item class="red--text" @click="deleteDialog = true">
                     <v-icon class="mr-1" color="error">{{ mdiDelete }}</v-icon>
@@ -507,9 +507,9 @@
         </v-dialog>
         <add-batch-to-queue-dialog
             :is-visible="dialogAddBatchToQueue.isVisible"
+            :show-toast="true"
             :filename="dialogAddBatchToQueue.filename"
-            @closeDialog="closeAddBatchToQueueDialog"
-            @addToQueue="showAddBatchToQueueFeedbackToast" />
+            @close="closeAddBatchToQueueDialog" />
     </div>
 </template>
 
@@ -538,10 +538,7 @@ import {
     mdiNotebook,
     mdiFileCancel,
 } from '@mdi/js'
-import AddBatchToQueueDialog, {
-    addBatchToQueueDialogProps,
-    addBatchToQueueEventData,
-} from '@/components/dialogs/AddBatchToQueueDialog.vue'
+import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 
 @Component({
     components: { Panel, AddBatchToQueueDialog },
@@ -583,7 +580,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
         boolShow: false,
     }
 
-    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+    dialogAddBatchToQueue: { isVisible: boolean; filename: string } = {
         isVisible: false,
         filename: '',
     }
@@ -975,26 +972,14 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     }
 
     async addToQueue(item: ServerHistoryStateJob) {
-        if (!item.exists || !this.isJobQueueAvailable) {
-            return
-        }
-
         await this.$store.dispatch('server/jobQueue/addToQueue', [item.filename])
 
         this.$toast.info(this.$t('History.AddToQueueSuccessful', { filename: item.filename }).toString())
     }
 
     openAddBatchToQueueDialog(item: ServerHistoryStateJob) {
-        if (!item.exists || !this.isJobQueueAvailable) {
-            return
-        }
-
         this.dialogAddBatchToQueue.isVisible = true
         this.dialogAddBatchToQueue.filename = item.filename
-    }
-
-    showAddBatchToQueueFeedbackToast(eventData: addBatchToQueueEventData) {
-        this.$toast.info(this.$t('History.AddToQueueSuccessful', { filename: eventData.filename }).toString())
     }
 
     closeAddBatchToQueueDialog() {

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -985,6 +985,10 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     }
 
     openAddBatchToQueueDialog(item: ServerHistoryStateJob) {
+        if (!item.exists || !this.isJobQueueAvailable) {
+            return
+        }
+
         this.dialogAddBatchToQueue.isVisible = true
         this.dialogAddBatchToQueue.filename = item.filename
     }

--- a/src/components/panels/Status/Gcodefiles.vue
+++ b/src/components/panels/Status/Gcodefiles.vue
@@ -173,53 +173,10 @@
             </panel>
         </v-dialog>
 
-        <v-dialog v-model="dialogAddBatchToQueue.show" max-width="400">
-            <panel
-                :title="$t('Files.AddToQueue')"
-                card-class="gcode-files-add-to-queue-dialog"
-                :icon="mdiPlaylistPlus"
-                :margin-bottom="false">
-                <template #buttons>
-                    <v-btn icon tile @click="dialogAddBatchToQueue.show = false">
-                        <v-icon>{{ mdiCloseThick }}</v-icon>
-                    </v-btn>
-                </template>
-
-                <v-card-text>
-                    <v-text-field
-                        ref="inputFieldAddToQueueCount"
-                        v-model="dialogAddBatchToQueue.count"
-                        :label="$t('Files.Count')"
-                        required
-                        hide-spin-buttons
-                        type="number"
-                        :rules="countInputRules"
-                        @keyup.enter="addBatchToQueueAction">
-                        <template #append-outer>
-                            <div class="_spin_button_group">
-                                <v-btn class="mt-n3" icon plain small @click="dialogAddBatchToQueue.count++">
-                                    <v-icon>{{ mdiChevronUp }}</v-icon>
-                                </v-btn>
-                                <v-btn
-                                    :disabled="dialogAddBatchToQueue.count <= 1"
-                                    class="mb-n3"
-                                    icon
-                                    plain
-                                    small
-                                    @click="dialogAddBatchToQueue.count--">
-                                    <v-icon>{{ mdiChevronDown }}</v-icon>
-                                </v-btn>
-                            </div>
-                        </template>
-                    </v-text-field>
-                </v-card-text>
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn color="" text @click="dialogAddBatchToQueue.show = false">{{ $t('Files.Cancel') }}</v-btn>
-                    <v-btn color="primary" text @click="addBatchToQueueAction">{{ $t('Files.AddToQueue') }}</v-btn>
-                </v-card-actions>
-            </panel>
-        </v-dialog>
+        <add-batch-to-queue-dialog
+            :is-visible="dialogAddBatchToQueue.isVisible"
+            :filename="dialogAddBatchToQueue.filename"
+            @closeDialog="closeAddBatchToQueueDialog" />
     </v-card>
 </template>
 
@@ -246,6 +203,7 @@ import {
 } from '@mdi/js'
 import Panel from '@/components/ui/Panel.vue'
 import { defaultBigThumbnailBackground } from '@/store/variables'
+import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
 
 interface dialogRenameObject {
     show: boolean
@@ -253,16 +211,11 @@ interface dialogRenameObject {
     item: FileStateGcodefile
 }
 
-interface dialogAddBatchToQueue {
-    show: boolean
-    count: number
-    item: FileStateGcodefile
-}
-
 @Component({
     components: {
         Panel,
         StartPrintDialog,
+        AddBatchToQueueDialog,
     },
 })
 export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixin) {
@@ -320,10 +273,9 @@ export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixi
         item: { ...this.dialogFile },
     }
 
-    private dialogAddBatchToQueue: dialogAddBatchToQueue = {
-        show: false,
-        count: 1,
-        item: { ...this.contextMenu.item },
+    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+        isVisible: false,
+        filename: '',
     }
 
     private countInputRules = [
@@ -470,23 +422,12 @@ export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixi
     }
 
     openAddBatchToQueueDialog(item: FileStateGcodefile) {
-        this.dialogAddBatchToQueue.show = true
-        this.dialogAddBatchToQueue.count = 1
-        this.dialogAddBatchToQueue.item = item
+        this.dialogAddBatchToQueue.isVisible = true
+        this.dialogAddBatchToQueue.filename = item.filename
     }
 
-    async addBatchToQueueAction() {
-        let filename = [this.currentPath, this.dialogAddBatchToQueue.item.filename].join('/')
-        if (filename.startsWith('/')) filename = filename.slice(1)
-
-        const array: string[] = []
-        for (let i = 0; i < this.dialogAddBatchToQueue.count; i++) {
-            array.push(filename)
-        }
-
-        await this.$store.dispatch('server/jobQueue/addToQueue', array)
-
-        this.dialogAddBatchToQueue.show = false
+    closeAddBatchToQueueDialog() {
+        this.dialogAddBatchToQueue.isVisible = false
     }
 
     view3D(item: FileStateGcodefile) {
@@ -570,12 +511,5 @@ export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixi
 <style scoped>
 .filesGcodeCard {
     position: relative;
-}
-
-._spin_button_group {
-    width: 24px;
-    margin-top: -6px;
-    margin-left: -6px;
-    margin-bottom: -6px;
 }
 </style>

--- a/src/components/panels/Status/Gcodefiles.vue
+++ b/src/components/panels/Status/Gcodefiles.vue
@@ -176,7 +176,7 @@
         <add-batch-to-queue-dialog
             :is-visible="dialogAddBatchToQueue.isVisible"
             :filename="dialogAddBatchToQueue.filename"
-            @closeDialog="closeAddBatchToQueueDialog" />
+            @close="closeAddBatchToQueueDialog" />
     </v-card>
 </template>
 
@@ -188,8 +188,6 @@ import ControlMixin from '@/components/mixins/control'
 import { FileStateGcodefile } from '@/store/files/types'
 import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
 import {
-    mdiChevronDown,
-    mdiChevronUp,
     mdiFile,
     mdiPlay,
     mdiPlaylistPlus,
@@ -203,7 +201,7 @@ import {
 } from '@mdi/js'
 import Panel from '@/components/ui/Panel.vue'
 import { defaultBigThumbnailBackground } from '@/store/variables'
-import AddBatchToQueueDialog, { addBatchToQueueDialogProps } from '@/components/dialogs/AddBatchToQueueDialog.vue'
+import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 
 interface dialogRenameObject {
     show: boolean
@@ -219,8 +217,6 @@ interface dialogRenameObject {
     },
 })
 export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixin) {
-    mdiChevronDown = mdiChevronDown
-    mdiChevronUp = mdiChevronUp
     mdiFile = mdiFile
     mdiPlay = mdiPlay
     mdiPlaylistPlus = mdiPlaylistPlus
@@ -273,7 +269,7 @@ export default class StatusPanelGcodefiles extends Mixins(BaseMixin, ControlMixi
         item: { ...this.dialogFile },
     }
 
-    private dialogAddBatchToQueue: addBatchToQueueDialogProps = {
+    dialogAddBatchToQueue: { isVisible: boolean; filename: string } = {
         isVisible: false,
         filename: '',
     }

--- a/src/components/panels/Status/Jobqueue.vue
+++ b/src/components/panels/Status/Jobqueue.vue
@@ -13,7 +13,9 @@
                 </v-col>
             </v-row>
         </template>
-        <div v-else class="text-center">{{ $t('Panels.StatusPanel.EmptyJobqueue') }}</div>
+        <div v-else>
+            <p class="body-2 my-3 text-center text--disabled">{{ $t('Panels.StatusPanel.EmptyJobqueue') }}</p>
+        </div>
     </v-card>
 </template>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,11 +147,6 @@
         "SetupConsole": "Setup Console"
     },
     "Dialogs": {
-        "AddBatchToQueue": {
-            "AddToQueue": "Add to Queue",
-            "Cancel": "Cancel",
-            "Count": "Count"
-        },
         "StartPrint": {
             "Cancel": "Cancel",
             "DoYouWantToStartFilename": "Do you want to start {filename}?",
@@ -325,9 +320,7 @@
         "Wireframe": "Wireframe"
     },
     "History": {
-        "AddBatchToQueue": "Add batch to Queue",
         "AddNote": "Add note",
-        "AddToQueue": "Add to Queue",
         "AddToQueueSuccessful": "File {filename} added to Queue.",
         "AllJobs": "All",
         "AvgPrinttime": "Print Time - Ø",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -321,6 +321,8 @@
     },
     "History": {
         "AddNote": "Add note",
+        "AddToQueue": "Add to Queue",
+        "AddToQueueSuccessful": "File {filename} added to Queue.",
         "AllJobs": "All",
         "AvgPrinttime": "Print Time - Ø",
         "Cancel": "Cancel",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,6 +147,11 @@
         "SetupConsole": "Setup Console"
     },
     "Dialogs": {
+        "AddBatchToQueue": {
+            "AddToQueue": "Add to Queue",
+            "Cancel": "Cancel",
+            "Count": "Count"
+        },
         "StartPrint": {
             "Cancel": "Cancel",
             "DoYouWantToStartFilename": "Do you want to start {filename}?",
@@ -154,11 +159,6 @@
             "Headline": "Start Job",
             "Print": "print",
             "Timelapse": "Timelapse"
-        },
-        "AddBatchToQueue": {
-            "AddToQueue": "Add to Queue",
-            "Count": "Count",
-            "Cancel": "Cancel"
         }
     },
     "Editor": {
@@ -325,8 +325,8 @@
         "Wireframe": "Wireframe"
     },
     "History": {
-        "AddNote": "Add note",
         "AddBatchToQueue": "Add batch to Queue",
+        "AddNote": "Add note",
         "AddToQueue": "Add to Queue",
         "AddToQueueSuccessful": "File {filename} added to Queue.",
         "AllJobs": "All",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -154,6 +154,11 @@
             "Headline": "Start Job",
             "Print": "print",
             "Timelapse": "Timelapse"
+        },
+        "AddBatchToQueue": {
+            "AddToQueue": "Add to Queue",
+            "Count": "Count",
+            "Cancel": "Cancel"
         }
     },
     "Editor": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -326,6 +326,7 @@
     },
     "History": {
         "AddNote": "Add note",
+        "AddBatchToQueue": "Add batch to Queue",
         "AddToQueue": "Add to Queue",
         "AddToQueueSuccessful": "File {filename} added to Queue.",
         "AllJobs": "All",


### PR DESCRIPTION
## Description

This feature request & PR implements new context menu entry in History view, allowing users to add history entries to Queue. Right now, Mainsail only allows to start reprinting historical items immediately, which in certain cases might not be desired (eg. when user wants to print that file later; user is already printing something but wants to quickly schedule next prints from the History view; user wants to reprint a file, but with a different Spool which has to be changed via Spoolman panel on the Dasboard).

After adding an item to the Queue, a toast is being presented, indicating that something has happened. This was added mostly because adding to queue does not force any screen change (and it shouldn't, as there's no reason to do that, users might want to continue adding other historical entries to the Queue), so there should be some form of feedback.

~This PR adds only the "Add to Queue" menu item.~

This PR:
- adds both "Add to Queue" & "Add batch to Queue" menu items.
- refactors and componentizes "Add batch to Queue" dialog used in File explorer, Status files list & (now) History entries list, making it reusable and self-contained.
- fixes form validation - previously, even though `count` field validation was applied and displayed "on input", it would not prevent users from submitting the form, by either pressing "Enter" key on the field, or clicking on the "Add to Queue" button.

~"Add batch to Queue" is possible, however would require a bit of refactoring (the "Add batch" modal should be refactored into a separate component, to make it reusable and prevent yet another, third I think, implementation to exist). I might take this up as well, but since the basic functionality already works, I believe this can be picked up in the future (in case if I won't be able to pick this up in this PR - let's not stall feature delivery if it's possible to take the iterative approach).~

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings

![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/2ececc1a-4e31-4725-a3bd-16e11420c5fb)
![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/558cd411-bb63-46b6-9217-c5cd58a9209f)

