### PR TITLE
fix(z-tilt): Fix z_tilt check for older Klipper versions

### DIFF
--- a/src/components/mixins/control.ts
+++ b/src/components/mixins/control.ts
@@ -110,14 +110,24 @@ export default class ControlMixin extends Vue {
     }
 
     get toolchangeMacros(): string[] {
-        return Object.keys(this.$store.state.printer.gcode?.commands ?? {})
-            .filter((gcode) => gcode.match(/^T\d+/))
-            .sort((a: string, b: string) => {
-                const numberA = parseInt(a.slice(1))
-                const numberB = parseInt(b.slice(1))
+        const sortToolchangeMacros = (a: string, b: string) => {
+            const numberA = parseInt(a.slice(1))
+            const numberB = parseInt(b.slice(1))
 
-                return numberA - numberB
-            })
+            return numberA - numberB
+        }
+
+        const commands = this.$store.state.printer.gcode?.commands ?? null
+        if (commands) {
+            return Object.keys(commands)
+                .filter((gcode) => gcode.match(/^T\d+/))
+                .sort(sortToolchangeMacros)
+        }
+
+        return Object.keys(this.$store.state.printer)
+            .filter((gcode) => gcode.toLowerCase().match(/^gcode_macro t\d+/))
+            .map((gcode) => gcode.slice(gcode.indexOf(' ') + 1))
+            .sort(sortToolchangeMacros)
     }
 
     get existsClientLinearMoveMacro() {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -780,9 +780,19 @@ export const getters: GetterTree<PrinterState, RootState> = {
     },
 
     existsZtilt: (state) => {
-        if (!state.gcode) return false
+        // check for new Klipper gcode.commands for Z_TILT_ADJUST command
+        const commands = state.gcode?.commands ?? null
+        if (commands) {
+            return 'Z_TILT_ADJUST' in commands
+        }
 
-        return 'Z_TILT_ADJUST' in state.gcode.commands
+        // fallback for older Klipper versions
+        const settings = state.configfile?.settings ?? null
+        if (settings) {
+            return 'z_tilt' in settings
+        }
+
+        return false
     },
 
     existsBedTilt: (state) => {


### PR DESCRIPTION
## Description

This PR fix the z_tilt check and add a fallback for older Klipper versions in the control mixin.

## Related Tickets & Documents

fixes #2100 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
