### PR TITLE
fix: Tool rows in even lengths, and more visually tidy

### DIFF
--- a/src/components/panels/Extruder/ExtruderControlPanelTools.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelTools.vue
@@ -21,7 +21,8 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
     mdiPrinter3dNozzle = mdiPrinter3dNozzle
 
     get rows() {
-        const cols = 6
+        let len = this.toolchangeMacros.length
+        let cols = Math.ceil(len / Math.ceil(len / 6.0))
         let rows = []
 
         for (let i = 0; i < this.toolchangeMacros.length; i += cols) {

--- a/src/components/panels/Extruder/ExtruderControlPanelTools.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelTools.vue
@@ -21,8 +21,8 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ControlMixin
     mdiPrinter3dNozzle = mdiPrinter3dNozzle
 
     get rows() {
-        let len = this.toolchangeMacros.length
-        let cols = Math.ceil(len / Math.ceil(len / 6.0))
+        const len = this.toolchangeMacros.length
+        const cols = Math.ceil(len / Math.ceil(len / 6))
         let rows = []
 
         for (let i = 0; i < this.toolchangeMacros.length; i += cols) {


### PR DESCRIPTION
## Description

This uses a formula to make the tool rows have or at least approximately have even lengths. The current behaviour is the last row has `num % 6` tools. There will be no more rows than there was before.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

Before:
![image](https://github.com/user-attachments/assets/d7b78cc4-7efe-4cab-8bac-e02d104c0803)

After:
![image](https://github.com/user-attachments/assets/b3b135eb-a810-48e9-9670-fb4c2c4762f1)


## [optional] Are there any post-deployment tasks we need to perform?

none
