### PR TITLE
feat: add option to disable favicon progress circle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,6 +187,10 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
         }
     }
 
+    get progressAsFavicon() {
+        return this.$store.state.gui.uiSettings.progressAsFavicon
+    }
+
     @Watch('language')
     async languageChanged(newVal: string): Promise<void> {
         await setAndLoadLocale(newVal)
@@ -235,7 +239,7 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
         const favicon32: HTMLLinkElement | null = document.querySelector("link[rel*='icon'][sizes='32x32']")
 
         if (favicon16 && favicon32) {
-            if (this.printerIsPrinting) {
+            if (this.progressAsFavicon && this.printerIsPrinting) {
                 let faviconSize = 64
 
                 let canvas = document.createElement('canvas')
@@ -301,6 +305,11 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
 
     @Watch('customFavicons')
     customFaviconsChanged(): void {
+        this.drawFavicon(this.print_percent)
+    }
+
+    @Watch('progressAsFavicon')
+    progressAsFaviconChanged(): void {
         this.drawFavicon(this.print_percent)
     }
 

--- a/src/components/settings/SettingsUiSettingsTab.vue
+++ b/src/components/settings/SettingsUiSettingsTab.vue
@@ -105,6 +105,13 @@
                 </settings-row>
                 <v-divider class="my-2" />
                 <settings-row
+                    :title="$t('Settings.UiSettingsTab.ProgressAsFavicon')"
+                    :sub-title="$t('Settings.UiSettingsTab.ProgressAsFaviconDescription')"
+                    :dynamic-slot-width="true">
+                    <v-switch v-model="progressAsFavicon" hide-details class="mt-0" />
+                </settings-row>
+                <v-divider class="my-2" />
+                <settings-row
                     :title="$t('Settings.UiSettingsTab.LockSliders')"
                     :sub-title="$t('Settings.UiSettingsTab.LockSlidersDescription')"
                     :dynamic-slot-width="true">
@@ -338,6 +345,14 @@ export default class SettingsUiSettingsTab extends Mixins(BaseMixin) {
 
     set displayCancelPrint(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'uiSettings.displayCancelPrint', value: newVal })
+    }
+
+    get progressAsFavicon() {
+        return this.$store.state.gui.uiSettings.progressAsFavicon
+    }
+
+    set progressAsFavicon(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'uiSettings.progressAsFavicon', value: newVal })
     }
 
     get confirmOnEmergencyStop() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1185,7 +1185,7 @@
             "PowerDeviceNameDescription": "Select which Moonraker power device should be used to power on the printer.",
             "Primary": "Primary",
             "ProgressAsFavicon": "Show progress as favicon",
-            "ProgressAsFaviconDescription": "Switch from the Mainsail logo to a progress circle in the favicon.",
+            "ProgressAsFaviconDescription": "Change the Mainsail logo favicon to a progress circle.",
             "ScrewsTiltAdjustDialog": "Screws Tilt Adjust Dialog",
             "ScrewsTiltAdjustDialogDescription": "Display helper dialog for SCREWS_TILT_CALCULATE.",
             "TempchartHeight": "Height Temperature Chart",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1184,6 +1184,8 @@
             "PowerDeviceName": "Printer power device",
             "PowerDeviceNameDescription": "Select which Moonraker power device should be used to power on the printer.",
             "Primary": "Primary",
+            "ProgressAsFavicon": "Progress as favicon",
+            "ProgressAsFaviconDescription": "Switch from the Mainsail logo to a progress circle in the favicon.",
             "ScrewsTiltAdjustDialog": "Screws Tilt Adjust Dialog",
             "ScrewsTiltAdjustDialogDescription": "Display helper dialog for SCREWS_TILT_CALCULATE.",
             "TempchartHeight": "Height Temperature Chart",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1184,7 +1184,7 @@
             "PowerDeviceName": "Printer power device",
             "PowerDeviceNameDescription": "Select which Moonraker power device should be used to power on the printer.",
             "Primary": "Primary",
-            "ProgressAsFavicon": "Progress as favicon",
+            "ProgressAsFavicon": "Show progress as favicon",
             "ProgressAsFaviconDescription": "Switch from the Mainsail logo to a progress circle in the favicon.",
             "ScrewsTiltAdjustDialog": "Screws Tilt Adjust Dialog",
             "ScrewsTiltAdjustDialogDescription": "Display helper dialog for SCREWS_TILT_CALCULATE.",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -165,6 +165,7 @@ export const getDefaultState = (): GuiState => {
             navigationStyle: 'iconsAndText',
             defaultNavigationStateSetting: 'alwaysOpen',
             powerDeviceName: null,
+            progressAsFavicon: true,
             hideSaveConfigForBedMash: false,
             disableFanAnimation: false,
             boolManualProbeDialog: true,

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -114,6 +114,7 @@ export interface GuiState {
         navigationStyle: 'iconsAndText' | 'iconsOnly'
         defaultNavigationStateSetting: 'alwaysOpen' | 'alwaysClosed' | 'lastState'
         powerDeviceName: string | null
+        progressAsFavicon: boolean
         hideSaveConfigForBedMash: boolean
         disableFanAnimation: boolean
         boolManualProbeDialog: boolean


### PR DESCRIPTION
## Description

This PR adds a option to disable the progress circle as favicon during a print.

## Related Tickets & Documents

fixes: #1754 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
