### PR TITLE
fix(Webcam): add ICE check to support older CS versions

### DIFF
--- a/src/components/webcams/streamers/WebrtcCameraStreamer.vue
+++ b/src/components/webcams/streamers/WebrtcCameraStreamer.vue
@@ -136,7 +136,12 @@ export default class WebrtcCameraStreamer extends Mixins(BaseMixin, WebcamMixin)
 
         this.pc.addTransceiver('video', { direction: 'recvonly' })
 
-        this.pc.onicecandidate = (e: RTCPeerConnectionIceEvent) => this.onIceCandidate(e, iceResponse.id)
+        if ('iceServers' in iceResponse) {
+            this.pc.onicecandidate = (e: RTCPeerConnectionIceEvent) => this.onIceCandidate(e, iceResponse.id)
+        } else {
+            this.log('No ICE servers returned, so the current camera-streamer version may not support them')
+        }
+
         this.pc.onconnectionstatechange = () => this.onConnectionStateChange()
         this.pc.ontrack = (e) => this.onTrack(e)
 


### PR DESCRIPTION
## Description

This PR adds a check for ICE Candidates to fix the connection to older camera-streamer backends (for example the default version for the latest MainsailOS v1.3.2).

## Related Tickets & Documents

fixes #2068 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
