### PR TITLE
refactor: remove unused attribute in getPrinttimeAvgArray getter

### DIFF
--- a/src/store/server/history/getters.ts
+++ b/src/store/server/history/getters.ts
@@ -243,7 +243,7 @@ export const getters: GetterTree<ServerHistoryState, any> = {
         })
     },
 
-    getPrinttimeAvgArray(state, getters, rootState) {
+    getPrinttimeAvgArray(state, getters) {
         const output = [0, 0, 0, 0, 0]
         const startDate = new Date(new Date().getTime() - 60 * 60 * 24 * 14 * 1000)
 


### PR DESCRIPTION
## Description

This PR only remove an unused attribute in the getPrinttimeAvgArray history getter.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
