### PR TITLE
fix(screwsTiltCalculate): use the same direction on retry

### DIFF
--- a/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
+++ b/src/components/dialogs/TheScrewsTiltAdjustDialog.vue
@@ -50,6 +50,7 @@ import SettingsRow from '@/components/settings/SettingsRow.vue'
 import { mdiArrowCollapseDown, mdiCloseThick } from '@mdi/js'
 import ControlMixin from '@/components/mixins/control'
 import TheScrewsTiltAdjustDialogEntry from '@/components/dialogs/TheScrewsTiltAdjustDialogEntry.vue'
+import { ServerStateEvent } from '@/store/server/types'
 @Component({
     components: { TheScrewsTiltAdjustDialogEntry, Panel, Responsive, SettingsRow },
 })
@@ -92,9 +93,17 @@ export default class TheScrewsTiltAdjustDialog extends Mixins(BaseMixin, Control
     }
 
     async retryScrewsTiltAdjust() {
+        const entries = [...(this.$store.state.server.events ?? [])]
+        const lastCommand = entries
+            .reverse()
+            .find(
+                (entry: ServerStateEvent) =>
+                    entry.type === 'command' && entry.message.startsWith('SCREWS_TILT_CALCULATE')
+            )
+
         await this.$store.dispatch('printer/clearScrewsTiltAdjust')
 
-        this.doSend('SCREWS_TILT_CALCULATE')
+        this.doSend(lastCommand?.message ?? 'SCREWS_TILT_CALCULATE')
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR fixes an issue with the `SCREWS_TILT_CALCULATE` helper panel. It checks the console history for the last execution of the `SCREWS_TILT_CALCULATE` command to use the same `DIRECTION` as the initial command.

## Related Tickets & Documents

fixes: #1917 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
