### PR TITLE
feat(updateManager): use info_tag desc for the name

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -2,7 +2,7 @@
     <div>
         <v-row class="py-2">
             <v-col class="pl-6">
-                <strong>{{ repo.name }}</strong>
+                <strong>{{ name }}</strong>
                 <br />
                 <template v-if="type === 'git_repo' && commitsBehind.length">
                     <a class="info--text cursor--pointer" @click="boolShowCommitList = true">
@@ -159,6 +159,11 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     @Prop({ required: true }) readonly repo!: ServerUpdateManagerStateGitRepo
 
     get name() {
+        const info_tags = this.repo.info_tags ?? []
+        const description = info_tags.find((tag) => tag.startsWith('desc='))
+
+        if (description) return description.replace('desc=', '')
+
         return this.repo.name ?? 'UNKNOWN'
     }
 

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -162,7 +162,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         const info_tags = this.repo.info_tags ?? []
         const description = info_tags.find((tag) => tag.startsWith('desc='))
 
-        if (description) return description.replace('desc=', '')
+        if (description && description.trim() !== 'desc=') return description.replace('desc=', '').trim()
 
         return this.repo.name ?? 'UNKNOWN'
     }


### PR DESCRIPTION
## Description

Use the `desc` in `info_tags` from the `update_manager` section in the `moonraker.conf`. This is a config example:

```
[update_manager beacon]
type: git_repo
channel: dev
path: ~/beacon_klipper
origin: https://github.com/beacon3d/beacon_klipper.git
env: ~/klippy-env/bin/python
requirements: requirements.txt
install_script: install.sh
is_system_service: False
managed_services: klipper
info_tags:
  desc=Beacon Surface Scanner
```

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

With this PR:
![image](https://github.com/user-attachments/assets/9c95e2a1-4ef3-48ee-b595-9c27730341be)

## [optional] Are there any post-deployment tasks we need to perform?

none
