### PR TITLE
fix: keep macro prompt open for events older than 100

### DIFF
--- a/src/components/dialogs/TheMacroPrompt.vue
+++ b/src/components/dialogs/TheMacroPrompt.vue
@@ -86,20 +86,16 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
                 continue
             }
 
-            const type = (event.message ?? '').replace('// action:prompt_', '').split(' ')[0].trim()
+            const match = event.message.match(this.promptMessageExp)
+            const type = match?.groups?.type ?? ''
 
-            // stop processing and clear events once we find a end action
+            // stop processing and clear events once we find an end action
             if (type === 'end') {
                 this.currentPrompt = []
                 break
             }
 
-            console.log(event.message)
-
-            // extract our message from the action event
-            // supports no quote, double quote, and single quote wrapped messages
-            const { groups: { msg1, msg2, msg3 } = {} } = event.message.match(this.promptMessageExp) ?? {}
-            const message = (msg1 ?? msg2 ?? msg3 ?? '').trim()
+            const message = (match?.groups?.msg1 || match?.groups?.msg2 || '').trim()
 
             // prepend the event to prompt events found in this chunk
             promptEvents.unshift({

--- a/src/components/dialogs/TheMacroPrompt.vue
+++ b/src/components/dialogs/TheMacroPrompt.vue
@@ -58,27 +58,72 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
     mdiCloseThick = mdiCloseThick
 
     private internalCloseCommand: number | null = null
+    private checkpointEvent: ServerStateEvent | null = null
+    private currentPrompt: ServerStateEventPrompt[] = []
+    // regex that extracts the type and message, omitting the wrapping double quotes of the message (if any)
+    private promptMessageExp =
+        /^\/\/ action:prompt_(?<type>[^\s]+) *(?:(?<quote>['"])(?<msg1>.*)\k<quote>|(?<msg2>.*))\s*$/
 
     get events() {
-        return this.$store.state.server.events.slice(-100)
+        return this.$store.state.server.events
     }
 
     get macroPromptEvents() {
-        return this.events
-            .filter((event: ServerStateEvent) => event.type === 'action')
-            .filter((event: ServerStateEvent) => event.message.startsWith('// action:prompt_'))
-            .map((event: ServerStateEvent) => {
-                const type = (event.message ?? '').replace('// action:prompt_', '').split(' ')[0].trim()
-                const message = (event.message ?? '').replace(`// action:prompt_${type}`, '').replace(/"/g, '').trim()
+        const events: ServerStateEvent[] = this.events
+        const promptEvents: ServerStateEventPrompt[] = []
+        // process events from most recent (end of array) to oldest (beginning of array) event until we reach
+        // the events we have already processed
+        for (let i = events.length - 1; i >= 0; i--) {
+            const event = events[i]
+            // if we've reached the checkpoint event (i.e. the point where we know there are no earlier prompts to process)
+            if (event === this.checkpointEvent) {
+                // break the loop
+                break
+            }
 
-                const promptContent: ServerStateEventPrompt = {
-                    date: event.date,
-                    type,
-                    message,
-                }
+            // not a prompt action, skip it
+            if (event.type !== 'action' || !event.message?.startsWith('// action:prompt_')) {
+                continue
+            }
 
-                return promptContent
+            const type = (event.message ?? '').replace('// action:prompt_', '').split(' ')[0].trim()
+
+            // stop processing and clear events once we find a end action
+            if (type === 'end') {
+                this.currentPrompt = []
+                break
+            }
+
+            console.log(event.message)
+
+            // extract our message from the action event
+            // supports no quote, double quote, and single quote wrapped messages
+            const { groups: { msg1, msg2, msg3 } = {} } = event.message.match(this.promptMessageExp) ?? {}
+            const message = (msg1 ?? msg2 ?? msg3 ?? '').trim()
+
+            // prepend the event to prompt events found in this chunk
+            promptEvents.unshift({
+                date: event.date,
+                type,
+                message,
             })
+
+            // stop processing events once we find a begin action
+            if (type === 'begin') {
+                this.currentPrompt = []
+                break
+            }
+        }
+
+        // save our checkpoint event...we'll never have to look at messages prior to the checkpoint again
+        this.checkpointEvent = events[events.length - 1]
+
+        // if we found new prompt events in this chunk, let's append them
+        if (promptEvents.length > 0) {
+            this.currentPrompt = [...this.currentPrompt, ...promptEvents]
+        }
+
+        return this.currentPrompt
     }
 
     get lastPromptBeginPos() {


### PR DESCRIPTION

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

Previously we were only looking for a series of prompt action events within the last 100 events. However, if things are happening in the background while the prompt is still open, those events can keep racking up and eventually the prompt window will close (though klipperscreen still displays it).

I've now refactored this code so that it will internally keep an array of the prompt events and we will process through all the events at first, but we will set a checkpoint at the most recent processed event so that we don't go back and re-process ones that were already done. Effectively this means on first load sure we iterated through potentially a lot of events, but then after that we're really only processing through at most a few events. It is certainly less concise than the previous implementation, but I believe it is a more robust solution and perhaps a bit more performant. Previously every time we asked for `this.macroPromptEvents` it would iterate through the last 100 messages doing its filters and map. And that would get called numerous times in the scope of a single render. With this new process each time we call it (aside from the first load), it typically will only have at most a few items to filter through.

In addition, the part of the code that would parse out the message, because it would replace all double quotes, it meant that I could not do this:

```
RESPOND TYPE=command MSG="action:prompt_begin \"Question of the day\""
RESPOND TYPE=command MSG="action:prompt_button Foo Bar|RESPOND MSG=\"FOO BAR\""
RESPOND TYPE=command MSG="action:prompt_show"
```

If I tried to click that button I would get the following error:

```
Malformed command 'RESPOND MSG=FOO BAR'
```

I've updated the message parsing to effectively just strip off matching open and closing single or double quotes from the message. For example, all of the following would result in a message of `Question of the day`:

```
RESPOND TYPE=command MSG="action:prompt_begin \"Question of the day\""
RESPOND TYPE=command MSG="action:prompt_begin 'Question of the day'"
RESPOND TYPE=command MSG="action:prompt_begin Question of the day"
```

Here's a quick couple macros that demonstrate the bug. Execute the `MAINSAIL_BUG_TEST` macro and then click the button to `Send 100`. This will then execute 100 respond macros and the prompt dialog in mainsail will close without the user intending to close it.

```ini
[gcode_macro MAINSAIL_BUG_TEST]
gcode:
  RESPOND TYPE=command MSG="action:prompt_begin Question of the day"
  RESPOND TYPE=command MSG="action:prompt_button Send 100|MAINSAIL_BUG_TEST_MSG LOOP=100"
  RESPOND TYPE=command MSG="action:prompt_button Send 10|MAINSAIL_BUG_TEST_MSG LOOP=10"
  RESPOND TYPE=command MSG="action:prompt_button Send 1|MAINSAIL_BUG_TEST_MSG LOOP=1"
  RESPOND TYPE=command MSG="action:prompt_show"

[gcode_macro MAINSAIL_BUG_TEST_MSG]
gcode:
  {% set loop  = params.LOOP|default(10)|int %}
  {% for i in range(loop) %}
    RESPOND MSG="Iteration {i}"
  {% endfor %}
```

## Related Tickets & Documents

None found

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots showing the before and after -->

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
