### PR TITLE
fix: fix commit list view on desktop and mobile devices

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="boolShowDialog" persistent :max-width="800">
+    <v-dialog v-model="boolShowDialog" persistent :max-width="800" :fullscreen="isMobile">
         <panel
             :title="$t('Machine.UpdatePanel.Commits')"
             :icon="mdiUpdate"
@@ -11,8 +11,8 @@
                 </v-btn>
             </template>
             <v-card-text class="py-0 px-0">
-                <overlay-scrollbars style="height: 400px" :options="{ overflowBehavior: { x: 'hidden' } }">
-                    <v-timeline class="groupedCommits" align-top dense style="min-height: 100%">
+                <overlay-scrollbars :style="overlayScrollbarsStyle" :options="{ overflowBehavior: { x: 'hidden' } }">
+                    <v-timeline :class="timelineClassName" align-top dense style="min-height: 100%">
                         <git-commits-list-day
                             v-for="group of groupedCommits"
                             :key="group.date.getTime()"
@@ -106,6 +106,24 @@ export default class GitCommitsList extends Mixins(BaseMixin) {
         return `https://github.com/${this.repo?.owner}/${this.repo?.name}/commits/${this.repo?.branch}/?after=${this.lastCommit?.sha}+0`
     }
 
+    get overlayScrollbarsStyle() {
+        if (this.isMobile) {
+            return {
+                height: 'calc(100vh - 48px)',
+            }
+        }
+
+        return {
+            height: '400px',
+        }
+    }
+
+    get timelineClassName() {
+        if (this.isMobile) return ['groupedCommits', 'mobile']
+
+        return ['groupedCommits']
+    }
+
     closeDialog() {
         this.$emit('close-dialog')
     }
@@ -155,6 +173,20 @@ export default class GitCommitsList extends Mixins(BaseMixin) {
                 margin-top: 10px;
             }
         }
+    }
+}
+
+::v-deep .groupedCommits.mobile {
+    &:before {
+        left: 20px;
+    }
+
+    .v-timeline-item__body {
+        max-width: calc(100% - 41px);
+    }
+
+    .v-timeline-item__divider {
+        min-width: 41px;
     }
 }
 </style>

--- a/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="boolShowDialog" persistent max-width="800">
+    <v-dialog v-model="boolShowDialog" persistent :max-width="800">
         <panel
             :title="$t('Machine.UpdatePanel.Commits')"
             :icon="mdiUpdate"
@@ -11,35 +11,31 @@
                 </v-btn>
             </template>
             <v-card-text class="py-0 px-0">
-                <overlay-scrollbars style="max-height: 400px" :options="{ overflowBehavior: { x: 'hidden' } }">
-                    <v-row>
-                        <v-col>
-                            <v-timeline class="groupedCommits" align-top dense>
-                                <git-commits-list-day
-                                    v-for="group of groupedCommits"
-                                    :key="group.date.getTime()"
-                                    :repo="repo"
-                                    :grouped-commits="group" />
-                                <v-timeline-item
-                                    v-if="displayFullHistoryWaring"
-                                    small
-                                    class="git-commit-list-day git-commit-list-warning">
-                                    <v-row class="pt-0">
-                                        <v-col class="pr-12">
-                                            <v-alert dense text type="info">
-                                                <p>{{ $t('Machine.UpdatePanel.MoreCommitsInfo') }}</p>
-                                                <div class="text-center mb-3">
-                                                    <v-btn :href="linkToGithub" target="_blank">
-                                                        {{ $t('Machine.UpdatePanel.LinkToGithub') }}
-                                                    </v-btn>
-                                                </div>
-                                            </v-alert>
-                                        </v-col>
-                                    </v-row>
-                                </v-timeline-item>
-                            </v-timeline>
-                        </v-col>
-                    </v-row>
+                <overlay-scrollbars style="height: 400px" :options="{ overflowBehavior: { x: 'hidden' } }">
+                    <v-timeline class="groupedCommits" align-top dense style="min-height: 100%">
+                        <git-commits-list-day
+                            v-for="group of groupedCommits"
+                            :key="group.date.getTime()"
+                            :repo="repo"
+                            :grouped-commits="group" />
+                        <v-timeline-item
+                            v-if="displayFullHistoryWaring"
+                            small
+                            class="git-commit-list-day git-commit-list-warning">
+                            <v-row class="pt-0">
+                                <v-col class="pr-12">
+                                    <v-alert dense text type="info">
+                                        <p>{{ $t('Machine.UpdatePanel.MoreCommitsInfo') }}</p>
+                                        <div class="text-center mb-3">
+                                            <v-btn :href="linkToGithub" target="_blank">
+                                                {{ $t('Machine.UpdatePanel.LinkToGithub') }}
+                                            </v-btn>
+                                        </div>
+                                    </v-alert>
+                                </v-col>
+                            </v-row>
+                        </v-timeline-item>
+                    </v-timeline>
                 </overlay-scrollbars>
             </v-card-text>
         </panel>

--- a/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsListDayCommit.vue
@@ -1,6 +1,6 @@
 <template>
     <li class="commit px-3 py-2">
-        <v-row>
+        <v-row class="flex-column flex-sm-row">
             <v-col>
                 <h4 class="subtitle-2 text--white mb-0">
                     {{ title }}
@@ -20,7 +20,7 @@
                     <span>{{ commitFormatDate }}</span>
                 </p>
             </v-col>
-            <v-col class="col-auto pt-4">
+            <v-col class="col-auto pt-0 pt-sm-4">
                 <v-chip outlined label small :href="commitHref" target="_blank">
                     {{ commitShortSha }}
                 </v-chip>


### PR DESCRIPTION
## Description

This PR just fix some UI issues in the commit list in the update manager. It add a min height on desktop devices and switch to fullscreen on mobile devices. on mobile devices i also changed the margin on the left side with the line and also put the hash of the commit at the bottom to have a single col layout inside of the commit.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before on desktop with less entries:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/b8ae48c5-3b85-4be3-a305-1deef63d8f85)

after on desktop with less entries:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/274bd148-7abb-4c30-b067-25980ca35298)

before on mobile with less entries:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/965198f2-080c-4483-aca2-d4ec6e480d77)

after on mobile with less entries:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/e0d40579-4747-485f-aa35-16485f1ebdb6)

after on mobile with more entries:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/afb1d03b-81a5-44d4-891e-fa040ec071b5)

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
