### PR TITLE
feat(Editor): add option to set default state of the structure sidebar

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -396,8 +396,12 @@ export default class TheEditor extends Mixins(BaseMixin) {
             }
         }
 
-        this.fileStructureSidebar = true
+        this.fileStructureSidebar = this.defaultSidebarState
         return structure
+    }
+
+    get defaultSidebarState() {
+        return this.$store.state.gui.editor.defaultSidebarState ?? true
     }
 
     cancelDownload() {

--- a/src/components/settings/SettingsEditorTab.vue
+++ b/src/components/settings/SettingsEditorTab.vue
@@ -34,6 +34,13 @@
                         dense
                         attached />
                 </settings-row>
+                <v-divider class="my-2" />
+                <settings-row
+                    :title="$t('Settings.EditorTab.DefaultSidebarState')"
+                    :sub-title="$t('Settings.EditorTab.DefaultSidebarStateDescription')"
+                    :dynamic-slot-width="true">
+                    <v-switch v-model="defaultSidebarState" hide-details class="mt-0" />
+                </settings-row>
             </v-card-text>
         </v-card>
     </div>
@@ -97,6 +104,14 @@ export default class SettingsEditorTab extends Mixins(BaseMixin) {
 
     set klipperRestartMethod(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'editor.klipperRestartMethod', value: newVal })
+    }
+
+    get defaultSidebarState() {
+        return this.$store.state.gui.editor.defaultSidebarState
+    }
+
+    set defaultSidebarState(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'editor.defaultSidebarState', value: newVal })
     }
 }
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -962,6 +962,8 @@
         "EditorTab": {
             "ConfirmUnsavedChanges": "Prompt to save or discard unsaved changes",
             "ConfirmUnsavedChangesDescription": "If enabled, the editor requires a confirmation to either save or discard the changes made. If disabled, changes are silently discarded.",
+            "DefaultSidebarState": "Default Sidebar State",
+            "DefaultSidebarStateDescription": "Set the default state of the editor sidebar (open/closed).",
             "Editor": "Editor",
             "KlipperRestartMethod": "Klipper restart method",
             "KlipperRestartMethodDescription": "Select which restart method will be used on 'Save & Restart' when editing Klipper config files.",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -122,6 +122,7 @@ export const getDefaultState = (): GuiState => {
             confirmUnsavedChanges: true,
             klipperRestartMethod: 'FIRMWARE_RESTART',
             tabSize: 2,
+            defaultSidebarState: true,
         },
         gcodeViewer: {
             extruderColors: ['#E76F51FF', '#F4A261FF', '#E9C46AFF', '#2A9D8FFF', '#264653FF'],

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -62,6 +62,7 @@ export interface GuiState {
         confirmUnsavedChanges: boolean
         klipperRestartMethod: 'FIRMWARE_RESTART' | 'RESTART'
         tabSize: number
+        defaultSidebarState: boolean
     }
     gcodeViewer: {
         extruderColors: string[]


### PR DESCRIPTION
## Description

This PR adds an option to set the default state of the structure sidebar in the editor.

## Related Tickets & Documents

fixes #2106 

## Mobile & Desktop Screenshots/Recordings

Option in the Interface Settings > Editor Tab
![image](https://github.com/user-attachments/assets/9d700eb3-d301-4b2d-b11a-192bba93f26f)

## [optional] Are there any post-deployment tasks we need to perform?

none
