### PR TITLE
feat: add output on connection dialog for unauthorized

### DIFF
--- a/src/components/TheConnectingDialog.vue
+++ b/src/components/TheConnectingDialog.vue
@@ -1,35 +1,30 @@
-<style scoped></style>
-
 <template>
     <v-dialog v-model="showDialog" persistent :width="400">
-        <v-card>
-            <v-toolbar flat dense>
-                <v-toolbar-title>
-                    <span class="subheading">
-                        <v-icon left>{{ mdiConnection }}</v-icon>
-                        {{ titleText }}
-                    </span>
-                </v-toolbar-title>
-            </v-toolbar>
+        <panel :title="titleText" :icon="mdiConnection" card-class="the-connection-dialog" :margin-bottom="false">
             <v-card-text v-if="connectingFailed" class="pt-5">
-                <connection-status :moonraker="false"></connection-status>
-                <p class="text-center mt-3">{{ $t('ConnectionDialog.CannotConnectTo', { host: formatHostname }) }}</p>
+                <connection-status :moonraker="false" />
+                <p class="text-center mt-3 mb-0">
+                    {{ $t('ConnectionDialog.CannotConnectTo', { host: formatHostname }) }}
+                </p>
+                <p v-if="connectionFailedMessage" class="text-center mt-1 red--text">
+                    {{ $t('ConnectionDialog.ErrorMessage', { message: connectionFailedMessage }) }}
+                </p>
                 <template v-if="counter > 2">
-                    <v-divider class="my-3"></v-divider>
+                    <v-divider class="my-3" />
                     <p>{{ $t('ConnectionDialog.CheckMoonrakerLog') }}</p>
                     <ul>
                         <li>~/printer_data/logs/moonraker.log</li>
                     </ul>
-                    <v-divider class="mt-4 mb-5"></v-divider>
+                    <v-divider class="mt-4 mb-5" />
                 </template>
-                <div class="text-center">
+                <div class="text-center mt-3">
                     <v-btn class="primary--text" @click="reconnect">{{ $t('ConnectionDialog.TryAgain') }}</v-btn>
                 </div>
             </v-card-text>
             <v-card-text v-else class="pt-5">
-                <v-progress-linear :color="progressBarColor" indeterminate></v-progress-linear>
+                <v-progress-linear :color="progressBarColor" indeterminate />
             </v-card-text>
-        </v-card>
+        </panel>
     </v-dialog>
 </template>
 
@@ -51,10 +46,6 @@ export default class TheConnectingDialog extends Mixins(BaseMixin, ThemeMixin) {
     mdiConnection = mdiConnection
 
     counter = 0
-
-    get protocol() {
-        return this.$store.state.socket.protocol
-    }
 
     get hostname() {
         return this.$store.state.socket.hostname
@@ -92,6 +83,10 @@ export default class TheConnectingDialog extends Mixins(BaseMixin, ThemeMixin) {
         if (!this.guiIsReady) return this.$t('ConnectionDialog.Initializing')
 
         return this.formatHostname
+    }
+
+    get connectionFailedMessage() {
+        return this.$store.state.socket.connectionFailedMessage ?? null
     }
 
     reconnect() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -154,6 +154,7 @@
         "CannotConnectTo": "Cannot connect to Moonraker ({host}).",
         "CheckMoonrakerLog": "If this message appears repeatedly, please have a look in the log file located at:",
         "Connecting": "Connecting to {host}",
+        "ErrorMessage": "Error message: {message}",
         "Failed": "Connection failed",
         "Initializing": "Initializing",
         "TryAgain": "try again"

--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -36,6 +36,11 @@ export class WebSocketClient {
                 window.console.error(`Response Error: ${data.error.message} (${wait?.action ?? 'no action'})`)
             }
 
+            if (data.error.message === 'Unauthorized' && wait?.action === 'server/setConnectionId') {
+                this.close()
+                this.store?.dispatch('socket/setConnectionFailed', data.error.message)
+            }
+
             if (wait?.id) {
                 const modulename = wait.action?.split('/')[1] ?? null
 

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -173,4 +173,8 @@ export const actions: ActionTree<SocketState, RootState> = {
     reportDebug(_, payload) {
         window.console.log(payload)
     },
+
+    setConnectionFailed({ commit }, payload) {
+        commit('setDisconnected', payload)
+    },
 }

--- a/src/store/socket/index.ts
+++ b/src/store/socket/index.ts
@@ -20,6 +20,7 @@ export const getDefaultState = (): SocketState => {
         isConnected: false,
         isConnecting: false,
         connectingFailed: false,
+        connectionFailedMessage: null,
         loadings: [],
         initializationList: ['server'],
         connection_id: null,

--- a/src/store/socket/mutations.ts
+++ b/src/store/socket/mutations.ts
@@ -16,11 +16,13 @@ export const mutations: MutationTree<SocketState> = {
         Vue.set(state, 'connectingFailed', false)
     },
 
-    setDisconnected(state) {
+    setDisconnected(state, message?: string) {
         Vue.set(state, 'isConnected', false)
         Vue.set(state, 'isConnecting', false)
         Vue.set(state, 'connectingFailed', true)
         Vue.set(state, 'connection_id', null)
+
+        if (message) Vue.set(state, 'connectionFailedMessage', message)
     },
 
     setData(state, payload) {

--- a/src/store/socket/types.ts
+++ b/src/store/socket/types.ts
@@ -7,6 +7,7 @@ export interface SocketState {
     isConnected: boolean
     isConnecting: boolean
     connectingFailed: boolean
+    connectionFailedMessage: string | null
     loadings: string[]
     initializationList: string[]
     connection_id: number | null


### PR DESCRIPTION
## Description

This PR adds an output for "Unauthorized" connections on the ConnectionDialog. Without this PR, the user would only see an endless initialize dialog.

## Related Tickets & Documents

fixes #1971 

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/user-attachments/assets/ba3a0f0e-a3e9-49b2-a642-b6ba75202552)

after:
![image](https://github.com/user-attachments/assets/ab364fbf-5669-474a-b5bf-45e8b96e39eb)

## [optional] Are there any post-deployment tasks we need to perform?

none
