### PR TITLE
fix: hide crowsnest backups when "Hide backup files" is enabled

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -842,7 +842,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
         }
 
         if (this.hideBackupFiles) {
-            const klipperBackupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
+            const klipperBackupFileMatcher = /^printer-\d{8}_\d{6}\.cfg$/
             const crowsnestBackupFileMatcher = /^crowsnest\.conf\.\d{4}-\d{2}-\d{2}-\d{4}$/
 
             files = files.filter(

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -842,8 +842,15 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
         }
 
         if (this.hideBackupFiles) {
-            const backupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
-            files = files.filter((file) => !file.filename.match(backupFileMatcher) && !file.filename.endsWith('.bkp'))
+            const klipperBackupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
+            const crowsnestBackupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
+
+            files = files.filter(
+                (file) =>
+                    !file.filename.match(klipperBackupFileMatcher) &&
+                    !file.filename.match(crowsnestBackupFileMatcher) &&
+                    !file.filename.endsWith('.bkp')
+            )
         }
 
         return files

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -843,7 +843,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
 
         if (this.hideBackupFiles) {
             const klipperBackupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
-            const crowsnestBackupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
+            const crowsnestBackupFileMatcher = /^crowsnest\.conf\.\d{4}-\d{2}-\d{2}-\d{4}$/
 
             files = files.filter(
                 (file) =>


### PR DESCRIPTION
## Description

This PR only adds the regex to hide crowsnest backup files, when "Hide Backup files" is enabled in the Config Files panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
