### PR TITLE
fix: update Gcode-Viewer lib from sindarius to fix G2/G3 visualisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@codemirror/view": "^6.0.3",
                 "@jaames/iro": "^5.5.2",
                 "@lezer/highlight": "^1.0.0",
-                "@sindarius/gcodeviewer": "^3.7.13",
+                "@sindarius/gcodeviewer": "^3.7.15",
                 "@uiw/codemirror-theme-vscode": "^4.19.11",
                 "axios": "^1.7.4",
                 "codemirror": "^6.0.1",
@@ -3195,9 +3195,9 @@
             "dev": true
         },
         "node_modules/@sindarius/gcodeviewer": {
-            "version": "3.7.13",
-            "resolved": "https://registry.npmjs.org/@sindarius/gcodeviewer/-/gcodeviewer-3.7.13.tgz",
-            "integrity": "sha512-VADagtkvPlPmPOkFJ2qZSiQ/+SjBN/c5HLqBjsTws8pwvCrrcoXtwECl/DYNiji7W5V7g1Fy61do9Ow3g2aS0w==",
+            "version": "3.7.15",
+            "resolved": "https://registry.npmjs.org/@sindarius/gcodeviewer/-/gcodeviewer-3.7.15.tgz",
+            "integrity": "sha512-4puvAzdUj6G66IFdhNS8apcweTFC/f8kdjLenrzUTysPT5goxZYT2jFbQWR+gfJ+N9J77uiNVVc/FEF3L5wNEw==",
             "dependencies": {
                 "@babylonjs/core": "^7.29.0",
                 "@babylonjs/inspector": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@codemirror/view": "^6.0.3",
         "@jaames/iro": "^5.5.2",
         "@lezer/highlight": "^1.0.0",
-        "@sindarius/gcodeviewer": "^3.7.13",
+        "@sindarius/gcodeviewer": "^3.7.15",
         "@uiw/codemirror-theme-vscode": "^4.19.11",
         "axios": "^1.7.4",
         "codemirror": "^6.0.1",


### PR DESCRIPTION
## Description

This PR update the gcode-viewer lib to fix G2/G3 visualisation.

## Related Tickets & Documents

fixes: #2123 

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/user-attachments/assets/48b7f7c8-3942-4ff3-b248-5960cdb83c11)

## [optional] Are there any post-deployment tasks we need to perform?

none
