### PR TITLE
feat: add qr search function in the spoolman change spool dialog

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -156,6 +156,11 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
     }
 
     customFilter(value: any, search: string, item: ServerSpoolmanStateSpool): boolean {
+        if (search.trim().startsWith('web+spoolman:s-')) {
+            const spoolId = parseInt(search.trim().substring(15)) ?? -1
+            return item.id === spoolId
+        }
+
         const querySplits = search.toLowerCase().split(' ')
         const searchArray = [
             item.comment,


### PR DESCRIPTION
## Description

This PR adds the support to use the QR-Code content to search the spool in the change spool dialog.

## Related Tickets & Documents

fixes #1801 1756

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/8c0cbb9b-19c3-40e7-9ea4-b4ff1f8d1ed5)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/1f11f82a-8fd7-4527-a291-07b31bdfec07)


## [optional] Are there any post-deployment tasks we need to perform?

none
