### PR TITLE
feat(Heightmap): add option to set the default orientation

### DIFF
--- a/src/components/charts/HeightmapChart.vue
+++ b/src/components/charts/HeightmapChart.vue
@@ -6,7 +6,7 @@
         style="height: 600px; width: 100%; overflow: hidden" />
 </template>
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Ref } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import BedmeshMixin from '@/components/mixins/bedmesh'
 
@@ -42,11 +42,6 @@ interface HeightmapSerie {
 
 @Component
 export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, ThemeMixin) {
-    declare $refs: {
-        // eslint-disable-next-line
-        heightmap: any
-    }
-
     @Prop({ type: Boolean, default: false }) showProbed!: boolean
     @Prop({ type: Boolean, default: false }) showMesh!: boolean
     @Prop({ type: Boolean, default: false }) showFlat!: boolean
@@ -54,8 +49,10 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
     @Prop({ type: Boolean, default: false }) scaleGradient!: boolean
     @Prop({ type: Number, default: 1 }) scaleZMax!: number
 
+    @Ref('heightmap') heightmap!: any
+
     get chart(): ECharts | null {
-        return this.$refs.heightmap?.chart ?? null
+        return this.heightmap?.chart ?? null
     }
 
     get chartOptions() {
@@ -151,7 +148,10 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
                 },
                 boxWidth: 100 * this.scaleX,
                 boxDepth: 100 * this.scaleY,
-                viewControl: { distance: 150 },
+                viewControl: {
+                    distance: 150,
+                    ...this.defaultOrientation,
+                },
             },
             series: this.series,
         }
@@ -386,6 +386,22 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
         if (this.minRangeXY === 0) return 1
 
         return this.absRangeY / this.minRangeXY
+    }
+
+    get defaultOrientation() {
+        const orientation = this.$store.state.gui.heightmap.defaultOrientation ?? 'rightFront'
+
+        switch (orientation) {
+            case 'leftFront':
+                return { alpha: 25, beta: -40 }
+            case 'front':
+                return { alpha: 25, beta: 0 }
+            case 'top':
+                return { alpha: 90, beta: 0 }
+
+            default:
+                return { alpha: 25, beta: 40 }
+        }
     }
 
     tooltipFormatter(data: any): string {

--- a/src/components/charts/HeightmapChart.vue
+++ b/src/components/charts/HeightmapChart.vue
@@ -149,7 +149,7 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
                 boxWidth: 100 * this.scaleX,
                 boxDepth: 100 * this.scaleY,
                 viewControl: {
-                    distance: 150,
+                    distance: 200,
                     ...this.defaultOrientation,
                 },
             },

--- a/src/components/settings/SettingsHeightmapTab.vue
+++ b/src/components/settings/SettingsHeightmapTab.vue
@@ -7,16 +7,16 @@
                     <v-card-title class="mx-n2">
                         {{ $t('Settings.HeightmapTab.Heightmap') }}
                     </v-card-title>
-                    <v-divider class="ml-3"></v-divider>
+                    <v-divider class="ml-3" />
                 </div>
+                <settings-row
+                    :title="$t('Settings.HeightmapTab.DefaultOrientation')"
+                    :sub-title="$t('Settings.HeightmapTab.DefaultOrientationDescription')">
+                    <v-select v-model="defaultOrientation" :items="availableOrientations" hide-details outlined dense />
+                </settings-row>
+                <v-divider class="my-2" />
                 <settings-row :title="$t('Settings.HeightmapTab.ColorSchemes')">
-                    <v-select
-                        v-model="colorScheme"
-                        :items="availableColorSchemes"
-                        hide-details
-                        outlined
-                        dense
-                        attach></v-select>
+                    <v-select v-model="colorScheme" :items="availableColorSchemes" hide-details outlined dense />
                 </settings-row>
             </v-card-text>
         </v-card>
@@ -39,6 +39,36 @@ import { mdiGrid } from '@mdi/js'
 })
 export default class SettingsHeightmapTab extends Mixins(BaseMixin) {
     mdiGrid = mdiGrid
+
+    get availableOrientations() {
+        return [
+            {
+                text: this.$t('Settings.HeightmapTab.Orientations.RightFront'),
+                value: 'rightFront',
+            },
+            {
+                text: this.$t('Settings.HeightmapTab.Orientations.LeftFront'),
+                value: 'leftFront',
+            },
+            {
+                text: this.$t('Settings.HeightmapTab.Orientations.Front'),
+                value: 'front',
+            },
+            {
+                text: this.$t('Settings.HeightmapTab.Orientations.Top'),
+                value: 'top',
+            },
+        ]
+    }
+
+    get defaultOrientation() {
+        return this.$store.state.gui.heightmap.defaultOrientation
+    }
+
+    set defaultOrientation(newVal) {
+        this.$store.dispatch('gui/heightmap/saveSetting', { name: 'defaultOrientation', value: newVal })
+    }
+
     get availableColorSchemes() {
         return [
             {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1021,7 +1021,7 @@
         "HeightmapTab": {
             "ColorSchemes": "Color Schemes",
             "DefaultOrientation": "Default Orientation",
-            "DefaultOrientationDescription": "Select the default view for the bed mesh visualization.",
+            "DefaultOrientationDescription": "Select the default orientation for the bed mesh visualization.",
             "Heightmap": "Heightmap",
             "IsDefault": "(Default)",
             "Orientations": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1020,8 +1020,16 @@
         },
         "HeightmapTab": {
             "ColorSchemes": "Color Schemes",
+            "DefaultOrientation": "Default Orientation",
+            "DefaultOrientationDescription": "Select the default view for the bed mesh visualization.",
             "Heightmap": "Heightmap",
             "IsDefault": "(Default)",
+            "Orientations": {
+                "Front": "Front",
+                "LeftFront": "Left Front",
+                "RightFront": "Right Front",
+                "Top": "Top"
+            },
             "Schemes": {
                 "GrayScale": "Grayscale",
                 "Hot": "Hot",

--- a/src/store/gui/heightmap/index.ts
+++ b/src/store/gui/heightmap/index.ts
@@ -6,6 +6,7 @@ import { actions } from './actions'
 export const getDefaultState = (): HeightmapState => {
     return {
         activecolorscheme: 'portland',
+        defaultOrientation: 'rightFront',
     }
 }
 

--- a/src/store/gui/heightmap/types.ts
+++ b/src/store/gui/heightmap/types.ts
@@ -1,3 +1,4 @@
 export interface HeightmapState {
     activecolorscheme: string
+    defaultOrientation: 'rightFront' | 'leftFront' | 'front' | 'top'
 }


### PR DESCRIPTION
## Description

This PR adds an option in the Settings to let the user set the default orientation of the bed mesh visualization.

## Related Tickets & Documents

fixes #993 

## Mobile & Desktop Screenshots/Recordings

Option "Right Front" (default option and the same orientation as before):
![image](https://github.com/user-attachments/assets/bccca234-915c-4919-a359-f59423f39bd8)

Option "Left Front":
![image](https://github.com/user-attachments/assets/c69ccfeb-3d1d-4b44-a3d1-d61d0d5830d2)

Option "Front":
![image](https://github.com/user-attachments/assets/0c0e4586-dc65-4c5f-9a2b-ddb087e9b1d3)

Option "Top":
![image](https://github.com/user-attachments/assets/555481ff-2fb1-42ca-9ae9-a23c06752250)

## [optional] Are there any post-deployment tasks we need to perform?

none
