### PR TITLE
fix: ignore wrong default.json file while resetting moonraker db

### DIFF
--- a/src/components/panels/Machine/LogfilesPanel/LogfilesPanelRolloverDialog.vue
+++ b/src/components/panels/Machine/LogfilesPanel/LogfilesPanelRolloverDialog.vue
@@ -65,7 +65,7 @@ export default class LogfilesPanelRolloverDialog extends Mixins(BaseMixin) {
     selectedRolloverLogs: string[] = []
 
     get loadingRolloverLogs() {
-        return this.loadings.filter((log) => log.startsWith('rolloverLog_')).length > 0
+        return this.loadings.filter((log) => log?.startsWith('rolloverLog_')).length > 0
     }
 
     @Watch('loadingRolloverLogs')

--- a/src/components/settings/General/GeneralReset.vue
+++ b/src/components/settings/General/GeneralReset.vue
@@ -86,7 +86,7 @@ export default class SettingsGeneralTabResetDatabase extends Mixins(BaseMixin, S
         this.resetableNamespaces = await this.loadBackupableNamespaces()
 
         // stop if history is not enabled
-        if (this.moonrakerComponents.includes('history')) return
+        if (!this.moonrakerComponents.includes('history')) return
 
         this.resetableNamespaces.push({
             value: 'history_jobs',

--- a/src/components/settings/General/GeneralReset.vue
+++ b/src/components/settings/General/GeneralReset.vue
@@ -85,17 +85,18 @@ export default class SettingsGeneralTabResetDatabase extends Mixins(BaseMixin, S
     async loadResetableNamespaces() {
         this.resetableNamespaces = await this.loadBackupableNamespaces()
 
-        if (this.moonrakerComponents.includes('history')) {
-            this.resetableNamespaces.push({
-                value: 'history_jobs',
-                label: this.$t('Settings.GeneralTab.DbHistoryJobs'),
-            })
+        // stop if history is not enabled
+        if (this.moonrakerComponents.includes('history')) return
 
-            this.resetableNamespaces.push({
-                value: 'history_totals',
-                label: this.$t('Settings.GeneralTab.DbHistoryTotals'),
-            })
-        }
+        this.resetableNamespaces.push({
+            value: 'history_jobs',
+            label: this.$t('Settings.GeneralTab.DbHistoryJobs'),
+        })
+
+        this.resetableNamespaces.push({
+            value: 'history_totals',
+            label: this.$t('Settings.GeneralTab.DbHistoryTotals'),
+        })
     }
 
     closeDialog() {

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -236,11 +236,13 @@ export const actions: ActionTree<GuiState, RootState> = {
 
         const urlDefault =
             rootGetters['socket/getUrl'] + '/server/files/config/' + themeDir + '/default.json?time=' + Date.now()
-        const responseDefault = await fetch(urlDefault)
+
         let defaults: any = {}
-        if (responseDefault) {
-            defaults = await responseDefault.json()
-            if (defaults.error?.code === 404) defaults = {}
+        try {
+            defaults = await fetch(urlDefault).then((result) => result.json())
+        } catch (error) {
+            window.console.error('Error while fetching/parsing default.json', error)
+            defaults = {}
         }
 
         for (const key of payload) {


### PR DESCRIPTION
## Description

This PR will ignore a wrong/not parseable default.json file during a moonraker db reset.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
