### PR TITLE
fix(Editor): fix editor width when sidebar is hidden

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -525,6 +525,13 @@ export default class TheEditor extends Mixins(BaseMixin) {
 }
 
 @media screen and (min-width: 960px) {
+  .codemirror:not(.withSidebar) {
+    width: 100%;
+  }
+  .codemirror.withSidebar {
+    width: calc(100% - 300px);
+  }
+}
     .codemirror {
         width: 100%;
     }

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -525,21 +525,14 @@ export default class TheEditor extends Mixins(BaseMixin) {
 }
 
 @media screen and (min-width: 960px) {
-  .codemirror:not(.withSidebar) {
-    width: 100%;
-  }
-  .codemirror.withSidebar {
-    width: calc(100% - 300px);
-  }
-}
-    .codemirror {
+    .codemirror:not(.withSidebar) {
         width: 100%;
     }
-
     .codemirror.withSidebar {
         width: calc(100% - 300px);
     }
 }
+
 .structure-sidebar {
     width: 300px;
     overflow-y: auto;

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -60,6 +60,7 @@
                         :name="filename"
                         :file-extension="fileExtension"
                         class="codemirror"
+                        :class="{ withSidebar: fileStructureSidebar }"
                         @lineChange="lineChanges" />
                     <div v-if="fileStructureSidebar" class="d-none d-md-flex structure-sidebar">
                         <v-treeview
@@ -525,6 +526,10 @@ export default class TheEditor extends Mixins(BaseMixin) {
 
 @media screen and (min-width: 960px) {
     .codemirror {
+        width: 100%;
+    }
+
+    .codemirror.withSidebar {
         width: calc(100% - 300px);
     }
 }


### PR DESCRIPTION
## Description

This PR fix the width of the editor area, when the filestructur sidebar is closed.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/user-attachments/assets/2b95e418-8c1f-4d18-8502-a341c6b010b6)

after:
![image](https://github.com/user-attachments/assets/241c827a-04e8-4252-8255-dcdf1f5514ea)

## [optional] Are there any post-deployment tasks we need to perform?

none

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the editor width issue by updating the CSS to handle the presence or absence of the file structure sidebar.

Bug Fixes:
- Fix the width of the editor area when the file structure sidebar is closed by adjusting the CSS classes.

<!-- Generated by sourcery-ai[bot]: end summary -->