### PR TITLE
feat: show macro description as tooltip when hovering a macro

### DIFF
--- a/src/components/inputs/MacroButton.vue
+++ b/src/components/inputs/MacroButton.vue
@@ -1,14 +1,21 @@
 <template>
     <v-item-group class="d-inline-block">
-        <v-btn
-            small
-            :color="color"
-            :class="paramArray.length ? 'macroWithParameters' : ''"
-            :loading="loadings.includes('macro_' + macro.name)"
-            :disabled="disabled"
-            @click="doSendMacro(macro.name)">
-            {{ alias ? alias : macro.name.replace(/_/g, ' ') }}
-        </v-btn>
+        <v-tooltip :disabled="!hasDescription" top>
+            <template #activator="{ on, attrs }">
+                <v-btn
+                    small
+                    :color="color"
+                    :class="paramArray.length ? 'macroWithParameters' : ''"
+                    :loading="loadings.includes('macro_' + macro.name)"
+                    :disabled="disabled"
+                    v-bind="attrs"
+                    v-on="on"
+                    @click="doSendMacro(macro.name)">
+                    {{ alias ? alias : macro.name.replace(/_/g, ' ') }}
+                </v-btn>
+            </template>
+            <span>{{ klipperMacro.description }}</span>
+        </v-tooltip>
         <template v-if="paramArray.length">
             <v-menu v-if="!isMobile" offset-y :close-on-content-click="false">
                 <template #activator="{ on, attrs }">
@@ -118,6 +125,8 @@ interface params {
     components: { Panel },
 })
 export default class MacroButton extends Mixins(BaseMixin) {
+    DEFAULT_DESC = 'G-Code macro'
+
     /**
      * Icons
      */
@@ -165,6 +174,10 @@ export default class MacroButton extends Mixins(BaseMixin) {
 
     get paramsOverlayWidth() {
         return 200 * this.paramCols
+    }
+
+    get hasDescription(): boolean {
+        return this.klipperMacro.description && this.klipperMacro.description !== this.DEFAULT_DESC
     }
 
     @Watch('klipperMacro')

--- a/src/components/inputs/MacroButton.vue
+++ b/src/components/inputs/MacroButton.vue
@@ -125,9 +125,9 @@ export default class MacroButton extends Mixins(BaseMixin) {
     mdiMenuDown = mdiMenuDown
     mdiRefresh = mdiRefresh
 
-    private paramArray: string[] = []
-    private params: params = {}
-    private paramsDialog = false
+    paramArray: string[] = []
+    params: params = {}
+    paramsDialog = false
 
     @Prop({ required: true })
     declare readonly macro: GuiMacrosStateMacrogroupMacro | PrinterStateMacro


### PR DESCRIPTION
Signed-off-by: Dominik Willner <th33xitus@gmail.com>


## Description
This PR adds a tooltip to macro buttons which description is NOT the default (`G-Code macro`) macro description.

## Related Tickets & Documents
Fixes #1848 

## Mobile & Desktop Screenshots/Recordings
### Before:
![image](https://github.com/mainsail-crew/mainsail/assets/31533186/d132541a-59ab-434c-a8f4-dfa0f7f650e7)

### After:
![image](https://github.com/mainsail-crew/mainsail/assets/31533186/ea1532ed-6c3c-4d26-a1aa-0b5a2d6a3765)
