### PR TITLE
refactor(ExtruderPanel): add `_` prefix to gcode_state name

### DIFF
--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -93,7 +93,7 @@
                             <template #activator="{ on }">
                                 <div v-on="on">
                                     <v-btn
-                                        :loading="loadings.includes('btnDetract')"
+                                        :loading="loadings.includes('btnExtrude')"
                                         :disabled="!extrudePossible || tooLargeExtrusion || printerIsPrintingOnly"
                                         small
                                         class="_btn-extruder-cmd"
@@ -157,7 +157,7 @@
                                     <template #activator="{ on }">
                                         <div class="pt-1 pb-2 px-3" v-on="on">
                                             <v-btn
-                                                :loading="loadings.includes('btnDetract')"
+                                                :loading="loadings.includes('btnExtrude')"
                                                 :disabled="
                                                     !extrudePossible || tooLargeExtrusion || printerIsPrintingOnly
                                                 "
@@ -263,23 +263,22 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
     }
 
     sendRetract(): void {
-        const gcode =
-            `SAVE_GCODE_STATE NAME=ui_retract\n` +
-            `M83\n` +
-            `G1 E-${this.feedamount} F${this.feedrate * 60}\n` +
-            `RESTORE_GCODE_STATE NAME=ui_retract`
-        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnRetract' })
+        this.sendCommand(this.feedamount * -1, 'btnRetract')
     }
 
     sendExtrude(): void {
+        this.sendCommand(this.feedamount, 'btnExtrude')
+    }
+
+    sendCommand(length: number, loading: string): void {
         const gcode =
-            `SAVE_GCODE_STATE NAME=ui_extrude\n` +
+            `SAVE_GCODE_STATE NAME=_ui_extrude\n` +
             `M83\n` +
-            `G1 E${this.feedamount} F${this.feedrate * 60}\n` +
-            `RESTORE_GCODE_STATE NAME=ui_extrude`
+            `G1 E${length} F${this.feedrate * 60}\n` +
+            `RESTORE_GCODE_STATE NAME=_ui_extrude`
+
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'btnDetract' })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading })
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR combine the sendRetract & sendExtrude function and add a `_` as prefix to the gcode_state.

## Related Tickets & Documents

Suggestion from @pedrolamas in the control panel PR: https://github.com/mainsail-crew/mainsail/pull/1988#discussion_r1741707530

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
