### PR TITLE
fix(extruderPanel): Modified ExtruderControlPanelControl to use _CLIENT_EXTRUDE and _CLIENT_RETRACT for correct extrusion mode after operation

### DIFF
--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -263,13 +263,13 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
     }
 
     sendRetract(): void {
-        const gcode = `M83\nG1 E-${this.feedamount} F${this.feedrate * 60}`
+        const gcode = `_CLIENT_RETRACT LENGTH=${this.feedamount} SPEED=${this.feedrate}`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnRetract' })
     }
 
     sendExtrude(): void {
-        const gcode = `M83\nG1 E${this.feedamount} F${this.feedrate * 60}`
+        const gcode = `_CLIENT_EXTRUDE LENGTH=${this.feedamount} SPEED=${this.feedrate}`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnDetract' })
     }


### PR DESCRIPTION
## Description
This PR changes the way how Extruder Control Panel sends motion requests to the extruder.
Originally, when pressing **EXTRUDE**, the panel would send out this command:
```
M83
G1 E${this.feedamount} F${this.feedrate * 60}
```
**RETRACT** command:
```
M83
G1 E-${this.feedamount} F${this.feedrate * 60}
```
This puts the extruder movements into Relative mode and stays like that until `M82` is emmited, **resulting in unwanted behavior** if using Absolute mode otherwise.

My Pull Request replaces that **EXTRUDE** command with:
```
_CLIENT_EXTRUDE LENGTH=${this.feedamount} SPEED=${this.feedrate}
```
...and **RETRACT** command with:
```
_CLIENT_RETRACT LENGTH=${this.feedamount} SPEED=${this.feedrate}
```
By utilizing `_CLIENT_EXTRUDE` and `_CLIENT_RETRACT` defined in `mainsail.cfg`, we address the issue of movement modes, as these macros take care of **retaining the same movement mode**, and as a bonus it also handles firmware retract and cold extrusion protection.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
none
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings
### Before:
![before](https://github.com/user-attachments/assets/527a4e41-4baf-41b8-b241-5dd2989bfc8d)
### After:
![after](https://github.com/user-attachments/assets/833e48d3-8615-476e-997e-06e943f8b6b1)

(`PROBE_EXTRUSION` checks whether Absolute mode is present)
<!-- Visual changes require screenshots showing the before and after -->

## [optional] Are there any post-deployment tasks we need to perform?
none
<!-- note: PRs with deleted sections will be marked invalid -->


Signed-off-by: Marek Rozemberg <marek.rozembergsk@gmail.com>