### PR TITLE
feat(miscellaneous): add support for pwm_tool and pwm_cycle_time

### DIFF
--- a/src/components/inputs/MiscellaneousSlider.vue
+++ b/src/components/inputs/MiscellaneousSlider.vue
@@ -14,9 +14,9 @@
                     <v-icon v-else-if="type === 'led'" class="mr-2" small :retain-focus-on-click="true" @click="ledOn">
                         {{ mdiLightbulbOutline }}
                     </v-icon>
-                    <v-icon v-else-if="type !== 'output_pin'" small :class="fanClasses">{{ mdiFan }}</v-icon>
+                    <v-icon v-else-if="type.includes('fan')" small :class="fanClasses">{{ mdiFan }}</v-icon>
                     <span>{{ convertName(name) }}</span>
-                    <v-spacer></v-spacer>
+                    <v-spacer />
                     <small v-if="rpm !== null" :class="rpmClasses">{{ Math.round(rpm ?? 0) }} RPM</small>
                     <span v-if="!controllable" class="font-weight-bold">
                         {{ Math.round(parseFloat(value) * 100) }} %
@@ -199,12 +199,11 @@ export default class MiscellaneousSlider extends Mixins(BaseMixin) {
     sendCmd(newVal: number): void {
         if (this.value === newVal) return
 
-        let gcode = ''
+        let gcode = `SET_PIN PIN=${this.name} VALUE=${newVal.toFixed(2)}`
         if (newVal < this.min) newVal = 0
         newVal = newVal * this.multi
         if (this.type === 'fan') gcode = `M106 S${newVal.toFixed(0)}`
         if (this.type === 'fan_generic') gcode = `SET_FAN_SPEED FAN=${this.name} SPEED=${newVal}`
-        if (this.type === 'output_pin') gcode = `SET_PIN PIN=${this.name} VALUE=${newVal.toFixed(2)}`
         if (this.type === 'led')
             gcode = `SET_LED LED=${this.name} ${this.ledChannelName}=${newVal.toFixed(2)} SYNC=0 TRANSMIT=1`
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -289,7 +289,15 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
     getMiscellaneous: (state) => {
         const output: PrinterStateMiscellaneous[] = []
-        const supportedObjects = ['controller_fan', 'heater_fan', 'fan_generic', 'fan', 'output_pin']
+        const supportedObjects = [
+            'controller_fan',
+            'heater_fan',
+            'fan_generic',
+            'fan',
+            'output_pin',
+            'pwm_tool',
+            'pwm_cycle_time',
+        ]
 
         const controllableFans = ['fan_generic', 'fan']
 
@@ -308,10 +316,11 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
                     if (nameSplit[0].toLowerCase() === 'fan') scale = 255
 
-                    if (nameSplit[0].toLowerCase() === 'output_pin') {
+                    if (['output_pin', 'pwm_tool', 'pwm_cycle_time'].includes(nameSplit[0])) {
                         controllable = true
                         pwm = false
                         if ('pwm' in settings) pwm = settings?.pwm ?? false
+                        if (['pwm_tool', 'pwm_cycle_time'].includes(nameSplit[0])) pwm = true
                         if ('scale' in settings) scale = settings?.scale ?? 1
                     }
 


### PR DESCRIPTION
## Description

This PR will add the support from `pwm_tool` and `pwm_cycle_tool`. Both will displayed like a `output_pin`.

## Related Tickets & Documents

PRs in Klipper:
- https://github.com/Klipper3d/klipper/pull/6369

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
