### PR TITLE
fix: fix print start from dashboard for subdirectory files

### DIFF
--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -95,8 +95,8 @@
         </v-menu>
         <start-print-dialog
             :bool="showPrintDialog"
-            :file="startPrintItem"
-            :current-path="pathOfFile"
+            :file="item"
+            current-path=""
             @closeDialog="showPrintDialog = false" />
         <add-batch-to-queue-dialog
             :is-visible="showAddBatchToQueueDialog"

--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -274,13 +274,6 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
         return this.item.filename.slice(this.item.filename.lastIndexOf('/') + 1)
     }
 
-    get startPrintItem() {
-        const file = { ...this.item }
-        file.filename = this.filename
-
-        return file
-    }
-
     showContextMenu(e: any) {
         if (this.contextMenuShow) return
 

--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -95,7 +95,7 @@
         </v-menu>
         <start-print-dialog
             :bool="showPrintDialog"
-            :file="item"
+            :file="startPrintItem"
             :current-path="pathOfFile"
             @closeDialog="showPrintDialog = false" />
         <add-batch-to-queue-dialog
@@ -272,6 +272,13 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
 
     get filename() {
         return this.item.filename.slice(this.item.filename.lastIndexOf('/') + 1)
+    }
+
+    get startPrintItem() {
+        const file = { ...this.item }
+        file.filename = this.filename
+
+        return file
     }
 
     showContextMenu(e: any) {


### PR DESCRIPTION
## Description

This PR will fix the issue with start prints form the dashboard with files in a subdirectory. It creates a new file object without the complete path as filename for the start-print-dialog.

## Related Tickets & Documents

fixes #2073 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
