### PR TITLE
fix: hide horizontal scrollbar in StartPrintDialog.vue

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -1,5 +1,10 @@
 <template>
-    <v-dialog v-model="bool" :max-width="400" @click:outside="closeDialog" @keydown.esc="closeDialog">
+    <v-dialog
+        v-model="bool"
+        :max-width="400"
+        content-class="overflow-x-hidden"
+        @click:outside="closeDialog"
+        @keydown.esc="closeDialog">
         <v-card>
             <div v-if="file.big_thumbnail" class="d-flex align-center justify-center" style="min-height: 200px">
                 <v-img


### PR DESCRIPTION
## Description

This PR hide the horizontal scrollbar in the StartPrintDialog, but the vertical scrollbar is still untouched and can be visible, when the window is too small.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
![image](https://github.com/user-attachments/assets/4ee7232e-0ee6-4265-83a3-fb410a0f8b48)

after:
![image](https://github.com/user-attachments/assets/a644d5df-9638-48bf-a13e-a3d86a1690cf)

## [optional] Are there any post-deployment tasks we need to perform?

none
