### PR TITLE
fix(statusPanel): fix the thumbnail overlay in the light theme

### DIFF
--- a/src/components/panels/Status/PrintstatusThumbnail.vue
+++ b/src/components/panels/Status/PrintstatusThumbnail.vue
@@ -10,9 +10,7 @@
             :style="thumbnailStyle"
             @focus="focusBigThumbnail"
             @blur="blurBigThumbnail">
-            <v-card-title
-                class="white--text py-2 px-2"
-                style="background-color: rgba(0, 0, 0, 0.3); backdrop-filter: blur(3px)">
+            <v-card-title class="white--text py-2 px-2" :style="styleThumbnailOverlay">
                 <v-row>
                     <v-col style="width: 100px">
                         <span class="subtitle-2 text-truncate px-0 text--disabled d-block">
@@ -195,6 +193,19 @@ export default class StatusPanelPrintstatusThumbnail extends Mixins(BaseMixin) {
         }
 
         return {}
+    }
+
+    get styleThumbnailOverlay() {
+        const style = {
+            backgroundColor: 'rgba(0, 0, 0, 0.3)',
+            backdropFilter: 'blur(3px)',
+        }
+
+        if (!this.$vuetify.theme.dark) {
+            style.backgroundColor = 'rgba(255, 255, 255, 0.3)'
+        }
+
+        return style
     }
 
     focusBigThumbnail() {


### PR DESCRIPTION
## Description

This PR fix the thumbnail overlay in the status panel with light mode. It change the overlay background color from black to white.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/fec9c2f5-591e-40b0-b931-0da69852ba7c)

## [optional] Are there any post-deployment tasks we need to perform?

none
