### PR TITLE
fix: prevent config editor dialog overflow when there are too many `file structure` sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 # Changelog
 All notable changes to Mainsail will be documented in this file.
 
+## [2.13.2](https://github.com/mainsail-crew/mainsail/releases/tag/v2.13.2) - 2024-12-25
+### Bug Fixes and Improvements
+
+- **Editor**: Fix maximal height of the sidebar ([#2079](https://github.com/mainsail-crew/mainsail/pull/2079))
+- **Editor**: Fix docs link for Kalico ([#2080](https://github.com/mainsail-crew/mainsail/pull/2080))
+- **Tools**: Use gcode commands instead of config gcode macros ([#2088](https://github.com/mainsail-crew/mainsail/pull/2088))
+- **macro-prompts**: Preserve outer quotes ([#2076](https://github.com/mainsail-crew/mainsail/pull/2076))
+- Fix print start from dashboard for subdirectory files ([#2074](https://github.com/mainsail-crew/mainsail/pull/2074))
+- Hide horizontal scrollbar in StartPrintDialog.vue ([#2075](https://github.com/mainsail-crew/mainsail/pull/2075))
+- Fix z_tilt button for z_tilt_ng with Kalico ([#2078](https://github.com/mainsail-crew/mainsail/pull/2078))
+
+### Localization
+
+- **zh**: Update chinese locale ([#2081](https://github.com/mainsail-crew/mainsail/pull/2081))
+
 ## [2.13.1](https://github.com/mainsail-crew/mainsail/releases/tag/v2.13.1) - 2024-12-07
 ### Bug Fixes and Improvements
 


### PR DESCRIPTION
## Description

This PR fixes the editor dialog overflow issue that occurs when the configuration file contains numerous sections. Previously, when a config file had many sections, the file structure sidebar would extend beyond the viewport height, causing the entire dialog to overflow. The fix adds proper height constraints and scrolling behavior to maintain a clean layout.

## Related Tickets & Documents
No existing issue - implemented direct fix due to straightforward solution.

_Note: Future enhancement could involve refactoring the layout to use CSS Grid for improved structure:_
```css
grid-template-areas:
  "header header"
  "editor structure"
```

## Mobile & Desktop Screenshots/Recordings

Befor:
- File structure sidebar extended beyond viewport height
- Caused entire dialog to overflow
- Required vertical scrolling of whole interface

https://github.com/user-attachments/assets/dc992c19-999f-4b03-9390-e445bd6bdeb6

After:
- Content properly contained within viewport
- File structure sidebar scrolls independently
- Clean, consistent layout maintained
- 
https://github.com/user-attachments/assets/db2ab638-ec8c-427b-aefc-abe8d81f47db





