### PR TITLE
fix(Locale): Add missing translation key in SettingsControlTab

### DIFF
--- a/src/components/settings/SettingsControlTab.vue
+++ b/src/components/settings/SettingsControlTab.vue
@@ -15,7 +15,7 @@
                 </settings-row>
                 <v-divider class="my-2" />
                 <template v-if="['circle', 'cross'].includes(controlStyle) && actionOptions.length > 1">
-                    <settings-row :title="'Overwrite action button'">
+                    <settings-row :title="$t('Settings.ControlTab.OverwriteActionButton')">
                         <v-select v-model="actionButton" :items="actionOptions" outlined dense hide-details attach />
                     </settings-row>
                     <v-divider class="my-2" />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -939,6 +939,7 @@
             "MoveDistancesInMm": "Move distance increments (in mm)",
             "MoveDistancesXYInMm": "Move distance increments X & Y axes (in mm)",
             "MoveDistancesZInMm": "Move distance increments Z axis (in mm)",
+            "OverwriteActionButton": "Overwrite action button",
             "QuadGantryLevel": "Quad Gantry Level{isDefault}",
             "SpeedEInMms": "Extrusion speed presets (in mm/s)",
             "SpeedXY": "Movement speed X & Y axes",


### PR DESCRIPTION
## Description

This PR adds a missing translation key in the SettingsControlTab for "Overwrite action button".

## Related Tickets & Documents

fixes #2101 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
