### PR TITLE
fix: hide moonraker backups when "Hide backup files" is enabled

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -843,7 +843,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
 
         if (this.hideBackupFiles) {
             const backupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
-            files = files.filter((file) => !file.filename.match(backupFileMatcher))
+            files = files.filter((file) => !file.filename.match(backupFileMatcher) && !file.filename.endsWith('.bkp'))
         }
 
         return files


### PR DESCRIPTION
## Description

This PR add `*.bkp` files to the `Hide backup files` function in Config Files list.

## Related Tickets & Documents

fixes: #1794

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
