### PR TITLE
fix(macroPromts): fix internal close function

### DIFF
--- a/src/components/dialogs/TheMacroPrompt.vue
+++ b/src/components/dialogs/TheMacroPrompt.vue
@@ -100,7 +100,13 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
 
     get showDialog() {
         if (this.lastPromptBeginPos === -1) return false
-        if (this.internalCloseCommand !== null && this.internalCloseCommand == this.lastPromptBeginPos) return false
+
+        const lastBeginEvent = this.macroPromptEvents[this.lastPromptBeginPos] ?? null
+        if (
+            this.internalCloseCommand !== null &&
+            this.internalCloseCommand == (lastBeginEvent?.date?.getTime() ?? null)
+        )
+            return false
 
         return this.lastPromptBeginPos > this.lastPromptClosePos && this.activePromptContent.length > 0
     }
@@ -152,7 +158,7 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
 
     closePrompt() {
         // close prompt immediately, because klipper could be busy
-        this.internalCloseCommand = this.lastPromptBeginPos
+        this.internalCloseCommand = this.macroPromptEvents[this.lastPromptBeginPos]?.date?.getTime() ?? null
 
         const gcode = `RESPOND type="command" msg="action:prompt_end"`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })


### PR DESCRIPTION
## Description

This PR fix the computed showDialog in the macro prompts. I switch from array pos to timestamp from the event entry. The macro prompt didn't open, when you opened the same macro prompt multiple times without a refresh before.

## Related Tickets & Documents

fixes: #1899 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
