### PR TITLE
feat(console): add option for RAW-output (for debugging)

### DIFF
--- a/src/components/console/ConsoleTableEntry.vue
+++ b/src/components/console/ConsoleTableEntry.vue
@@ -1,7 +1,13 @@
 <template>
     <v-row :class="entryStyle">
         <v-col class="col-auto pr-0 text--disabled console-time">{{ entryFormatTime }}</v-col>
-        <v-col :class="messageClass" style="min-width: 0" @click.capture="commandClick" v-html="event.formatMessage" />
+        <v-col
+            v-if="!rawOutput"
+            :class="messageClass"
+            style="min-width: 0"
+            @click.capture="commandClick"
+            v-html="event.formatMessage" />
+        <v-col v-else :class="messageClass" style="min-width: 0" @click.capture="commandClick" v-text="event.message" />
     </v-row>
 </template>
 
@@ -36,6 +42,10 @@ export default class ConsoleTableEntry extends Mixins(BaseMixin) {
         else classes.push('text--primary')
 
         return classes
+    }
+
+    get rawOutput() {
+        return this.$store.state.gui.console.rawOutput ?? false
     }
 
     commandClick(event: Event) {

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -50,6 +50,13 @@
                             :label="filter.name"
                             @change="toggleFilter(filter)" />
                     </v-list-item>
+                    <v-list-item class="minHeight36">
+                        <v-checkbox
+                            v-model="rawOutput"
+                            class="mt-0"
+                            hide-details
+                            :label="$t('Panels.MiniconsolePanel.RawOutput')" />
+                    </v-list-item>
                 </v-list>
             </v-menu>
         </template>
@@ -202,6 +209,14 @@ export default class MiniconsolePanel extends Mixins(BaseMixin) {
 
     set autoscroll(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'console.autoscroll', value: newVal })
+    }
+
+    get rawOutput(): boolean {
+        return this.$store.state.gui.console.rawOutput ?? false
+    }
+
+    set rawOutput(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'console.rawOutput', value: newVal })
     }
 
     commandClick(msg: string): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -663,6 +663,7 @@
             "Headline": "Console",
             "HideTemperatures": "Hide temperatures",
             "HideTimelapse": "Hide Timelapse",
+            "RawOutput": "RAW-Output (for debugging)",
             "SendCode": "Send code...",
             "SetupConsole": "Setup Console"
         },

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -71,6 +71,13 @@
                                 :label="filter.name"
                                 @change="toggleFilter(filter)" />
                         </v-list-item>
+                        <v-list-item class="minHeight36">
+                            <v-checkbox
+                                v-model="rawOutput"
+                                class="mt-0"
+                                hide-details
+                                :label="$t('Panels.MiniconsolePanel.RawOutput')" />
+                        </v-list-item>
                     </v-list>
                 </v-menu>
             </v-col>
@@ -191,6 +198,14 @@ export default class PageConsole extends Mixins(BaseMixin) {
 
     set autoscroll(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'console.autoscroll', value: newVal })
+    }
+
+    get rawOutput(): boolean {
+        return this.$store.state.gui.console.rawOutput ?? false
+    }
+
+    set rawOutput(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'console.rawOutput', value: newVal })
     }
 
     commandClick(msg: string): void {

--- a/src/store/gui/console/index.ts
+++ b/src/store/gui/console/index.ts
@@ -13,6 +13,7 @@ export const getDefaultState = (): GuiConsoleState => {
         height: 300,
         autoscroll: true,
         consolefilters: {},
+        rawOutput: false,
     }
 }
 

--- a/src/store/gui/console/types.ts
+++ b/src/store/gui/console/types.ts
@@ -9,6 +9,7 @@ export interface GuiConsoleState {
     consolefilters: {
         [key: string]: GuiConsoleStateFilter
     }
+    rawOutput: boolean
 }
 
 export interface GuiConsoleStateFilter {


### PR DESCRIPTION
## Description

This PR adds an option to display all console outputs without filtering prefixes or something similar. This could help to create better filter regex rules, because you see prefixes like `//` or `!!`.

## Related Tickets & Documents

I came up with this idea during a conversation in the Mainsail Discord: https://discord.com/channels/758059413700345988/1273211754423521323

## Mobile & Desktop Screenshots/Recordings

without raw-output:
![image](https://github.com/user-attachments/assets/8da1129a-2dfa-4601-bcca-cc5b6ec9a7a6)

with raw-output:
![image](https://github.com/user-attachments/assets/5ecd645f-6fe6-4c8f-b6ac-0079f2037b9c)


## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
