### PR TITLE
feat: Add hotkeys tied to Save, Save + Restart

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -8,10 +8,10 @@
             :transition="false"
             @close="close"
             @keydown.esc="escClose"
-            @keydown.ctrl.s.prevent="save(null)"
-            @keydown.meta.s.prevent="save(null)"
             @keydown.ctrl.shift.s.prevent="restartServiceNameExists && save(restartServiceName)"
-            @keydown.meta.shift.s.prevent="restartServiceNameExists && save(restartServiceName)">
+            @keydown.meta.shift.s.prevent="restartServiceNameExists && save(restartServiceName)"
+            @keydown.ctrl.s.prevent="save(null)"
+            @keydown.meta.s.prevent="save(null)">
             <panel
                 card-class="editor-dialog"
                 :icon="isWriteable ? mdiFileDocumentEditOutline : mdiFileDocumentOutline"

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -8,8 +8,10 @@
             :transition="false"
             @close="close"
             @keydown.esc="escClose"
-            @keydown.ctrl.s.prevent="hotkeySave()"
-            @keydown.meta.s.prevent="hotkeySave()">
+            @keydown.ctrl.s.prevent="save(null)"
+            @keydown.meta.s.prevent="save(null)"
+            @keydown.ctrl.shift.s.prevent="restartServiceNameExists && save(restartServiceName)"
+            @keydown.meta.shift.s.prevent="restartServiceNameExists && save(restartServiceName)">
             <panel
                 card-class="editor-dialog"
                 :icon="isWriteable ? mdiFileDocumentEditOutline : mdiFileDocumentOutline"
@@ -333,10 +335,6 @@ export default class TheEditor extends Mixins(BaseMixin) {
             content: this.sourcecode,
             restartServiceName: restartServiceName,
         })
-    }
-
-    hotkeySave() {
-        if (this.isWriteable) this.save(null)
     }
 
     @Watch('changed')

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -7,7 +7,9 @@
             hide-overlay
             :transition="false"
             @close="close"
-            @keydown.esc="escClose">
+            @keydown.esc="escClose"
+            @keydown.ctrl.s.prevent="hotkeySave()"
+            @keydown.meta.s.prevent="hotkeySave()">
             <panel
                 card-class="editor-dialog"
                 :icon="isWriteable ? mdiFileDocumentEditOutline : mdiFileDocumentOutline"
@@ -331,6 +333,10 @@ export default class TheEditor extends Mixins(BaseMixin) {
             content: this.sourcecode,
             restartServiceName: restartServiceName,
         })
+    }
+
+    hotkeySave() {
+        if (this.isWriteable) this.save(null)
     }
 
     @Watch('changed')


### PR DESCRIPTION
## Description
I am trying to solve a personal issue of mine with this PR. I compulsively press <kbd>ctrl</kbd>+<kbd>s</kbd> while making changes in my editor, but this breaks my flow since it launches the save page dialog of the browser.

I propose overriding the default browser behavior for hotkeys with keybindings for our editor actions.

Changes:
 - <kbd>ctrl</kbd>+<kbd>s</kbd> => Save
 - <kbd>meta</kbd>+<kbd>s</kbd> => Save (Mac)
 - <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>s</kbd> => Save + Restart 
 - <kbd>meta</kbd>+<kbd>shift</kbd>+<kbd>s</kbd> => Save + Restart (Mac)

## Screenshots
I could try and make a screen recording of pressing the hotkeys but I didn't feel like it would add much to the PR 