### PR TITLE
fix(macro-prompts): preserve outer quotes

### DIFF
--- a/src/components/dialogs/TheMacroPrompt.vue
+++ b/src/components/dialogs/TheMacroPrompt.vue
@@ -61,8 +61,7 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
     private checkpointEvent: ServerStateEvent | null = null
     private currentPrompt: ServerStateEventPrompt[] = []
     // regex that extracts the type and message, omitting the wrapping double quotes of the message (if any)
-    private promptMessageExp =
-        /^\/\/ action:prompt_(?<type>[^\s]+) *(?:(?<quote>['"])(?<msg1>.*)\k<quote>|(?<msg2>.*))\s*$/
+    private promptMessageExp = /^\/\/ action:prompt_(?<type>[^\s]+) *(?<msg>.*)$/
 
     get events() {
         return this.$store.state.server.events
@@ -95,7 +94,7 @@ export default class TheMacroPrompt extends Mixins(BaseMixin) {
                 break
             }
 
-            const message = (match?.groups?.msg1 || match?.groups?.msg2 || '').trim()
+            const message = (match?.groups?.msg || '').trim()
 
             // prepend the event to prompt events found in this chunk
             promptEvents.unshift({


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

Previously if you had a macro prompt such as the following, the modal title would display `Question`, not `"Question"`. However, in other projects (Klipperscreen and Fluidd), they will preserve those outer quotes and they will be included in the title. This change makes Mainsail consistent with the other implementations.

```
RESPOND TYPE=command MSG="action:prompt_begin \"Question\""
RESPOND TYPE=command MSG="action:prompt_button Button1|RESPOND MSG=\"Clicked it!\""
RESPOND TYPE=command MSG="action:prompt_show"
```

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents

Implements discussion from #2045.

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

<img width="850" alt="Screenshot 2024-12-09 at 10 04 05 PM" src="https://github.com/user-attachments/assets/43cc386a-9133-4267-ae69-fc8e3a31de40">

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
