### PR TITLE
fix: fix z_tilt button for z_tilt_ng with Kalico

### DIFF
--- a/src/components/mixins/control.ts
+++ b/src/components/mixins/control.ts
@@ -55,7 +55,16 @@ export default class ControlMixin extends Vue {
     }
 
     get colorZTilt() {
-        const status = this.$store.state.printer.z_tilt?.applied ?? true
+        let status = true
+
+        // normal Klipper z_tilt
+        if ('z_tilt' in this.$store.state.printer) {
+            status = this.$store.state.printer.z_tilt?.applied
+        }
+        // check Kalico next gen z_tilt
+        else if ('z_tilt_ng' in this.$store.state.printer) {
+            status = this.$store.state.printer.z_tilt_ng?.applied
+        }
 
         return status ? 'primary' : 'warning'
     }

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -780,9 +780,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
     },
 
     existsZtilt: (state) => {
-        if (!state.configfile?.settings) return false
+        if (!state.gcode) return false
 
-        return 'z_tilt' in state.configfile.settings
+        return 'Z_TILT_ADJUST' in state.gcode.commands
     },
 
     existsBedTilt: (state) => {


### PR DESCRIPTION
## Description

This PR fix fix the z_tilt button for z_tilt_ng when using Kalico. I just changed the check from checking the config for a z_tilt section to just check if the gcode Z_TILT_ADJUST exists.

## Related Tickets & Documents

fixes #2067 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
