### PR TITLE
fix(Editor): Trigger gotoLine only when change is from sidebar

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -67,7 +67,7 @@
                             dense
                             :active="structureActive"
                             :open="structureOpen"
-                            item-key="line"
+                            :item-key="treeviewItemKeyProp"
                             :items="configFileStructure"
                             class="w-100"
                             @update:active="activeChanges">
@@ -189,6 +189,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     dialogConfirmChange = false
     dialogDevices = false
     fileStructureSidebar = true
+    treeviewItemKeyProp = 'line' as const
     structureActive: number[] = []
     structureOpen: number[] = []
     structureActiveChangedBySidebar: boolean = false
@@ -431,13 +432,18 @@ export default class TheEditor extends Mixins(BaseMixin) {
         this.structureActiveChangedBySidebar = true
     }
 
-    activeChanges(key: any) {
+    activeChanges(activeItems: Array<ConfigFileSection[typeof this.treeviewItemKeyProp]>) {
         if (!this.structureActiveChangedBySidebar) {
             return
         }
 
         this.structureActiveChangedBySidebar = false
-        this.editor?.gotoLine(key)
+
+        if (!activeItems.length) {
+            return
+        }
+
+        this.editor?.gotoLine(activeItems[0])
     }
 
     lineChanges(line: number) {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -74,7 +74,8 @@
                             <template #label="{ item }">
                                 <div
                                     class="cursor-pointer _structure-sidebar-item"
-                                    :class="item.type == 'item' ? 'ͼp' : 'ͼt'">
+                                    :class="item.type == 'item' ? 'ͼp' : 'ͼt'"
+                                    @click="activeChangesItemClick">
                                     {{ item.name }}
                                 </div>
                             </template>
@@ -190,6 +191,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     fileStructureSidebar = true
     structureActive: number[] = []
     structureOpen: number[] = []
+    structureActiveChangedBySidebar: boolean = false
 
     formatFilesize = formatFilesize
 
@@ -424,7 +426,17 @@ export default class TheEditor extends Mixins(BaseMixin) {
         this.fileStructureSidebar = !this.fileStructureSidebar
     }
 
+    // Relies on event bubbling to flip the flag before treeview active change is handled
+    activeChangesItemClick() {
+        this.structureActiveChangedBySidebar = true
+    }
+
     activeChanges(key: any) {
+        if (!this.structureActiveChangedBySidebar) {
+            return
+        }
+
+        this.structureActiveChangedBySidebar = false
         this.editor?.gotoLine(key)
     }
 


### PR DESCRIPTION
## Description

- Fixes jarring editor experience as described in #2011
  - It uses a flag to indicate when sidebar item activation originates from the sidebar itself, or somewhere else, by detecting the sidebar's item click. Not a perfect solution, but generally works, although it does leave a bit of a dead click zone when user clicks on very boundaries of sidebar's item. Still better than previous behavior.
  - Once Mainsail upgrades to Vuetify v3, this can be solved a bit easier & cleaner using `click:open` event handler of the Treeview component, see https://vuetifyjs.com/en/api/v-treeview/#events-click:open
- Fixes JS error being thrown when sidebar item is deactivated by "unclicking" the item
  - Also, slightly improves TS typings for `activeChanges`, although due to `this.editor` being typed as `any`, this is just cosmetics and maybe slightly better code documentation experience

## Related Tickets & Documents

#2011 

## Mobile & Desktop Screenshots/Recordings

### Before

[editor_before.webm](https://github.com/user-attachments/assets/fec20f10-d83f-4936-9852-30f9da5b33b1)

### After

[editor_after.webm](https://github.com/user-attachments/assets/c0349816-b460-431c-8a67-5c997327ef42)
