### PR TITLE
feat: add only save button to editor

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -37,12 +37,7 @@
                         <v-icon small class="mr-1">{{ mdiRestart }}</v-icon>
                         {{ $t('Editor.SaveRestart') }}
                     </v-btn>
-                    <v-btn
-                        v-if="isWriteable"
-                        icon
-                        tile
-                        :color="restartServiceName === null ? 'primary' : ''"
-                        @click="save(null)">
+                    <v-btn v-if="isWriteable" icon tile @click="save(null)">
                         <v-icon>{{ mdiContentSave }}</v-icon>
                     </v-btn>
                     <v-btn icon tile @click="close">

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -28,15 +28,6 @@
                         {{ $t('Editor.ConfigReference') }}
                     </v-btn>
                     <v-btn
-                        v-if="isWriteable"
-                        text
-                        tile
-                        :color="restartServiceName === null ? 'primary' : ''"
-                        @click="save(null)">
-                        <v-icon small class="mr-1">{{ mdiContentSave }}</v-icon>
-                        <span class="d-none d-sm-inline">{{ $t('Editor.SaveClose') }}</span>
-                    </v-btn>
-                    <v-btn
                         v-if="restartServiceNameExists"
                         color="primary"
                         text
@@ -45,6 +36,14 @@
                         @click="save(restartServiceName)">
                         <v-icon small class="mr-1">{{ mdiRestart }}</v-icon>
                         {{ $t('Editor.SaveRestart') }}
+                    </v-btn>
+                    <v-btn
+                        v-if="isWriteable"
+                        icon
+                        tile
+                        :color="restartServiceName === null ? 'primary' : ''"
+                        @click="save(null)">
+                        <v-icon>{{ mdiContentSave }}</v-icon>
                     </v-btn>
                     <v-btn icon tile @click="close">
                         <v-icon>{{ mdiCloseThick }}</v-icon>
@@ -56,7 +55,7 @@
                         ref="editor"
                         v-model="sourcecode"
                         :name="filename"
-                        :file-extension="fileExtension"></codemirror-async>
+                        :file-extension="fileExtension" />
                 </v-card-text>
             </panel>
         </v-dialog>
@@ -105,7 +104,7 @@
                     </v-row>
                 </v-card-text>
                 <v-card-actions>
-                    <v-spacer></v-spacer>
+                    <v-spacer />
                     <v-btn text @click="discardChanges">
                         {{ $t('Editor.DontSave') }}
                     </v-btn>
@@ -166,8 +165,6 @@ export default class TheEditor extends Mixins(BaseMixin) {
     mdiFileDocumentEditOutline = mdiFileDocumentEditOutline
     mdiFileDocumentOutline = mdiFileDocumentOutline
     mdiUsb = mdiUsb
-
-    private scrollbarOptions = { scrollbars: { autoHide: 'never' } }
 
     declare $refs: {
         editor: Codemirror
@@ -343,10 +340,14 @@ export default class TheEditor extends Mixins(BaseMixin) {
 
     @Watch('changed')
     changedChanged(newVal: boolean) {
-        if (this.confirmUnsavedChanges) {
-            if (newVal) window.addEventListener('beforeunload', windowBeforeUnloadFunction)
-            else window.removeEventListener('beforeunload', windowBeforeUnloadFunction)
+        if (!this.confirmUnsavedChanges) return
+
+        if (newVal) {
+            window.addEventListener('beforeunload', windowBeforeUnloadFunction)
+            return
         }
+
+        window.removeEventListener('beforeunload', windowBeforeUnloadFunction)
     }
 }
 </script>

--- a/src/store/editor/actions.ts
+++ b/src/store/editor/actions.ts
@@ -133,7 +133,10 @@ export const actions: ActionTree<EditorState, RootState> = {
                 } else if (payload.restartServiceName !== null) {
                     Vue.$socket.emit('machine.services.restart', { service: payload.restartServiceName })
                 }
-                dispatch('close')
+
+                commit('updateLoadedHash', payload.content)
+
+                if (payload.restartServiceName !== null) dispatch('close')
             })
             .catch((error) => {
                 window.console.log(error.response?.data.error)

--- a/src/store/editor/mutations.ts
+++ b/src/store/editor/mutations.ts
@@ -68,4 +68,9 @@ export const mutations: MutationTree<EditorState> = {
 
         state.changed = sha256(payload) != state.loadedHash
     },
+
+    updateLoadedHash(state, payload) {
+        Vue.set(state, 'loadedHash', sha256(payload.replace(/(?:\r\n|\r|\n)/g, '\n')))
+        Vue.set(state, 'changed', false)
+    },
 }


### PR DESCRIPTION
## Description

This PR remove the "Save & Close" button and adds a only "Save" button to the editor.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
