### PR TITLE
fix: fix case sensibility for printer power device

### DIFF
--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -52,10 +52,14 @@ export default class BaseMixin extends Vue {
     }
 
     get printerPowerDevice(): string {
-        let deviceName = this.$store.state.gui.uiSettings.powerDeviceName ?? null
-        if (deviceName === null) deviceName = 'printer'
+        const deviceName = this.$store.state.gui.uiSettings.powerDeviceName ?? null
+        if (deviceName !== null) return deviceName
 
-        return deviceName
+        const devices = this.$store.getters['server/power/getDevices'] ?? []
+        return (
+            devices.find((device: ServerPowerStateDevice) => device.device.toLowerCase() === 'printer')?.device ??
+            'printer'
+        )
     }
 
     get isPrinterPowerOff() {

--- a/src/components/settings/SettingsUiSettingsTab.vue
+++ b/src/components/settings/SettingsUiSettingsTab.vue
@@ -445,10 +445,10 @@ export default class SettingsUiSettingsTab extends Mixins(BaseMixin) {
     }
 
     get autoPowerDevice() {
-        const autoIndex = this.powerDevices.findIndex((device: ServerPowerStateDevice) => device.device === 'printer')
-        if (autoIndex === -1) return '--'
-
-        return this.powerDevices[autoIndex].device
+        return (
+            this.powerDevices.find((device: ServerPowerStateDevice) => device.device.toLowerCase() === 'printer')
+                ?.device ?? '--'
+        )
     }
 
     get powerDeviceName() {


### PR DESCRIPTION
## Description

This PR also allow "Printer" (with uppercase first char) as "printer power device", for the default setting.

## Related Tickets & Documents

fixes: #1812 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
