### PR TITLE
fix: fix interface settings Control-Tab when printer is not available

### DIFF
--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -30,9 +30,7 @@ export default class ZoffsetMixin extends Vue {
     }
 
     get endstop_pin() {
-        const endstop_pin = this.settings[this.stepper_name]?.endstop_pin ?? ''
-
-        return endstop_pin.trim()
+        return this.settings[this.stepper_name]?.endstop_pin?.trim() ?? null
     }
 
     get zOffset(): number {

--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -30,9 +30,9 @@ export default class ZoffsetMixin extends Vue {
     }
 
     get endstop_pin() {
-        const stepperConfig = this.settings[this.stepper_name] ?? {}
+        const endstop_pin = this.settings[this.stepper_name]?.endstop_pin ?? ''
 
-        return stepperConfig?.endstop_pin.trim()
+        return endstop_pin.trim()
     }
 
     get zOffset(): number {

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -178,7 +178,7 @@
                     </settings-row>
                     <v-divider class="my-2" />
                 </template>
-                <template v-if="endstop_pin !== null">
+                <template v-if="klipperReadyForGui && endstop_pin !== null">
                     <settings-row
                         :title="$t('Settings.ControlTab.ZOffsetSaveOption')"
                         :sub-title="$t('Settings.ControlTab.ZOffsetSaveOptionDescription')">

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -580,7 +580,7 @@ export default class SettingsControlTab extends Mixins(BaseMixin, ControlMixin, 
     }
 
     mounted() {
-        this.$refs.formControlExtruder.validate()
+        this.$refs.formControlExtruder?.validate()
     }
 }
 </script>

--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -178,18 +178,20 @@
                     </settings-row>
                     <v-divider class="my-2" />
                 </template>
-                <settings-row
-                    :title="$t('Settings.ControlTab.ZOffsetSaveOption')"
-                    :sub-title="$t('Settings.ControlTab.ZOffsetSaveOptionDescription')">
-                    <v-select
-                        v-model="offsetZSaveOption"
-                        :items="offsetZSaveOptions"
-                        class="mt-0"
-                        hide-details
-                        outlined
-                        dense />
-                </settings-row>
-                <v-divider class="my-2" />
+                <template v-if="endstop_pin !== null">
+                    <settings-row
+                        :title="$t('Settings.ControlTab.ZOffsetSaveOption')"
+                        :sub-title="$t('Settings.ControlTab.ZOffsetSaveOptionDescription')">
+                        <v-select
+                            v-model="offsetZSaveOption"
+                            :items="offsetZSaveOptions"
+                            class="mt-0"
+                            hide-details
+                            outlined
+                            dense />
+                    </settings-row>
+                    <v-divider class="my-2" />
+                </template>
                 <settings-row :title="$t('Settings.ControlTab.ZOffsetIncrements')" :mobile-second-row="true">
                     <v-combobox
                         v-model="offsetsZ"


### PR DESCRIPTION
## Description

This PR fix the Control-Tab in the Interface-Settings when the printer/Klipper is not ready.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
