### PR TITLE
feat(Temperatures): add menu to open Settings & turn off heaters

### DIFF
--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <tr v-longpress:600="(e) => openContentMenu(e)" @contextmenu.prevent="openContentMenu($event)">
+    <tr v-longpress:600="(e) => openContextMenu(e)" @contextmenu.prevent="openContextMenu($event)">
         <td class="icon">
             <v-icon :color="iconColor" :class="iconClass" tabindex="-1" @click="openEditDialog">
                 {{ icon }}
@@ -312,7 +312,7 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
         EventBus.$off('close-temperature-context-menu', this.closeContextMenu)
     }
 
-    openContentMenu(event: MouseEvent) {
+    openContextMenu(event: MouseEvent) {
         EventBus.$emit('close-temperature-context-menu')
 
         this.showContextMenu = true

--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -1,12 +1,12 @@
 <template>
-    <tr>
+    <tr v-longpress:600="(e) => openContentMenu(e)" @contextmenu.prevent="openContentMenu($event)">
         <td class="icon">
-            <v-icon :color="iconColor" :class="iconClass" tabindex="-1" @click="showEditDialog = true">
+            <v-icon :color="iconColor" :class="iconClass" tabindex="-1" @click="openEditDialog">
                 {{ icon }}
             </v-icon>
         </td>
         <td class="name">
-            <span class="cursor-pointer" @click="showEditDialog = true">{{ formatName }}</span>
+            <span class="cursor-pointer" @click="openEditDialog">{{ formatName }}</span>
         </td>
         <td v-if="!isResponsiveMobile" class="state">
             <v-tooltip v-if="state !== null" top>
@@ -57,6 +57,18 @@
             :icon="icon"
             :color="color"
             @close-dialog="showEditDialog = false" />
+        <v-menu v-model="showContextMenu" :position-x="contextMenuX" :position-y="contextMenuY" absolute offset-y>
+            <v-list>
+                <v-list-item v-if="isHeater" :disabled="!isHeaterActive" @click="turnOffHeater">
+                    <v-icon left>{{ mdiSnowflake }}</v-icon>
+                    {{ $t('Panels.TemperaturePanel.TurnHeaterOff') }}
+                </v-list-item>
+                <v-list-item @click="openEditDialog">
+                    <v-icon left>{{ mdiCog }}</v-icon>
+                    {{ $t('Panels.TemperaturePanel.Settings') }}
+                </v-list-item>
+            </v-list>
+        </v-menu>
     </tr>
 </template>
 
@@ -66,6 +78,7 @@ import { Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { convertName } from '@/plugins/helpers'
 import {
+    mdiCog,
     mdiFan,
     mdiFire,
     mdiMemory,
@@ -73,16 +86,24 @@ import {
     mdiPrinter3dNozzleAlert,
     mdiRadiator,
     mdiRadiatorDisabled,
+    mdiSnowflake,
     mdiThermometer,
 } from '@mdi/js'
 import { additionalSensors, opacityHeaterActive, opacityHeaterInactive } from '@/store/variables'
+import { EventBus } from '@/plugins/eventBus'
 
 @Component
 export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
+    mdiCog = mdiCog
+    mdiSnowflake = mdiSnowflake
+
     @Prop({ type: String, required: true }) readonly objectName!: string
     @Prop({ type: Boolean, required: true }) readonly isResponsiveMobile!: boolean
 
     showEditDialog = false
+    showContextMenu = false
+    contextMenuX = 0
+    contextMenuY = 0
 
     get printerObject() {
         if (!(this.objectName in this.$store.state.printer)) return {}
@@ -269,6 +290,49 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
         if (this.command === 'SET_TEMPERATURE_FAN_TARGET') return 'TEMPERATURE_FAN'
 
         return ''
+    }
+
+    get availableHeaters() {
+        return this.$store.state.printer.heaters?.available_heaters ?? []
+    }
+
+    get isHeater() {
+        return this.availableHeaters.includes(this.objectName)
+    }
+
+    get isHeaterActive() {
+        return this.target > 0
+    }
+
+    mounted() {
+        EventBus.$on('close-temperature-context-menu', this.closeContextMenu)
+    }
+
+    beforeDestroy() {
+        EventBus.$off('close-temperature-context-menu', this.closeContextMenu)
+    }
+
+    openContentMenu(event: MouseEvent) {
+        EventBus.$emit('close-temperature-context-menu')
+
+        this.showContextMenu = true
+        this.contextMenuX = event?.clientX || event?.pageX || window.screenX / 2
+        this.contextMenuY = event?.clientY || event?.pageY || window.screenY / 2
+    }
+
+    closeContextMenu() {
+        this.showContextMenu = false
+    }
+
+    openEditDialog() {
+        this.closeContextMenu()
+        this.showEditDialog = true
+    }
+
+    turnOffHeater() {
+        const gcode = `SET_HEATER_TEMPERATURE HEATER=${this.name} TARGET=0`
+        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
+        this.$socket.emit('printer.gcode.script', { script: gcode })
     }
 }
 </script>

--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -90,7 +90,7 @@ import {
     mdiThermometer,
 } from '@mdi/js'
 import { additionalSensors, opacityHeaterActive, opacityHeaterInactive } from '@/store/variables'
-import { EventBus } from '@/plugins/eventBus'
+import { CLOSE_TEMPERATURE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
 
 @Component
 export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
@@ -305,15 +305,15 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
     }
 
     mounted() {
-        EventBus.$on('close-temperature-context-menu', this.closeContextMenu)
+        EventBus.$on(CLOSE_TEMPERATURE_CONTEXT_MENU, this.closeContextMenu)
     }
 
     beforeDestroy() {
-        EventBus.$off('close-temperature-context-menu', this.closeContextMenu)
+        EventBus.$off(CLOSE_TEMPERATURE_CONTEXT_MENU, this.closeContextMenu)
     }
 
     openContextMenu(event: MouseEvent) {
-        EventBus.$emit('close-temperature-context-menu')
+        EventBus.$emit(CLOSE_TEMPERATURE_CONTEXT_MENU)
 
         this.showContextMenu = true
         this.contextMenuX = event?.clientX || event?.pageX || window.screenX / 2

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -799,6 +799,7 @@
             "Min": "min",
             "Name": "Name",
             "Presets": "Presets",
+            "Settings": "Settings",
             "SetupTemperatures": "Setup Temperatures",
             "ShowChart": "Show Chart",
             "ShowNameInChart": "Show {name} in chart",
@@ -807,7 +808,8 @@
             "Target": "Target",
             "TemperaturesInChart": "Temperature [°C]",
             "TempTooHigh": "Temperature too high for {name}! (max: {max})",
-            "TempTooLow": "Temperature too low for {name}! (min: {min})"
+            "TempTooLow": "Temperature too low for {name}! (min: {min})",
+            "TurnHeaterOff": "Turn Heater Off"
         },
         "ToolheadControlPanel": {
             "Absolute": "absolute",

--- a/src/plugins/eventBus.ts
+++ b/src/plugins/eventBus.ts
@@ -1,0 +1,2 @@
+import Vue from 'vue'
+export const EventBus = new Vue()

--- a/src/plugins/eventBus.ts
+++ b/src/plugins/eventBus.ts
@@ -1,2 +1,4 @@
 import Vue from 'vue'
 export const EventBus = new Vue()
+
+export const CLOSE_TEMPERATURE_CONTEXT_MENU = 'close-temperature-context-menu'


### PR DESCRIPTION
## Description

This PR adds a ContextMenu to each entry in the Temperature Panel to open the Settings dialog and for heaters add an option to turn of this specific heater.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

If heater has a target temp:
![image](https://github.com/user-attachments/assets/a3e9fcef-3b7a-4e38-a825-2abb01985bf1)

If heater has 0 as target temp:
![image](https://github.com/user-attachments/assets/b7f8a6ed-0af2-48c9-8df0-02e2b170c42c)

If the line is no heater:
![image](https://github.com/user-attachments/assets/e644a04b-afa2-4ccb-b809-6f26ffc3b95d)

## [optional] Are there any post-deployment tasks we need to perform?

none
