### PR TITLE
feat(systemLoads): add firmware name, when it is not Klipper

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -416,7 +416,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
         Object.keys(state).forEach((key) => {
             if (key === 'mcu' || key.startsWith('mcu ')) {
                 const mcu = state[key]
-                const versionOutput = (mcu.mcu_version ?? 'unknown').split('-').slice(0, 4).join('-')
+                let versionOutput = (mcu.mcu_version ?? 'unknown').split('-').slice(0, 4).join('-')
+
+                if ('app' in mcu && mcu.app !== 'Klipper') versionOutput = mcu.app + ' ' + versionOutput
 
                 let load = 0
                 if (mcu.last_stats?.mcu_task_avg && mcu.last_stats?.mcu_task_stddev) {


### PR DESCRIPTION
## Description

This PR also add the firmware names for MCU, when it is different to Klipper (for example "Danger-Klipper").

## Related Tickets & Documents

PR in Danger-Klipper: https://github.com/DangerKlippers/danger-klipper/pull/301

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/90db8585-2bde-465a-93e8-8e0029e6d6f4)

## [optional] Are there any post-deployment tasks we need to perform?

none
