### PR TITLE
ci: update actions in release workflow to fix node16 deprecates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'develop'
           token: ${{ secrets.PAT }}
@@ -141,7 +141,7 @@ jobs:
       - name: Show CHANGELOG
         run: |
           cat CHANGELOG.md
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'docs(changelog): update changelog'
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Description

This PR fixes some deprecated warnings in the release workflow, but all actions are not available right now to fix all deprecate warnings.

## Related Tickets & Documents

Last run of the release workflow to check the warnings: https://github.com/mainsail-crew/mainsail/actions/runs/7922630451

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
