### PR TITLE
fix: fix color picker for PCA9632

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -228,7 +228,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 let singleChannelTarget = null
                 const colorData = object.state.color_data ?? []
 
-                if ('color_order' in object.settings) colorOrder = object.settings.color_order[0] ?? ''
+                if ('color_order' in object.settings)
+                    colorOrder = object.settings.color_order[0] ?? object.settings.color_order
 
                 if (object.type === 'led') {
                     colorOrder = ''

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -228,8 +228,13 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 let singleChannelTarget = null
                 const colorData = object.state.color_data ?? []
 
-                if ('color_order' in object.settings)
-                    colorOrder = object.settings.color_order[0] ?? object.settings.color_order
+                if ('color_order' in object.settings) {
+                    if (typeof object.settings.color_order === 'string') {
+                        colorOrder = object.settings.color_order
+                    } else if (Array.isArray(object.settings.color_order) && object.settings.color_order.length > 0) {
+                        colorOrder = object.settings.color_order[0]
+                    }
+                }
 
                 if (object.type === 'led') {
                     colorOrder = ''


### PR DESCRIPTION
## Description

This PR fix the color picker for PCA9632. 

## Related Tickets & Documents

fixes #2022 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none

## Summary by Sourcery

Bug Fixes:
- Fix the color picker functionality for PCA9632 by correcting the handling of the color_order setting.