### PR TITLE
fix(Tools): use gcode commands instead of config gcode macros

### DIFF
--- a/src/components/mixins/control.ts
+++ b/src/components/mixins/control.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import { PrinterStateMacro, PrinterStateToolchangeMacro } from '@/store/printer/types'
 
 @Component
 export default class ControlMixin extends Vue {
@@ -101,12 +100,12 @@ export default class ControlMixin extends Vue {
         return this.$store.getters['printer/getMacros']
     }
 
-    get toolchangeMacros(): PrinterStateToolchangeMacro[] {
-        return this.macros
-            .filter((macro: PrinterStateMacro) => macro.name.toUpperCase().match(/^T\d+/))
-            .sort((a: PrinterStateMacro, b: PrinterStateMacro) => {
-                const numberA = parseInt(a.name.slice(1))
-                const numberB = parseInt(b.name.slice(1))
+    get toolchangeMacros(): string[] {
+        return Object.keys(this.$store.state.printer.gcode?.commands ?? {})
+            .filter((gcode) => gcode.match(/^T\d+/))
+            .sort((a: string, b: string) => {
+                const numberA = parseInt(a.slice(1))
+                const numberB = parseInt(b.slice(1))
 
                 return numberA - numberB
             })

--- a/src/components/panels/Extruder/ExtruderControlPanelTools.vue
+++ b/src/components/panels/Extruder/ExtruderControlPanelTools.vue
@@ -3,7 +3,7 @@
         <v-row v-for="(row, index) in rows" :key="'row_' + index" class="mt-0">
             <v-col>
                 <v-item-group class="_btn-group py-0 px-3">
-                    <extruder-control-panel-tools-item v-for="macro in row" :key="macro.name" :macro="macro" />
+                    <extruder-control-panel-tools-item v-for="macro in row" :key="macro" :name="macro" />
                 </v-item-group>
             </v-col>
         </v-row>

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -241,12 +241,6 @@ export interface PrinterStateExtruderStepper {
     extruder: number
 }
 
-export interface PrinterStateToolchangeMacro {
-    name: string
-    active: boolean
-    color: string
-}
-
 export interface PrinterGetterObject {
     name: string
     type: string


### PR DESCRIPTION
## Description

This PR fix the issue when hardcoded gcodes are used instead of gcode_macros for tool macros.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
