### PR TITLE
fix: fix long M117 outputs in the status panel

### DIFF
--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -59,8 +59,10 @@
                 <v-container>
                     <v-row>
                         <v-col class="py-2">
-                            <span class="subtitle-2 d-block px-0 text--disabled">
-                                <v-icon class="mr-2" color="warning" small>{{ mdiAlertOutline }}</v-icon>
+                            <span class="subtitle-2 px-0 text--disabled">
+                                <v-icon class="mr-2 mt-1 float-left" color="warning" small>
+                                    {{ mdiAlertOutline }}
+                                </v-icon>
                                 {{ print_stats_message }}
                             </span>
                         </v-col>

--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -70,10 +70,10 @@
             </template>
             <template v-if="display_message">
                 <v-container>
-                    <v-row>
-                        <v-col class="py-2">
-                            <span class="subtitle-2 d-block px-0 text--disabled">
-                                <v-icon class="mr-2" small>{{ mdiMessageProcessingOutline }}</v-icon>
+                    <v-row class="flex-nowrap">
+                        <v-col class="py-2" style="min-width: 0">
+                            <span class="subtitle-2 px-0 text--disabled">
+                                <v-icon class="mr-2 mt-1 float-left" small>{{ mdiMessageProcessingOutline }}</v-icon>
                                 {{ display_message }}
                             </span>
                         </v-col>


### PR DESCRIPTION
## Description

This PR fix long M117 outputs in the status panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/32ce8a74-b473-4af8-b397-3d1f89c6bb0f)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/15b1b1f1-dc40-4a9e-ae89-5e00f8eb64a0)


## [optional] Are there any post-deployment tasks we need to perform?

none
