### PR TITLE
feat(Console): Improve key up/down function in Console textarea

### DIFF
--- a/src/components/inputs/ConsoleTextarea.vue
+++ b/src/components/inputs/ConsoleTextarea.vue
@@ -16,8 +16,8 @@
         :prepend-icon="isTouchDevice ? mdiChevronDoubleRight : ''"
         :append-icon="mdiSend"
         @keydown.enter.prevent.stop="doSend"
-        @keyup.up="onKeyUp"
-        @keyup.down="onKeyDown"
+        @keydown.up="onKeyUp"
+        @keydown.down="onKeyDown"
         @keydown.tab="onAutocomplete"
         @click:prepend="onAutocomplete"
         @click:append="doSend" />
@@ -45,6 +45,12 @@ export default class ConsoleTextarea extends Mixins(BaseMixin, ConsoleMixin) {
         return this.gcode?.split('\n').length ?? 1
     }
 
+    getCurrentLine(): number {
+        const textarea = this.gcodeCommandField.$refs.input
+        const textBeforeCursor = textarea.value.substring(0, textarea.selectionStart)
+        return textBeforeCursor.split('\n').length
+    }
+
     setGcode(gcode: string): void {
         this.gcode = gcode
 
@@ -53,7 +59,11 @@ export default class ConsoleTextarea extends Mixins(BaseMixin, ConsoleMixin) {
         })
     }
 
-    onKeyUp(): void {
+    onKeyUp(event: KeyboardEvent): void {
+        const currentLine = this.getCurrentLine()
+        if (this.rows > 1 && currentLine > 1) return
+
+        event.preventDefault()
         if (this.lastCommandNumber === null && this.lastCommands.length) {
             this.lastCommandNumber = this.lastCommands.length - 1
             this.gcode = this.lastCommands[this.lastCommandNumber]
@@ -63,7 +73,12 @@ export default class ConsoleTextarea extends Mixins(BaseMixin, ConsoleMixin) {
         }
     }
 
-    onKeyDown(): void {
+    onKeyDown(event: KeyboardEvent): void {
+        const currentLine = this.getCurrentLine()
+        if (this.rows > currentLine) return
+
+        event.preventDefault()
+
         if (this.lastCommandNumber === null) return
 
         if (this.lastCommandNumber < this.lastCommands.length - 1) {


### PR DESCRIPTION
## Description

This PR improves the key up/down function in the console history to scroll/jump multiline inputs up/down instead of jumping for/back in the history.

## Related Tickets & Documents

fixes #609 

## Mobile & Desktop Screenshots/Recordings

https://github.com/user-attachments/assets/9a630067-142c-42c5-8a00-d0d8c463b2b3

## [optional] Are there any post-deployment tasks we need to perform?

none
