### PR TITLE
fix: display "pause on layer"-button only when the macros exists

### DIFF
--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -263,7 +263,7 @@ export default class StatusPanel extends Mixins(BaseMixin) {
                 icon: mdiLayersPlus,
                 loadingName: 'pauseAtLayer',
                 status: () => {
-                    if (this.multiFunctionButton || this.layer_count === null) return false
+                    if (this.multiFunctionButton || !this.displayPauseAtLayerButton) return false
 
                     return ['paused', 'printing'].includes(this.printer_state)
                 },
@@ -319,7 +319,7 @@ export default class StatusPanel extends Mixins(BaseMixin) {
                 click: this.btnExcludeObject,
             },
             {
-                text: this.$t('Panels.StatusPanel.PauseAtLayer.PauseAtLayer') + ' - ' + this.displayPauseAtLayerButton,
+                text: this.$t('Panels.StatusPanel.PauseAtLayer.PauseAtLayer'),
                 loadingName: 'pauseAtLayer',
                 icon: mdiLayersPlus,
                 status: () => this.displayPauseAtLayerButton,


### PR DESCRIPTION
## Description

This PR fix the "Pause at Layer" button in the Status panel. Until now, you saw this button, if you don't have "Exclude objects" active, set Layer counts, but no macros (SET_PAUSE_AT_LAYER & SET_PAUSE_NEXT_LAYER).

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
