### PR TITLE
fix(console): trim output to remove spaces at first char

### DIFF
--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -72,11 +72,11 @@ export function formatConsoleMessage(message: string): string {
     message = message.replace(/\n\/\/ /g, '\n')
     // remove echo
     message = message.replace(/^echo:/g, '')
-    message = message.replace(/^echo: /g, '')
     // replace linebreaks with html <br>
     message = message.replace('\n// ', '<br>')
     message = message.replace(/\r\n|\r|\n/g, '<br>')
-    return message
+
+    return message.trim()
 }
 
 export const convertName = (name: string): string => {


### PR DESCRIPTION
## Description

This PR fix an issue with a space as a first letter in console output.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/user-attachments/assets/3f2cd1f9-d2d8-464c-9b44-138ed943bdaf)

after:
![image](https://github.com/user-attachments/assets/bb9fb0a0-2b99-4972-bda2-bfee57e7f320)

## [optional] Are there any post-deployment tasks we need to perform?

none
