### PR TITLE
feat(gui): fans can have multiple rpm values and add "fan_multi"

### DIFF
--- a/src/components/inputs/MiscellaneousSlider.vue
+++ b/src/components/inputs/MiscellaneousSlider.vue
@@ -17,7 +17,24 @@
                     <v-icon v-else-if="type.includes('fan')" small :class="fanClasses">{{ mdiFan }}</v-icon>
                     <span>{{ convertName(name) }}</span>
                     <v-spacer />
-                    <small v-if="rpm !== null" :class="rpmClasses">{{ Math.round(rpm ?? 0) }} RPM</small>
+                    <small v-if="rpm !== null && !Array.isArray(rpm)" :class="rpmClasses">
+                        {{ Math.round(rpm ?? 0) }} RPM
+                    </small>
+                    <template v-if="Array.isArray(rpm)">
+                        <template v-for="(rpmval, index) in rpm">
+                            <small
+                                v-if="rpm !== null"
+                                :key="index"
+                                :class="{
+                                    'mr-3': index !== rpm.length - 1,
+                                    'red--text': rpmval === 0 && value > 0,
+                                    'mt-2': controllable,
+                                    'mr-3 mt-1': !controllable,
+                                }">
+                                {{ Math.round(rpmval ?? 0) }} RPM
+                            </small>
+                        </template>
+                    </template>
                     <span v-if="!controllable" class="font-weight-bold">
                         {{ Math.round(parseFloat(value) * 100) }} %
                     </span>
@@ -205,6 +222,7 @@ export default class MiscellaneousSlider extends Mixins(BaseMixin) {
         let gcode = `SET_PIN PIN=${this.name} VALUE=${newVal.toFixed(2)}`
         if (this.type === 'fan') gcode = `M106 S${newVal.toFixed(0)}`
         if (this.type === 'fan_generic') gcode = `SET_FAN_SPEED FAN=${this.name} SPEED=${newVal}`
+        if (this.type === 'fan_multi') gcode = `SET_FAN_SPEED FAN=${this.name} SPEED=${newVal}`
         if (this.type === 'led')
             gcode = `SET_LED LED=${this.name} ${this.ledChannelName}=${newVal.toFixed(2)} SYNC=0 TRANSMIT=1`
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -186,10 +186,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
     getFans: (state, getters) => {
         const fans: PrinterStateFan[] = []
-        const supportedFans = ['temperature_fan', 'controller_fan', 'heater_fan', 'fan_generic', 'fan']
+        const supportedFans = ['temperature_fan', 'controller_fan', 'heater_fan', 'fan_generic', 'fan_multi', 'fan']
         const objects = getters.getPrinterObjects(supportedFans)
 
-        const controllableFans = ['fan_generic', 'fan']
+        const controllableFans = ['fan_generic', 'fan_multi', 'fan']
 
         objects.foreach((object: PrinterGetterObject) => {
             fans.push({
@@ -300,13 +300,14 @@ export const getters: GetterTree<PrinterState, RootState> = {
             'controller_fan',
             'heater_fan',
             'fan_generic',
+            'fan_multi',
             'fan',
             'output_pin',
             'pwm_tool',
             'pwm_cycle_time',
         ]
 
-        const controllableFans = ['fan_generic', 'fan']
+        const controllableFans = ['fan_generic', 'fan_multi', 'fan']
 
         for (const [key, value] of Object.entries(state)) {
             const nameSplit = key.split(' ')


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description
Changes how the fan rpm is displayed so it can be an array of multiple rpm values and also adds support "fan_multi" a fan that can have multiple tachometer_pins defined (https://github.com/xPatrikTwitch/klipper/blob/master/klippy/extras/fan_multi.py) (This does not break normal fans with one rpm value)

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
none

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/user-attachments/assets/9b51a650-85cb-46cd-a121-817d1814489e)

<!-- Visual changes require screenshots showing the before and after -->

## [optional] Are there any post-deployment tasks we need to perform?
none
<!-- note: PRs with deleted sections will be marked invalid -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for fans with multiple RPM values and introduce the 'fan_multi' type, enhancing the GUI to display these values appropriately.

New Features:
- Introduce support for fans with multiple RPM values, allowing for an array of RPMs to be displayed.
- Add support for 'fan_multi', a fan type that can have multiple tachometer pins defined.

Enhancements:
- Update the GUI to handle and display multiple RPM values for fans, ensuring compatibility with both single and multi-RPM fans.

<!-- Generated by sourcery-ai[bot]: end summary -->