### PR TITLE
fix(Timelapse): fix count per page switch in the Timelapse Files Panel

### DIFF
--- a/src/components/panels/Timelapse/TimelapseFilesPanel.vue
+++ b/src/components/panels/Timelapse/TimelapseFilesPanel.vue
@@ -599,7 +599,7 @@ export default class TimelapseFilesPanel extends Mixins(BaseMixin) {
     }
 
     get countPerPage() {
-        return this.$store.state.gui.view.gcodefiles?.countPerPage ?? 10
+        return this.$store.state.gui.view.timelapse?.countPerPage ?? 10
     }
 
     set countPerPage(newVal) {


### PR DESCRIPTION
## Description

This PR fix the "count per page" select in the Timelapse Files Panel.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
