### PR TITLE
fix(webcam): fix fps output in light mode

### DIFF
--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -257,4 +257,8 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     padding: 3px 10px;
     border-top-left-radius: 5px;
 }
+
+html.theme--light .webcamFpsOutput {
+    background: rgba(255, 255, 255, 0.7);
+}
 </style>

--- a/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
+++ b/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
@@ -227,4 +227,8 @@ export default class MjpegstreamerAdaptive extends Mixins(BaseMixin, WebcamMixin
     padding: 3px 10px;
     border-top-left-radius: 5px;
 }
+
+html.theme--light .webcamFpsOutput {
+    background: rgba(255, 255, 255, 0.7);
+}
 </style>


### PR DESCRIPTION
## Description

This PR fixes the contrast of the fps output in mjpegstreamer and mjpegstreamer-adaptive in the light theme.

## Related Tickets & Documents

fixes: #1900 

## Mobile & Desktop Screenshots/Recordings

after: 
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/313481b0-814a-4332-8f3e-92466b96ec5b)

before:
![image](https://github.com/mainsail-crew/mainsail/assets/8167632/1d9a8f02-22ac-4a5d-82ea-c235855749dc)

## [optional] Are there any post-deployment tasks we need to perform?

none
