### PR TITLE
fix(History): fix count per page switch in the History List Panel

### DIFF
--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -457,7 +457,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin, HistoryMixin, Hi
     }
 
     get countPerPage() {
-        return this.$store.state.gui.view.historycountPerPage
+        return this.$store.state.gui.view.history.countPerPage ?? 10
     }
 
     set countPerPage(newVal) {


### PR DESCRIPTION
## Description

This PR fix the "count per page" switch in the History List Panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
