### PR TITLE
fix(HistoryPanel): Fix History thumbnails of files in folders

### DIFF
--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -195,7 +195,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
                 thumb.height <= thumbnailSmallMax
         )
 
-        return this.createThumbnailUrl(thumbnail)
+        return thumbnail ? this.createThumbnailUrl(thumbnail) : false
     }
 
     get bigThumbnail() {
@@ -203,7 +203,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
 
         const thumbnail = this.item.metadata?.thumbnails?.find((thumb) => thumb.width >= thumbnailBigMin)
 
-        return this.createThumbnailUrl(thumbnail)
+        return thumbnail ? this.createThumbnailUrl(thumbnail) : false
     }
 
     get statusIcon() {
@@ -315,7 +315,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
         }
     }
 
-    createThumbnailUrl(thumbnail: FileStateFileThumbnail | undefined) {
+    createThumbnailUrl(thumbnail: FileStateFileThumbnail) {
         let relative_url = ''
         if (this.item.filename.lastIndexOf('/') !== -1) {
             relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)

--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -321,9 +321,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
             relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)
         }
 
-        if ((thumbnail?.relative_path ?? null) === null) return false
-
-        return `${this.apiUrl}/server/files/gcodes/${encodeURI(relative_url + thumbnail?.relative_path)}?timestamp=${
+        return `${this.apiUrl}/server/files/gcodes/${encodeURI(relative_url + thumbnail.relative_path)}?timestamp=${
             this.item.metadata.modified
         }`
     }

--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -134,6 +134,7 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import HistoryListPanelDetailsDialog from '@/components/dialogs/HistoryListPanelDetailsDialog.vue'
 import Panel from '@/components/ui/Panel.vue'
 import BaseMixin from '@/components/mixins/base'
+import { FileStateFileThumbnail } from '@/store/files/types'
 import { ServerHistoryStateJob } from '@/store/server/history/types'
 import { thumbnailBigMin, thumbnailSmallMax, thumbnailSmallMin } from '@/store/variables'
 import {
@@ -194,16 +195,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
                 thumb.height <= thumbnailSmallMax
         )
 
-        let relative_url = ''
-        if (this.item.filename.lastIndexOf('/') !== -1) {
-            relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)
-        }
-
-        if ((thumbnail?.relative_path ?? null) === null) return false
-
-        return `${this.apiUrl}/server/files/gcodes/${encodeURI(relative_url + thumbnail?.relative_path)}?timestamp=${
-            this.item.metadata.modified
-        }`
+        return this.createThumbnailUrl(thumbnail)
     }
 
     get bigThumbnail() {
@@ -211,16 +203,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
 
         const thumbnail = this.item.metadata?.thumbnails?.find((thumb: any) => thumb.width >= thumbnailBigMin)
 
-        let relative_url = ''
-        if (this.item.filename.lastIndexOf('/') !== -1) {
-            relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)
-        }
-
-        if ((thumbnail?.relative_path ?? null) === null) return false
-
-        return `${this.apiUrl}/server/files/gcodes/${encodeURI(relative_url + thumbnail?.relative_path)}?timestamp=${
-            this.item.metadata.modified
-        }`
+        return this.createThumbnailUrl(thumbnail)
     }
 
     get statusIcon() {
@@ -330,6 +313,19 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
             default:
                 return value
         }
+    }
+
+    createThumbnailUrl(thumbnail: FileStateFileThumbnail | undefined) {
+        let relative_url = ''
+        if (this.item.filename.lastIndexOf('/') !== -1) {
+            relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)
+        }
+
+        if ((thumbnail?.relative_path ?? null) === null) return false
+
+        return `${this.apiUrl}/server/files/gcodes/${encodeURI(relative_url + thumbnail?.relative_path)}?timestamp=${
+            this.item.metadata.modified
+        }`
     }
 }
 </script>

--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -196,7 +196,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
 
         let relative_url = ''
         if (this.item.filename.lastIndexOf('/') !== -1) {
-            relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/'))
+            relative_url = this.item.filename.substring(0, this.item.filename.lastIndexOf('/') + 1)
         }
 
         if ((thumbnail?.relative_path ?? null) === null) return false

--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -188,7 +188,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
         if ((this.item.metadata?.thumbnails?.length ?? 0) < 1) return false
 
         const thumbnail = this.item.metadata?.thumbnails?.find(
-            (thumb: any) =>
+            (thumb) =>
                 thumb.width >= thumbnailSmallMin &&
                 thumb.width <= thumbnailSmallMax &&
                 thumb.height >= thumbnailSmallMin &&
@@ -201,7 +201,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin) {
     get bigThumbnail() {
         if ((this.item.metadata?.thumbnails?.length ?? 0) < 1) return false
 
-        const thumbnail = this.item.metadata?.thumbnails?.find((thumb: any) => thumb.width >= thumbnailBigMin)
+        const thumbnail = this.item.metadata?.thumbnails?.find((thumb) => thumb.width >= thumbnailBigMin)
 
         return this.createThumbnailUrl(thumbnail)
     }


### PR DESCRIPTION
## Description

Fixes missing thumbnails in History page for files placed in non-root folders.

Bonus: refactors thumbnails url generation code so that it is reused for both small & big thumbnails, and improves TypeScript coverage by eliminating unwanted `any` usage.

## Related Tickets & Documents

#2009

## Mobile & Desktop Screenshots/Recordings

### Before

![obraz](https://github.com/user-attachments/assets/f15282ee-4ac9-4bb4-8105-f2e2ec24e6da)

### After

![obraz](https://github.com/user-attachments/assets/f292f1dd-bb28-4de2-bc1e-399f6d91707e)
