### PR TITLE
fix(ExtruderPanel): restore mode after extruding/retracting

### DIFF
--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -261,17 +261,15 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
             this.setFeedamount({ value: this.maxExtrudeOnlyDistance })
         }
     }
-    private counter: number = 0;
+
     sendRetract(): void {
-        this.counter++;
-        const gcode = `SAVE_GCODE_STATE NAME=mainsail_ui_retract${this.counter}\nM83\nG1 E-${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=mainsail_ui_retract${this.counter}`
+        const gcode = `SAVE_GCODE_STATE NAME=ui_retract\nM83\nG1 E-${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=ui_retract`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnRetract' })
     }
 
     sendExtrude(): void {
-        this.counter++;
-        const gcode = `SAVE_GCODE_STATE NAME=mainsail_ui_extrude${this.counter}\nM83\nG1 E${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=mainsail_ui_extrude${this.counter}`
+        const gcode = `SAVE_GCODE_STATE NAME=ui_extrude\nM83\nG1 E${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=ui_extrude`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnDetract' })
     }

--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -263,13 +263,21 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
     }
 
     sendRetract(): void {
-        const gcode = `SAVE_GCODE_STATE NAME=ui_retract\nM83\nG1 E-${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=ui_retract`
+        const gcode =
+            `SAVE_GCODE_STATE NAME=ui_retract\n` +
+            `M83\n` +
+            `G1 E-${this.feedamount} F${this.feedrate * 60}\n` +
+            `RESTORE_GCODE_STATE NAME=ui_retract`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnRetract' })
     }
 
     sendExtrude(): void {
-        const gcode = `SAVE_GCODE_STATE NAME=ui_extrude\nM83\nG1 E${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=ui_extrude`
+        const gcode =
+            `SAVE_GCODE_STATE NAME=ui_extrude\n` +
+            `M83\n` +
+            `G1 E${this.feedamount} F${this.feedrate * 60}\n` +
+            `RESTORE_GCODE_STATE NAME=ui_extrude`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnDetract' })
     }

--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -261,15 +261,17 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
             this.setFeedamount({ value: this.maxExtrudeOnlyDistance })
         }
     }
-
+    private counter: number = 0;
     sendRetract(): void {
-        const gcode = `M83\nG1 E-${this.feedamount} F${this.feedrate * 60}`
+        this.counter++;
+        const gcode = `SAVE_GCODE_STATE NAME=mainsail_ui_retract${this.counter}\nM83\nG1 E-${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=mainsail_ui_retract${this.counter}`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnRetract' })
     }
 
     sendExtrude(): void {
-        const gcode = `M83\nG1 E${this.feedamount} F${this.feedrate * 60}`
+        this.counter++;
+        const gcode = `SAVE_GCODE_STATE NAME=mainsail_ui_extrude${this.counter}\nM83\nG1 E${this.feedamount} F${this.feedrate * 60}\nRESTORE_GCODE_STATE NAME=mainsail_ui_extrude${this.counter}`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnDetract' })
     }


### PR DESCRIPTION
## Description

This PR restores the gcode state to the state before the extrusion, triggered through the UI, happenend.

The old behavior changes the extrusion mode and can create problems with absolute extrusion setups.
The new behavior saves the state with `SAVE_GCODE_STATE` an unique name and restores this state with `RESTORE_GCODE_STATE` after the extrusion happened.

## Related Tickets & Documents

This extends on the idea of #1964 but uses only Klipper built in commands to make this more generic.

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
