### PR TITLE
fix(spoolman): fix search for spool-id

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -163,6 +163,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
 
         const querySplits = search.toLowerCase().split(' ')
         const searchArray = [
+            item.id.toString(),
             item.comment,
             item.filament.name,
             item.filament.vendor.name,


### PR DESCRIPTION
## Description

This PR fix the spoolman search function to find spools by spool-id.

## Related Tickets & Documents

fixes #1866 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
