### PR TITLE
fix(extruderPanel): add speed_factor to estimate extrusion calc

### DIFF
--- a/src/components/panels/Extruder/EstimatedExtrusionOutput.vue
+++ b/src/components/panels/Extruder/EstimatedExtrusionOutput.vue
@@ -10,7 +10,7 @@
                 {{ nozzleDiameter }} mm
                 <v-tooltip v-if="showTooltip" top>
                     <template #activator="{ on, attrs }">
-                        <v-icon small color="red" v-bind="attrs" v-on="on">
+                        <v-icon small color="warning" v-bind="attrs" v-on="on">
                             {{ mdiInformationOutline }}
                         </v-icon>
                     </template>

--- a/src/components/panels/Extruder/EstimatedExtrusionOutput.vue
+++ b/src/components/panels/Extruder/EstimatedExtrusionOutput.vue
@@ -8,6 +8,21 @@
                     {{ mdiDiameterVariant }}
                 </v-icon>
                 {{ nozzleDiameter }} mm
+                <v-tooltip v-if="showTooltip" top>
+                    <template #activator="{ on, attrs }">
+                        <v-icon small color="red" v-bind="attrs" v-on="on">
+                            {{ mdiInformationOutline }}
+                        </v-icon>
+                    </template>
+                    <span>
+                        <div v-if="speed_factor !== 1">
+                            {{ $t('Panels.ToolheadControlPanel.SpeedFactor') }}: {{ speed_factor * 100 }} %
+                        </div>
+                        <div v-if="extrudeFactor !== 1">
+                            {{ $t('Panels.ExtruderControlPanel.ExtrusionFactor') }}: {{ extrudeFactor * 100 }} %
+                        </div>
+                    </span>
+                </v-tooltip>
             </span>
         </div>
     </v-container>
@@ -16,12 +31,13 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { mdiDiameterVariant } from '@mdi/js'
+import { mdiDiameterVariant, mdiInformationOutline } from '@mdi/js'
 import ExtruderMixin from '@/components/mixins/extruder'
 
 @Component({})
 export default class PressureAdvanceSettings extends Mixins(BaseMixin, ExtruderMixin) {
     mdiDiameterVariant = mdiDiameterVariant
+    mdiInformationOutline = mdiInformationOutline
 
     get showEstimatedExtrusion() {
         return this.$store.state.gui.control.extruder.showEstimatedExtrusionInfo ?? true
@@ -35,8 +51,18 @@ export default class PressureAdvanceSettings extends Mixins(BaseMixin, ExtruderM
         )
     }
 
+    get speed_factor() {
+        return this.$store.state.printer.gcode_move?.speed_factor ?? 1
+    }
+
     get volumetricFlow(): number {
-        return Math.round(Math.pow(this.filamentDiameter / 2, 2) * Math.PI * this.feedrate * 10) / 10
+        return (
+            Math.round(Math.pow(this.filamentDiameter / 2, 2) * Math.PI * this.feedrate * this.speed_factor * 10) / 10
+        )
+    }
+
+    get showTooltip() {
+        return this.speed_factor !== 1 || this.extrudeFactor !== 1
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR add the speed_factor to the estimate extrusion calculation and add a tooltip, when speed_factor and/or extrusion_factor is not 1.

## Related Tickets & Documents

fixes: #1904 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/mainsail-crew/mainsail/assets/8167632/4e664dff-a0bd-4ace-84ee-9d163f3798d9)

## [optional] Are there any post-deployment tasks we need to perform?

none
