### PR TITLE
fix(Editor): fix maximal height of the sidebar

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -542,6 +542,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
 .structure-sidebar {
     width: 300px;
     overflow-y: auto;
+    max-height: calc(100vh - 48px);
 }
 ._structure-sidebar-item {
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description

This PR fixes the maximal height of the editor sidebar. When you have too many entries, it will add a scrollbar in this sidebar, instead of scrolling the complete editor fullscreen dialog.

## Related Tickets & Documents

fixes #2077 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
