### PR TITLE
refactor(e-stop): remove fullscreen mode on mobile devices

### DIFF
--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -82,7 +82,7 @@
                 </v-btn>
             </template>
         </v-snackbar>
-        <v-dialog v-model="showEmergencyStopDialog" width="400" :fullscreen="isMobile">
+        <v-dialog v-model="showEmergencyStopDialog" width="400" persistent>
             <panel
                 :title="$t('EmergencyStopDialog.EmergencyStop')"
                 toolbar-color="error"

--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -82,26 +82,7 @@
                 </v-btn>
             </template>
         </v-snackbar>
-        <v-dialog v-model="showEmergencyStopDialog" width="400" persistent>
-            <panel
-                :title="$t('EmergencyStopDialog.EmergencyStop')"
-                toolbar-color="error"
-                card-class="emergency-stop-dialog"
-                :icon="mdiAlertOctagonOutline"
-                :margin-bottom="false">
-                <template #buttons>
-                    <v-btn icon tile @click="showEmergencyStopDialog = false">
-                        <v-icon>{{ mdiCloseThick }}</v-icon>
-                    </v-btn>
-                </template>
-                <v-card-text>{{ $t('EmergencyStopDialog.AreYouSure') }}</v-card-text>
-                <v-card-actions>
-                    <v-spacer />
-                    <v-btn text @click="showEmergencyStopDialog = false">{{ $t('EmergencyStopDialog.No') }}</v-btn>
-                    <v-btn color="primary" text @click="emergencyStop">{{ $t('EmergencyStopDialog.Yes') }}</v-btn>
-                </v-card-actions>
-            </panel>
-        </v-dialog>
+        <emergency-stop-dialog :show-dialog="showEmergencyStopDialog" @close="showEmergencyStopDialog = false" />
     </div>
 </template>
 
@@ -120,6 +101,7 @@ import MainsailLogo from '@/components/ui/MainsailLogo.vue'
 import TheNotificationMenu from '@/components/notifications/TheNotificationMenu.vue'
 import { topbarHeight } from '@/store/variables'
 import { mdiAlertOctagonOutline, mdiContentSave, mdiFileUpload, mdiClose, mdiCloseThick } from '@mdi/js'
+import EmergencyStopDialog from '@/components/dialogs/EmergencyStopDialog.vue'
 
 type uploadSnackbar = {
     status: boolean
@@ -132,6 +114,7 @@ type uploadSnackbar = {
 
 @Component({
     components: {
+        EmergencyStopDialog,
         Panel,
         TheSettingsMenu,
         TheTopCornerMenu,

--- a/src/components/dialogs/EmergencyStopDialog.vue
+++ b/src/components/dialogs/EmergencyStopDialog.vue
@@ -1,0 +1,52 @@
+<template>
+    <v-dialog :value="showDialog" width="400" persistent>
+        <panel
+            :title="$t('EmergencyStopDialog.EmergencyStop')"
+            toolbar-color="error"
+            card-class="emergency-stop-dialog"
+            :icon="mdiAlertOctagonOutline"
+            :margin-bottom="false">
+            <template #buttons>
+                <v-btn icon tile @click="closePrompt">
+                    <v-icon>{{ mdiCloseThick }}</v-icon>
+                </v-btn>
+            </template>
+            <v-card-text>{{ $t('EmergencyStopDialog.AreYouSure') }}</v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn text @click="closePrompt">{{ $t('EmergencyStopDialog.No') }}</v-btn>
+                <v-btn color="primary" text @click="emergencyStop">{{ $t('EmergencyStopDialog.Yes') }}</v-btn>
+            </v-card-actions>
+        </panel>
+    </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import Panel from '@/components/ui/Panel.vue'
+
+import { mdiAlertOctagonOutline, mdiCloseThick } from '@mdi/js'
+
+@Component({
+    components: { Panel },
+})
+export default class EmergencyStopDialog extends Mixins(BaseMixin) {
+    mdiAlertOctagonOutline = mdiAlertOctagonOutline
+    mdiCloseThick = mdiCloseThick
+
+    @Prop({ type: Boolean, default: false }) showDialog!: boolean
+
+    emergencyStop() {
+        this.$socket.emit('printer.emergency_stop', {}, { loading: 'topbarEmergencyStop' })
+
+        this.closePrompt()
+    }
+
+    closePrompt() {
+        this.$emit('close')
+    }
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Description

This PR remove the fullscreen mode on mobile devices and add persistent funciton.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/0c7bf416-0293-4634-9346-7c1fae8a5dc3)

after:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/aed0ac45-5d0a-44a5-8c3d-05c7103590f1)

## [optional] Are there any post-deployment tasks we need to perform?

none
