### PR TITLE
fix(spoolman): break long comments & support multiline comments

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
@@ -134,6 +134,6 @@ export default class SpoolmanChangeSpoolDialogRow extends Mixins(BaseMixin) {
 
 .comment {
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 </style>

--- a/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
@@ -16,7 +16,7 @@
                         </template>
                         <template v-if="spool.comment">
                             <br />
-                            <small>{{ spool.comment }}</small>
+                            <small class="preserveWhitespace">{{ spool.comment }}</small>
                         </template>
                     </v-list-item-title>
                 </v-list-item-content>
@@ -130,5 +130,9 @@ export default class SpoolmanChangeSpoolDialogRow extends Mixins(BaseMixin) {
 
 .no--padding {
     padding: 0;
+}
+
+.preserveWhitespace {
+    white-space: pre-wrap;
 }
 </style>

--- a/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialogRow.vue
@@ -16,7 +16,7 @@
                         </template>
                         <template v-if="spool.comment">
                             <br />
-                            <small class="preserveWhitespace">{{ spool.comment }}</small>
+                            <small class="comment">{{ spool.comment }}</small>
                         </template>
                     </v-list-item-title>
                 </v-list-item-content>
@@ -132,7 +132,8 @@ export default class SpoolmanChangeSpoolDialogRow extends Mixins(BaseMixin) {
     padding: 0;
 }
 
-.preserveWhitespace {
+.comment {
     white-space: pre-wrap;
+    word-break: break-word;
 }
 </style>


### PR DESCRIPTION
## Description

Spoolman allows putting newline characters in the "Comment" field, allowing users to somewhat organize any notes relevant to certain spools (for example, I put the selling vendor name & what was the condition of the spool on arrival).

Currently, Mainsail does not preserve these newline characters, just renders the received comment "as-is" in a plain HTML fashion. This leads to everything being presented in one line, easily overflowing the table & dialog when a lot of notes are added. There's also no line break behavior defined, so even one-liner, long comments cause dialog overflow (see attached screenshot). 

However, `\n` character is nothing special when proper CSS is applied, so this can be easily fixed, which is what this PR does. It should also takes care of long, unbreakable words, which are another case of potential unwanted horizontal overflow.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings

### Before:

![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/70bb59f5-9aee-4846-ab5c-db049e1954cb)

### After:

![obraz](https://github.com/mainsail-crew/mainsail/assets/4425221/00a50c84-5c1b-4cc5-bdc1-1096d0eedb65)



