### PR TITLE
fix: escape hash in filename in "upload & start"

### DIFF
--- a/src/components/TheTopbar.vue
+++ b/src/components/TheTopbar.vue
@@ -276,7 +276,7 @@ export default class TheTopbar extends Mixins(BaseMixin, ThemeMixin) {
 
     doUploadAndStart(file: File) {
         const formData = new FormData()
-        const filename = file.name
+        const filename = file.name.replaceAll('#', '')
 
         this.uploadSnackbar.filename = filename
         this.uploadSnackbar.status = true


### PR DESCRIPTION
## Description

This PR only escape/remove a # in the gcode filename while upload it.

## Related Tickets & Documents

fixes #2048 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
