### PR TITLE
fix: fix typo issues with save zoffset for probes

### DIFF
--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -39,8 +39,8 @@ export default class ZoffsetMixin extends Vue {
         return this.$store.state.printer?.gcode_move?.homing_origin[2].toFixed(3)
     }
     get isEndstopProbe() {
-        // this is to check all kinds of writings
-        return this.endstop_pin.startsWith('probe:') && this.endstop_pin.endsWith('z_virtual_endstop')
+        // remove spaces and search for probe:z_virtual_endstop
+        return this.endstop_pin.replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
     }
 
     get existZOffsetApplyProbe() {

--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -32,14 +32,15 @@ export default class ZoffsetMixin extends Vue {
     get endstop_pin() {
         const stepperConfig = this.settings[this.stepper_name] ?? {}
 
-        return stepperConfig?.endstop_pin
+        return stepperConfig?.endstop_pin.trim()
     }
 
     get zOffset(): number {
         return this.$store.state.printer?.gcode_move?.homing_origin[2].toFixed(3)
     }
     get isEndstopProbe() {
-        return this.endstop_pin.search('probe:z_virtual_endstop') !== -1
+        // this is to check all kinds of writings
+        return this.endstop_pin.startsWith('probe:') && this.endstop_pin.endsWith('z_virtual_endstop')
     }
 
     get existZOffsetApplyProbe() {


### PR DESCRIPTION
## Description

This PR fix an issue with not visible "save" button for the z-offset.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
