### PR TITLE
fix: correct github commit after link in commit list

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
+++ b/src/components/panels/Machine/UpdatePanel/GitCommitsList.vue
@@ -103,7 +103,7 @@ export default class GitCommitsList extends Mixins(BaseMixin) {
     }
 
     get linkToGithub() {
-        return `https://github.com/${this.repo?.owner}/${this.repo?.name}/commits/${this.repo?.branch}/?after=${this.lastCommit?.sha}+0`
+        return `https://github.com/${this.repo?.owner}/${this.repo?.repo_name}/commits/${this.repo?.branch}/?after=${this.lastCommit?.sha}+0`
     }
 
     get overlayScrollbarsStyle() {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Fixes an incorrect GitHub URL when the Moonraker `update_manager` extension name does not match the GitHub repo name.

Given the following update manager extension config ([which is the one LED Effects for Klipper uses](https://github.com/julianschill/klipper-led_effect/blob/master/file_templates/moonraker_update.txt))
```ini
[update_manager led_effect]
type: git_repo
path: ~/klipper-led_effect
origin: https://github.com/julianschill/klipper-led_effect.git
is_system_service: False
```
The change corrects the "Link to GitHub" buttton's address from
https://github.com/julianschill/led_effect/commits/master/?after=bde44b49246a0fe7b50d41e415d71e8f966d9542+0
to
https://github.com/julianschill/klipper-led_effect/commits/master/?after=bde44b49246a0fe7b50d41e415d71e8f966d9542+0

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
none

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots showing the before and after -->
none

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
none