### PR TITLE
fix: show system panel when klipper is not ready

### DIFF
--- a/src/components/panels/Machine/SystemPanel.vue
+++ b/src/components/panels/Machine/SystemPanel.vue
@@ -1,6 +1,6 @@
 <template>
     <panel
-        v-if="klipperReadyForGui"
+        v-if="showPanel"
         :title="$t('Machine.SystemPanel.SystemLoad')"
         :icon="mdiMemory"
         card-class="machine-systemload-panel"
@@ -44,6 +44,8 @@ export default class SystemPanel extends Mixins(BaseMixin) {
     dialogDevices = false
 
     get mcus() {
+        if (!this.klipperReadyForGui) return []
+
         const mcus = this.$store.getters['printer/getMcus'] ?? []
 
         return caseInsensitiveSort(mcus, 'name')
@@ -51,6 +53,10 @@ export default class SystemPanel extends Mixins(BaseMixin) {
 
     get hostStats() {
         return this.$store.getters['server/getHostStats'] ?? null
+    }
+
+    get showPanel() {
+        return this.mcus.length > 0 || this.hostStats
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR fix the issue with "not showing System Panel", when Klipper is not ready. 

## Related Tickets & Documents

fixes: #2147 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
