### PR TITLE
fix(spoolman): save spool id in lowercase variable

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -208,7 +208,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         }
 
         // Set spool_id to save_variable
-        const gcode2 = `SAVE_VARIABLE VARIABLE=${this.tool.toUpperCase()}__SPOOL_ID VALUE=${spool.id}`
+        const gcode2 = `SAVE_VARIABLE VARIABLE=${this.tool.toLowerCase()}__spool_id VALUE=${spool.id}`
         this.$store.dispatch('server/addEvent', { message: gcode2, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode2 })
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

Fixes an issue with saving spool IDs for individual tools on a multi-tool instance. Currently, no updates are written to the variables file and an error is shown when selcting a new spool for any toolhead. The cause appears to be that upper case letters (which the current implementation uses) are not allowed. See the [Klipper docs](https://www.klipper3d.org/G-Codes.html#save_variable).
This PR simply changes the variable name to lower case, resolving the problem.

Running Klipper v0.12.0-451, Moonraker v0.9.3-65

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings

Console output displaying the error message:
![grafik](https://github.com/user-attachments/assets/1205c7c2-0a03-49f3-8ec9-8d6376e72e26)

## [optional] Are there any post-deployment tasks we need to perform?

n/a

Signed-off-by: Paul Gendolla <contact@gendolla.net>