### PR TITLE
fix(webcam): fix memory leak in MJPEGStreamer client

### DIFF
--- a/src/components/webcams/WebcamWrapperItem.vue
+++ b/src/components/webcams/WebcamWrapperItem.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <template v-if="service === 'mjpegstreamer'">
-            <mjpegstreamer-async :cam-settings="webcam" :show-fps="showFps" :printer-url="printerUrl" />
+            <mjpegstreamer-async :cam-settings="webcam" :show-fps="showFps" :printer-url="printerUrl" :page="page" />
         </template>
         <template v-else-if="service === 'mjpegstreamer-adaptive'">
             <mjpegstreamer-adaptive-async :cam-settings="webcam" :show-fps="showFps" :printer-url="printerUrl" />

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -51,6 +51,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     @Prop({ required: true }) readonly camSettings!: GuiWebcamStateWebcam
     @Prop({ default: null }) readonly printerUrl!: string | null
     @Prop({ default: true }) declare showFps: boolean
+    @Prop({ type: String, default: null }) readonly page!: string | null
 
     @Ref('image') readonly image!: HTMLImageElement
 
@@ -86,6 +87,23 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
         if (!this.showFps) return false
 
         return !(this.camSettings.extra_data?.hideFps ?? false)
+    }
+
+    get expanded(): boolean {
+        if (this.page !== 'dashboard') return true
+
+        return this.$store.getters['gui/getPanelExpand']('webcam-panel', this.viewport) ?? false
+    }
+
+    // start or stop the video when the expanded state changes
+    @Watch('expanded')
+    expandChanged(newExpanded: boolean): void {
+        if (!newExpanded) {
+            this.stopStream()
+            return
+        }
+
+        this.startStream()
     }
 
     log(msg: string, obj?: any) {

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -22,9 +22,9 @@
 
 <script lang="ts">
 import Component from 'vue-class-component'
-import { Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
+import {Mixins, Prop, Ref, Watch} from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
+import {GuiWebcamStateWebcam} from '@/store/gui/webcams/types'
 import WebcamMixin from '@/components/mixins/webcam'
 
 const CONTENT_LENGTH = 'content-length'
@@ -235,9 +235,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                     }
 
                     // we're done reading the jpeg. Time to render it.
-                    const frame = URL.createObjectURL(new Blob([imageBuffer], { type: TYPE_JPEG }))
-                    if (this.image) this.image.src = frame
-                    this.image.onload = () => URL.revokeObjectURL(frame)
+                    this.image?.src = 'data:image/jpeg;base64,' + btoa(String.fromCharCode.apply(null, imageBuffer))
                     this.frames++
                     contentLength = 0
                     bytesRead = 0

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -229,7 +229,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
         try {
             await this.reader?.cancel()
         } catch (error) {
-            this.log('Fehler beim Abbrechen des Readers:', error)
+            this.log('Error cancelling reader:', error)
         } finally {
             this.reader?.releaseLock()
         }

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -22,9 +22,9 @@
 
 <script lang="ts">
 import Component from 'vue-class-component'
-import {Mixins, Prop, Ref, Watch} from 'vue-property-decorator'
+import { Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import {GuiWebcamStateWebcam} from '@/store/gui/webcams/types'
+import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
 import WebcamMixin from '@/components/mixins/webcam'
 
 const CONTENT_LENGTH = 'content-length'
@@ -33,13 +33,13 @@ const SOI = new Uint8Array(2)
 SOI[0] = 0xff
 SOI[1] = 0xd8
 
-function uint8ArrayToBase64(uint8Array) {
-    let binary = '';
-    const len = uint8Array.byteLength;
+function uint8ArrayToBase64(uint8Array: Uint8Array) {
+    let binary = ''
+    const len = uint8Array.byteLength
     for (let i = 0; i < len; i++) {
-        binary += String.fromCharCode(uint8Array[i]);
+        binary += String.fromCharCode(uint8Array[i])
     }
-    return window.btoa(binary);
+    return window.btoa(binary)
 }
 
 @Component

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -235,7 +235,9 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                     }
 
                     // we're done reading the jpeg. Time to render it.
-                    this.image?.src = 'data:image/jpeg;base64,' + btoa(String.fromCharCode.apply(null, imageBuffer))
+                    if (this.image) {
+                        this.image.src = 'data:image/jpeg;base64,' + btoa(Array.from(imageBuffer).map(byte => String.fromCharCode(byte)).join(''))
+                    }
                     this.frames++
                     contentLength = 0
                     bytesRead = 0

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -28,11 +28,19 @@ import {GuiWebcamStateWebcam} from '@/store/gui/webcams/types'
 import WebcamMixin from '@/components/mixins/webcam'
 
 const CONTENT_LENGTH = 'content-length'
-const TYPE_JPEG = 'image/jpeg'
 
 const SOI = new Uint8Array(2)
 SOI[0] = 0xff
 SOI[1] = 0xd8
+
+function uint8ArrayToBase64(uint8Array) {
+    let binary = '';
+    const len = uint8Array.byteLength;
+    for (let i = 0; i < len; i++) {
+        binary += String.fromCharCode(uint8Array[i]);
+    }
+    return window.btoa(binary);
+}
 
 @Component
 export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
@@ -205,7 +213,6 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
             let headers = ''
             let contentLength = -1
             let imageBuffer: Uint8Array = new Uint8Array(0)
-            const decoder = new TextDecoder('latin1');
             let bytesRead = 0
 
             let done: boolean | null = null
@@ -237,7 +244,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
                     // we're done reading the jpeg. Time to render it.
                     if (this.image) {
-                        this.image.src = 'data:image/jpeg;base64,' + btoa(decoder.decode(imageBuffer))
+                        this.image.src = 'data:image/jpeg;base64,' + uint8ArrayToBase64(imageBuffer)
                     }
                     this.frames++
                     contentLength = 0

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -165,9 +165,6 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                 return
             }
 
-            this.status = 'connected'
-            this.statusMessage = ''
-
             this.timerFPS = window.setInterval(() => {
                 this.currentFPS = this.frames
                 this.frames = 0
@@ -239,6 +236,12 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                         const objectURL = URL.createObjectURL(new Blob([imageBuffer], { type: 'image/jpeg' }))
                         this.image.src = objectURL
                         skipFrame = true
+
+                        // update status to 'connected' if the first frame is received
+                        if (this.status !== 'connected') {
+                            this.status = 'connected'
+                            this.statusMessage = ''
+                        }
 
                         this.image.onload = () => {
                             URL.revokeObjectURL(objectURL)

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -205,6 +205,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
             let headers = ''
             let contentLength = -1
             let imageBuffer: Uint8Array = new Uint8Array(0)
+            const decoder = new TextDecoder('latin1');
             let bytesRead = 0
 
             let done: boolean | null = null
@@ -236,7 +237,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
                     // we're done reading the jpeg. Time to render it.
                     if (this.image) {
-                        this.image.src = 'data:image/jpeg;base64,' + btoa(Array.from(imageBuffer).map(byte => String.fromCharCode(byte)).join(''))
+                        this.image.src = 'data:image/jpeg;base64,' + btoa(decoder.decode(imageBuffer))
                     }
                     this.frames++
                     contentLength = 0

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -46,7 +46,6 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     aspectRatio: null | number = null
     timerFPS: number | null = null
     timerRestart: number | null = null
-    reader: ReadableStreamDefaultReader<Uint8Array> | null = null
 
     @Prop({ required: true }) readonly camSettings!: GuiWebcamStateWebcam
     @Prop({ default: null }) readonly printerUrl!: string | null
@@ -54,6 +53,12 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     @Prop({ type: String, default: null }) readonly page!: string | null
 
     @Ref('image') readonly image!: HTMLImageElement
+
+    private reader: ReadableStreamDefaultReader<Uint8Array> | null
+    constructor() {
+        super()
+        this.reader = null
+    }
 
     get url() {
         return this.convertUrl(this.camSettings?.stream_url, this.printerUrl)

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -148,7 +148,11 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
         try {
             //readable stream credit to from https://github.com/aruntj/mjpeg-readable-stream
-            let response: Response | null = await fetch(this.url, { mode: 'cors' })
+
+            const url = new URL(this.url)
+            url.searchParams.append('timestamp', new Date().getTime().toString())
+
+            let response: Response | null = await fetch(url.toString(), { mode: 'cors' })
 
             if (!response.ok) {
                 this.log(`${response.status}: ${response.statusText}`)

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -247,7 +247,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                             URL.revokeObjectURL(objectURL)
                             skipFrame = false
                         }
-                    } else this.log('Skipping frame')
+                    }
                     this.frames++
                     contentLength = 0
                     bytesRead = 0

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -5,6 +5,8 @@
             v-observe-visibility="viewportVisibilityChanged"
             class="webcamImage"
             :style="webcamStyle"
+            :alt="camSettings.name"
+            src="#"
             @load="onload" />
         <span v-if="showFpsCounter" class="webcamFpsOutput">{{ $t('Panels.WebcamPanel.FPS') }}: {{ fpsOutput }}</span>
     </div>
@@ -12,7 +14,7 @@
 
 <script lang="ts">
 import Component from 'vue-class-component'
-import { Mixins, Prop, Watch } from 'vue-property-decorator'
+import { Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
 import WebcamMixin from '@/components/mixins/webcam'
@@ -20,29 +22,36 @@ import WebcamMixin from '@/components/mixins/webcam'
 const CONTENT_LENGTH = 'content-length'
 const TYPE_JPEG = 'image/jpeg'
 
+const SOI = new Uint8Array(2)
+SOI[0] = 0xff
+SOI[1] = 0xd8
+
+// variables to read the stream
+let headers = ''
+let contentLength = -1
+let imageBuffer: Uint8Array = new Uint8Array(0)
+let bytesRead = 0
+
 @Component
 export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
-    private currentFPS = 0
-    private streamState = false
-    private aspectRatio: null | number = null
-    // eslint-disable-next-line no-undef
-    private timerFPS: NodeJS.Timeout | null = null
-    // eslint-disable-next-line no-undef
-    private timerRestart: NodeJS.Timeout | null = null
-    private stream: ReadableStream | null = null
-    private controller: AbortController | null = null
-    private isVisibleViewport = false
-    private isVisibleDocument = true
+    // current read stream frames counter
+    frames = 0
+    // current displayed fps
+    currentFPS = 0
+    streamState = false
+    aspectRatio: null | number = null
+    timerFPS: number | null = null
+    timerRestart: number | null = null
+    //stream: ReadableStream | null = null
+    reader: ReadableStreamDefaultReader<Uint8Array> | undefined = undefined
+    isVisibleViewport = false
+    isVisibleDocument = true
 
     @Prop({ required: true }) readonly camSettings!: GuiWebcamStateWebcam
     @Prop({ default: null }) readonly printerUrl!: string | null
-
     @Prop({ default: true }) declare showFps: boolean
 
-    declare $refs: {
-        canvas: HTMLCanvasElement
-        image: HTMLImageElement
-    }
+    @Ref('image') readonly image!: HTMLImageElement
 
     get url() {
         return this.convertUrl(this.camSettings?.stream_url, this.printerUrl)
@@ -69,7 +78,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     }
 
     get fpsOutput() {
-        return this.currentFPS < 10 ? '0' + this.currentFPS.toString() : this.currentFPS
+        return this.currentFPS.toString().padStart(2, '0')
     }
 
     get showFpsCounter() {
@@ -78,106 +87,121 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
         return !(this.camSettings.extra_data?.hideFps ?? false)
     }
 
-    startStream() {
-        if (this.streamState) return
-        this.streamState = true
-
-        const SOI = new Uint8Array(2)
-        SOI[0] = 0xff
-        SOI[1] = 0xd8
-
-        function getLength(headers: any) {
-            let contentLength = -1
-            headers.split('\n').forEach((header: any) => {
-                const pair = header.split(':')
-                if (pair[0].toLowerCase() === CONTENT_LENGTH) {
-                    // Fix for issue https://github.com/aruntj/mjpeg-readable-stream/issues/3 suggested by martapanc
-                    contentLength = pair[1]
-                }
-            })
-            return contentLength
+    log(msg: string, obj?: any) {
+        if (obj) {
+            window.console.log(`[MJPEG streamer] ${msg}`, obj)
+            return
         }
 
-        this.controller = new AbortController()
-        const { signal } = this.controller
+        window.console.log(`[MJPEG streamer] ${msg}`)
+    }
 
-        //readable stream credit to from https://github.com/aruntj/mjpeg-readable-stream
-        fetch(this.url, { signal, mode: 'cors' })
-            .then((response) => response.body)
-            .then((rb) => {
-                const reader = rb?.getReader()
+    getLength(headers: any) {
+        let contentLength = -1
+        headers.split('\n').forEach((header: any) => {
+            const pair = header.split(':')
+            if (pair[0].toLowerCase() === CONTENT_LENGTH) {
+                // Fix for issue https://github.com/aruntj/mjpeg-readable-stream/issues/3 suggested by martapanc
+                contentLength = pair[1]
+            }
+        })
+        return contentLength
+    }
 
-                let headers = ''
-                let contentLength = -1
-                let imageBuffer: any = null
-                let bytesRead = 0
-                const img = this.$refs.image
+    async startStream() {
+        if (this.streamState) {
+            this.log('stream already started')
+            return
+        }
+        this.streamState = true
 
-                // calculating fps. This is pretty lame. Should probably implement a floating window function.
-                let frames = 0
+        // reset counter and timeout/interval
+        this.clearTimeouts()
 
-                this.timerFPS = setInterval(() => {
-                    this.currentFPS = frames
-                    frames = 0
-                }, 1000)
+        try {
+            //readable stream credit to from https://github.com/aruntj/mjpeg-readable-stream
+            const response = await fetch(this.url, { mode: 'cors' })
 
-                this.timerRestart = setInterval(() => {
-                    this.restartStream()
-                }, 60000)
+            if (!response.ok) {
+                this.log(`${response.status}: ${response.statusText}`)
+                await this.stopStream()
+                return
+            }
 
-                this.stream = new ReadableStream({
-                    start(controller) {
-                        // The following function handles each data chunk
-                        const pump = (): any => {
-                            // "done" is a Boolean and value a "Uint8Array"
-                            return reader?.read().then(({ done, value }) => {
-                                // If there is no more data to read
-                                if (done) {
-                                    controller.close()
-                                    return
-                                }
-                                // Get the data and send it to the browser via the controller
-                                controller.enqueue(value)
+            if (!response.body) {
+                this.log('ReadableStream not yet supported in this browser.')
+                await this.stopStream()
+                return
+            }
 
-                                if (value) {
-                                    for (let index = 0; index < value.length; index++) {
-                                        // we've found start of the frame. Everything we've read till now is the header.
-                                        if (value[index] === SOI[0] && value[index + 1] === SOI[1]) {
-                                            contentLength = getLength(headers)
-                                            imageBuffer = new Uint8Array(new ArrayBuffer(contentLength))
-                                        }
-                                        // we're still reading the header.
-                                        if (contentLength <= 0) {
-                                            headers += String.fromCharCode(value[index])
-                                        }
-                                        // we're now reading the jpeg.
-                                        else if (bytesRead < contentLength) {
-                                            imageBuffer[bytesRead++] = value[index]
-                                        }
-                                        // we're done reading the jpeg. Time to render it.
-                                        else {
-                                            if (img) {
-                                                img.src = URL.createObjectURL(
-                                                    new Blob([imageBuffer], { type: TYPE_JPEG })
-                                                )
-                                                img.onload = () => URL.revokeObjectURL(img.src)
-                                            }
-                                            frames++
-                                            contentLength = 0
-                                            bytesRead = 0
-                                            headers = ''
-                                        }
-                                    }
-                                }
+            this.timerFPS = window.setInterval(() => {
+                this.currentFPS = this.frames
+                this.frames = 0
+            }, 1000)
 
-                                return pump()
-                            })
-                        }
+            this.timerRestart = window.setTimeout(() => {
+                this.restartStream()
+            }, 10000)
 
-                        return pump()
-                    },
-                })
-            })
+            this.log('start read stream')
+            this.reader = response.body?.getReader()
+            this.readStream()
+        } catch (error: any) {
+            this.log(error.message)
+        }
+    }
+
+    async readStream() {
+        // stop if the stream is not ready
+        if (!this.reader) return
+
+        try {
+            const { done, value } = await this.reader.read()
+            if (done) {
+                this.log('done')
+                return
+            }
+
+            // stop if the stream has no value
+            if (!value) {
+                this.log('no value')
+                this.readStream()
+                return
+            }
+
+            for (let index = 0; index < value.length; index++) {
+                // we've found the start of the frame. Everything we've read till now is the header.
+                if (value[index] === SOI[0] && value[index + 1] === SOI[1]) {
+                    contentLength = this.getLength(headers)
+                    imageBuffer = new Uint8Array(new ArrayBuffer(contentLength))
+                }
+
+                // we're still reading the header.
+                if (contentLength <= 0) {
+                    headers += String.fromCharCode(value[index])
+                    continue
+                }
+
+                // we're now reading the jpeg.
+                if (bytesRead < contentLength) {
+                    imageBuffer[bytesRead++] = value[index]
+                    continue
+                }
+
+                // we're done reading the jpeg. Time to render it.
+                const frame = URL.createObjectURL(new Blob([imageBuffer], { type: TYPE_JPEG }))
+                this.image.src = frame
+                this.image.onload = () => URL.revokeObjectURL(frame)
+                this.frames++
+                contentLength = 0
+                bytesRead = 0
+                headers = ''
+            }
+
+            this.readStream()
+        } catch (error: any) {
+            this.log(`readStream error: ${error.message ?? ''}`, error)
+        }
     }
 
     mounted() {
@@ -190,18 +214,35 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
         this.stopStream()
     }
 
-    stopStream() {
+    clearTimeouts() {
+        this.frames = 0
+        if (this.timerFPS) {
+            window.clearInterval(this.timerFPS)
+            this.timerFPS = null
+        }
+        if (this.timerRestart) {
+            window.clearTimeout(this.timerRestart)
+            this.timerRestart = null
+        }
+    }
+
+    async stopStream() {
         this.streamState = false
-        URL.revokeObjectURL(this.url)
-        if (this.timerFPS) clearTimeout(this.timerFPS)
-        if (this.timerRestart) clearTimeout(this.timerRestart)
-        this.controller?.abort()
-        this.stream?.cancel()
+
+        this.clearTimeouts()
+
+        try {
+            await this.reader?.cancel()
+        } catch (error) {
+            this.log('Fehler beim Abbrechen des Readers:', error)
+        } finally {
+            this.reader?.releaseLock()
+        }
     }
 
     async restartStream() {
-        this.stopStream()
-        this.startStream()
+        await this.stopStream()
+        await this.startStream()
     }
 
     @Watch('camSettings', { immediate: true, deep: true })
@@ -235,9 +276,9 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
     }
 
     onload() {
-        if (this.aspectRatio !== null || !this.$refs.image) return
+        if (this.aspectRatio !== null || !this.image) return
 
-        this.aspectRatio = this.$refs.image.naturalWidth / this.$refs.image.naturalHeight
+        this.aspectRatio = this.image.naturalWidth / this.image.naturalHeight
     }
 }
 </script>

--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -110,7 +110,6 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
     async startStream() {
         if (this.streamState) {
-            this.log('stream already started')
             return
         }
         this.streamState = true
@@ -143,7 +142,6 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
                 this.restartStream()
             }, 10000)
 
-            this.log('start read stream')
             this.reader = response.body?.getReader()
             this.readStream()
         } catch (error: any) {
@@ -157,10 +155,7 @@ export default class Mjpegstreamer extends Mixins(BaseMixin, WebcamMixin) {
 
         try {
             const { done, value } = await this.reader.read()
-            if (done) {
-                this.log('done')
-                return
-            }
+            if (done) return
 
             // stop if the stream has no value
             if (!value) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -813,6 +813,9 @@
         },
         "WebcamPanel": {
             "All": "All",
+            "ConnectingTo": "Connecting to {url}",
+            "Disconnected": "Disconnected",
+            "ErrorWhileConnecting": "Error while connecting to {url}",
             "FPS": "FPS",
             "Headline": "Webcam",
             "NoWebcam": "No webcam available. Add a webcam under \"Interface Settings\" -> \"Webcams\".",


### PR DESCRIPTION
## Description

This PR fixes a memory leak in the Mjpeg-Streamer client with Firefox.

## Related Tickets & Documents

fixes: #904 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
