### PR TITLE
docs: add github sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: mainsail-crew
 patreon: meteyou
 open_collective: # Replace with a single Open Collective username
 ko_fi: mainsail


### PR DESCRIPTION
## Description

Add the GitHub Sponsor link to the Mainsail Repo.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
