### PR TITLE
feat: Disable Zoom on Mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0, user-scalable=no" />
         <title>Mainsail</title>
         <meta name="description" content="Mainsail is the popular web interface for Klipper." />
 


### PR DESCRIPTION
The reason zooming should be disabled, is because double tapping buttons (e.g. moving an axis) causes zooming.