### PR TITLE
fix(maintenance): add init store entry to init maintenance store only one time

### DIFF
--- a/src/store/gui/maintenance/actions.ts
+++ b/src/store/gui/maintenance/actions.ts
@@ -36,6 +36,14 @@ export const actions: ActionTree<GuiMaintenanceState, RootState> = {
         // stop, when no entries are available/found
         const entries = defaults.entries ?? []
         if (entries?.length === 0) {
+            Vue.$socket.emit('server.database.post_item', {
+                namespace: 'maintenance',
+                key: uuidv4(),
+                value: {
+                    name: 'MAINTENANCE_INIT',
+                },
+            })
+
             return
         }
 
@@ -92,7 +100,12 @@ export const actions: ActionTree<GuiMaintenanceState, RootState> = {
 
     async initStore({ commit, dispatch }, payload) {
         await commit('reset')
-        await commit('initStore', payload)
+
+        const entries = payload.value ?? {}
+        const initKey = Object.keys(entries).find((key) => entries[key]?.name === 'MAINTENANCE_INIT')
+        if (initKey) delete entries[initKey]
+
+        await commit('initStore', entries)
         await dispatch('socket/removeInitModule', 'gui/maintenance/init', { root: true })
     },
 

--- a/src/store/gui/maintenance/mutations.ts
+++ b/src/store/gui/maintenance/mutations.ts
@@ -9,7 +9,7 @@ export const mutations: MutationTree<GuiMaintenanceState> = {
     },
 
     initStore(state, payload) {
-        Vue.set(state, 'entries', payload.value)
+        Vue.set(state, 'entries', payload)
     },
 
     store(state, payload) {


### PR DESCRIPTION
## Description

This PR fixes the init maintenance store routine. It will add one "MAINTENANCE_INIT" entry in the Moonraker DB.

## Related Tickets & Documents

fixes: #1879 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
