### PR TITLE
feat: use _CLIENT_LINEAR_MOVE macros instead of multi-line gcodes

### DIFF
--- a/src/components/mixins/control.ts
+++ b/src/components/mixins/control.ts
@@ -112,10 +112,10 @@ export default class ControlMixin extends Vue {
             })
     }
 
-    get existsClientAxisMoveMacro() {
+    get existsClientLinearMoveMacro() {
         const macros = this.$store.state.printer?.gcode?.commands ?? {}
 
-        return '_CLIENT_AXIS_MOVE' in macros
+        return '_CLIENT_LINEAR_MOVE' in macros
     }
 
     doHome() {
@@ -160,7 +160,7 @@ export default class ControlMixin extends Vue {
             `G1 ${gcode} F${feedrate * 60}\n` +
             `RESTORE_GCODE_STATE NAME=_ui_movement`
 
-        if (this.existsClientAxisMoveMacro) {
+        if (this.existsClientLinearMoveMacro) {
             gcode = gcode
                 .split(' ')
                 .map((part) => {
@@ -171,7 +171,7 @@ export default class ControlMixin extends Vue {
                 })
                 .join(' ')
 
-            command = `_CLIENT_AXIS_MOVE ${gcode} F=${feedrate * 60}`
+            command = `_CLIENT_LINEAR_MOVE ${gcode} F=${feedrate * 60}`
         }
 
         this.doSend(command)

--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -250,6 +250,12 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
         return this.feedamount * this.extrudeFactor > this.maxExtrudeOnlyDistance
     }
 
+    get existsHelperMacro(): boolean {
+        const macros = this.$store.state.printer?.gcode?.commands ?? {}
+
+        return '_CLIENT_EXTRUDER_MOVE' in macros
+    }
+
     @Watch('maxExtrudeOnlyDistance', { immediate: true })
     onMaxExtrudeOnlyDistanceChange(): void {
         /**
@@ -271,11 +277,15 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
     }
 
     sendCommand(length: number, loading: string): void {
-        const gcode =
+        let gcode =
             `SAVE_GCODE_STATE NAME=_ui_extrude\n` +
             `M83\n` +
             `G1 E${length} F${this.feedrate * 60}\n` +
             `RESTORE_GCODE_STATE NAME=_ui_extrude`
+
+        if (this.existsHelperMacro) {
+            gcode = `_CLIENT_EXTRUDER_MOVE E=${length} F=${this.feedrate * 60}`
+        }
 
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading })

--- a/src/components/panels/Extruder/ExtruderControlPanelControl.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelControl.vue
@@ -250,10 +250,10 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
         return this.feedamount * this.extrudeFactor > this.maxExtrudeOnlyDistance
     }
 
-    get existsHelperMacro(): boolean {
+    get existsClientLinearMoveMacro() {
         const macros = this.$store.state.printer?.gcode?.commands ?? {}
 
-        return '_CLIENT_EXTRUDER_MOVE' in macros
+        return '_CLIENT_LINEAR_MOVE' in macros
     }
 
     @Watch('maxExtrudeOnlyDistance', { immediate: true })
@@ -283,8 +283,8 @@ export default class ExtruderControlPanel extends Mixins(BaseMixin, ExtruderMixi
             `G1 E${length} F${this.feedrate * 60}\n` +
             `RESTORE_GCODE_STATE NAME=_ui_extrude`
 
-        if (this.existsHelperMacro) {
-            gcode = `_CLIENT_EXTRUDER_MOVE E=${length} F=${this.feedrate * 60}`
+        if (this.existsClientLinearMoveMacro) {
+            gcode = `_CLIENT_LINEAR_MOVE E=${length} F=${this.feedrate * 60}`
         }
 
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })

--- a/src/components/panels/ToolheadControls/MoveToControl.vue
+++ b/src/components/panels/ToolheadControls/MoveToControl.vue
@@ -165,14 +165,14 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
 
     sendCmd(): void {
         let gcode: string[] = []
-        if (!this.existsClientAxisMoveMacro) {
+        if (!this.existsClientLinearMoveMacro) {
             gcode.push('SAVE_GCODE_STATE NAME=_ui_movement')
             gcode.push('G90')
         }
 
         if (this.input.z.pos !== this.gcodePositions.z) {
-            if (this.existsClientAxisMoveMacro)
-                gcode.push(`_CLIENT_AXIS_MOVE Z=${this.input.z.pos} F=${this.feedrateZ * 60} ABSOLUTE=1`)
+            if (this.existsClientLinearMoveMacro)
+                gcode.push(`_CLIENT_LINEAR_MOVE Z=${this.input.z.pos} F=${this.feedrateZ * 60} ABSOLUTE=1`)
             else gcode.push(`G1 Z${this.input.z.pos} F${this.feedrateZ * 60}`)
         }
 
@@ -180,11 +180,11 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
             let xPos = ''
             let yPos = ''
 
-            if (this.existsClientAxisMoveMacro) {
+            if (this.existsClientLinearMoveMacro) {
                 if (this.input.x.pos !== this.gcodePositions.x) xPos = ` X=${this.input.x.pos}`
                 if (this.input.y.pos !== this.gcodePositions.y) yPos = ` Y=${this.input.y.pos}`
 
-                gcode.push(`_CLIENT_AXIS_MOVE${xPos}${yPos} F=${this.feedrateXY * 60} ABSOLUTE=1`)
+                gcode.push(`_CLIENT_LINEAR_MOVE${xPos}${yPos} F=${this.feedrateXY * 60} ABSOLUTE=1`)
             } else {
                 if (this.input.x.pos !== this.gcodePositions.x) xPos = ` X${this.input.x.pos}`
                 if (this.input.y.pos !== this.gcodePositions.y) yPos = ` Y${this.input.y.pos}`
@@ -193,7 +193,7 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
             }
         }
 
-        if (!this.existsClientAxisMoveMacro) {
+        if (!this.existsClientLinearMoveMacro) {
             gcode.push('RESTORE_GCODE_STATE NAME=_ui_movement')
         }
 

--- a/src/components/panels/ToolheadControls/MoveToControl.vue
+++ b/src/components/panels/ToolheadControls/MoveToControl.vue
@@ -16,9 +16,7 @@
                             'col-3': el.is.large,
                         }"
                         class="v-subheader text--secondary mr-2">
-                        <v-icon small class="mr-1">
-                            {{ mdiCrosshairsGps }}
-                        </v-icon>
+                        <v-icon small class="mr-1">{{ mdiCrosshairsGps }}</v-icon>
                         <span v-if="!el.is.xsmall" class="text-no-wrap">
                             {{ $t('Panels.ToolheadControlPanel.Position') }}:&nbsp;
                         </span>
@@ -27,12 +25,8 @@
                     <v-col
                         v-if="currentProfileName"
                         class="v-subheader text--secondary pl-2 justify-end text-no-wrap text-truncate">
-                        <v-icon small class="mr-1">
-                            {{ mdiGrid }}
-                        </v-icon>
-                        <span class="text-no-wrap text-truncate">
-                            {{ currentProfileName }}
-                        </span>
+                        <v-icon small class="mr-1">{{ mdiGrid }}</v-icon>
+                        <span class="text-no-wrap text-truncate">{{ currentProfileName }}</span>
                     </v-col>
                 </v-row>
                 <v-row v-if="showCoordinates" dense>
@@ -45,7 +39,7 @@
                             :current-pos="gcodePositions.x"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!xAxisHomed"
-                            @submit="sendCmd"></move-to-input>
+                            @submit="sendCmd" />
                     </v-col>
                     <v-col :class="el.is.xsmall ? 'col-12' : 'col-4'">
                         <move-to-input
@@ -56,7 +50,7 @@
                             :current-pos="gcodePositions.y"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!yAxisHomed"
-                            @submit="sendCmd"></move-to-input>
+                            @submit="sendCmd" />
                     </v-col>
                     <v-col :class="el.is.xsmall ? 'col-12' : 'col-4'">
                         <move-to-input
@@ -67,7 +61,7 @@
                             :current-pos="gcodePositions.z"
                             :readonly="['printing'].includes(printer_state)"
                             :disabled="!zAxisHomed"
-                            @submit="sendCmd"></move-to-input>
+                            @submit="sendCmd" />
                     </v-col>
                 </v-row>
             </template>
@@ -170,24 +164,44 @@ export default class MoveToControl extends Mixins(BaseMixin, ControlMixin) {
     }
 
     sendCmd(): void {
-        const xPos = this.input.x.pos !== this.gcodePositions.x ? ` X${this.input.x.pos}` : ''
-        const yPos = this.input.y.pos !== this.gcodePositions.y ? ` Y${this.input.y.pos}` : ''
-        const zPos = this.input.z.pos !== this.gcodePositions.z ? ` Z${this.input.z.pos}` : ''
-
-        let gcode = ''
-        if (!this.positionAbsolute) {
-            gcode += 'G90\n'
-        }
-        if (zPos !== '') {
-            gcode += `G1${zPos} F${this.feedrateZ * 60}\n`
-        }
-        if (xPos !== '' || yPos !== '') {
-            gcode += `G1${xPos}${yPos} F${this.feedrateXY * 60}`
+        let gcode: string[] = []
+        if (!this.existsClientAxisMoveMacro) {
+            gcode.push('SAVE_GCODE_STATE NAME=_ui_movement')
+            gcode.push('G90')
         }
 
-        if (gcode !== '' && this.input.x.valid && this.input.y.valid && this.input.z.valid) {
-            this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-            this.$socket.emit('printer.gcode.script', { script: gcode })
+        if (this.input.z.pos !== this.gcodePositions.z) {
+            if (this.existsClientAxisMoveMacro)
+                gcode.push(`_CLIENT_AXIS_MOVE Z=${this.input.z.pos} F=${this.feedrateZ * 60} ABSOLUTE=1`)
+            else gcode.push(`G1 Z${this.input.z.pos} F${this.feedrateZ * 60}`)
+        }
+
+        if (this.input.x.pos !== this.gcodePositions.x || this.input.y.pos !== this.gcodePositions.y) {
+            let xPos = ''
+            let yPos = ''
+
+            if (this.existsClientAxisMoveMacro) {
+                if (this.input.x.pos !== this.gcodePositions.x) xPos = ` X=${this.input.x.pos}`
+                if (this.input.y.pos !== this.gcodePositions.y) yPos = ` Y=${this.input.y.pos}`
+
+                gcode.push(`_CLIENT_AXIS_MOVE${xPos}${yPos} F=${this.feedrateXY * 60} ABSOLUTE=1`)
+            } else {
+                if (this.input.x.pos !== this.gcodePositions.x) xPos = ` X${this.input.x.pos}`
+                if (this.input.y.pos !== this.gcodePositions.y) yPos = ` Y${this.input.y.pos}`
+
+                gcode.push(`G1${xPos}${yPos} F${this.feedrateXY * 60}`)
+            }
+        }
+
+        if (!this.existsClientAxisMoveMacro) {
+            gcode.push('RESTORE_GCODE_STATE NAME=_ui_movement')
+        }
+
+        const gcodeStr = gcode.join('\n')
+
+        if (this.input.x.valid && this.input.y.valid && this.input.z.valid) {
+            this.$store.dispatch('server/addEvent', { message: gcodeStr, type: 'command' })
+            this.$socket.emit('printer.gcode.script', { script: gcodeStr })
         }
 
         return


### PR DESCRIPTION
## Description

This PR use will change the move gcodes, when _CLIENT_AXIS_MOVE or _CLIENT_EXTRUDER_MOVE macros exists. This will make the console less noisy.

## Related Tickets & Documents

PR: mainsail-cew/mainsail-config

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
