### PR TITLE
fix(Webcam): make webcam view non-draggable

### DIFF
--- a/src/components/webcams/streamers/Mjpegstreamer.vue
+++ b/src/components/webcams/streamers/Mjpegstreamer.vue
@@ -4,6 +4,7 @@
             v-show="status === 'connected'"
             ref="image"
             class="webcamImage"
+            draggable="false"
             :style="webcamStyle"
             :alt="camSettings.name"
             src="#"

--- a/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
+++ b/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
@@ -4,6 +4,7 @@
             v-show="status === 'connected'"
             ref="image"
             class="webcamImage"
+            draggable="false"
             :style="webcamStyle"
             :alt="camSettings.name"
             src="#"

--- a/src/components/webcams/streamers/Uv4lMjpeg.vue
+++ b/src/components/webcams/streamers/Uv4lMjpeg.vue
@@ -5,6 +5,7 @@
             v-observe-visibility="viewportVisibilityChanged"
             :style="webcamStyle"
             class="webcamImage"
+            draggable="false"
             @load="onload" />
     </div>
 </template>


### PR DESCRIPTION
## Description

This PR makes the `<img>` tags created by the webcam preview non-draggable. They were draggable before, which would (at least in my case) lead to accidentally dragging it and uploading it to the config folder using the drag and drop function.
I was only able to test the `Mjpegstreamer` and `MjpegstreamerAdaptive`, so I didn't modify any of the other views.