### PR TITLE
fix(maintenance): fix filament trigger for maintenance entries

### DIFF
--- a/src/store/gui/maintenance/getters.ts
+++ b/src/store/gui/maintenance/getters.ts
@@ -24,7 +24,7 @@ export const getters: GetterTree<GuiMaintenanceState, any> = {
             if (entry.reminder.type === null || entry.end_time !== null) return false
 
             if (entry.reminder.filament.bool) {
-                const end = entry.start_filament + (entry.reminder.filament.value ?? 0)
+                const end = entry.start_filament + (entry.reminder.filament.value ?? 0) * 1000
 
                 if (end <= currentTotalFilamentUsed) return true
             }


### PR DESCRIPTION
## Description

This PR fix the filament trigger for maintenance entries. The factor for converting mm to m was missing in the getter.

## Related Tickets & Documents

fixes #1938 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
