### PR TITLE
fix: fix image viewer if the image is wider than the viewport

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -260,9 +260,9 @@
                     <img
                         v-if="dialogImage.item.url"
                         :src="dialogImage.item.url"
-                        style="max-height: 100%; width: auto; object-fit: contain"
+                        style="max-height: 100%; width: auto; max-width: 100%; object-fit: contain"
                         alt="image" />
-                    <div v-else-if="dialogImage.item.svg" class="fill-width" v-html="dialogImage.item.svg"></div>
+                    <div v-else-if="dialogImage.item.svg" class="fill-width" v-html="dialogImage.item.svg" />
                 </div>
             </panel>
         </v-dialog>


### PR DESCRIPTION
## Description

This PR fix only the max-width from the imageviewer and fit the image to the current viewport.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the image viewer component to handle images wider than the viewport by adjusting the max-width style property.

Bug Fixes:
- Fix image viewer to ensure images wider than the viewport are properly scaled to fit within the current viewport.

<!-- Generated by sourcery-ai[bot]: end summary -->