### PR TITLE
feat: Add load cell gram scales in misc panel

### DIFF
--- a/src/components/panels/Miscellaneous/MiscellaneousSensor.vue
+++ b/src/components/panels/Miscellaneous/MiscellaneousSensor.vue
@@ -29,7 +29,7 @@ export default class MiscellaneousSensor extends Mixins(BaseMixin) {
     @Prop({ type: String, required: false }) declare readonly unit: string
 
     get output() {
-        const value = isNaN(this.value) ? '---' : this.value
+        const value = isNaN(this.value) ? '--' : this.value
 
         if (this.unit === null) return this.value
 

--- a/src/components/panels/Miscellaneous/MiscellaneousSensor.vue
+++ b/src/components/panels/Miscellaneous/MiscellaneousSensor.vue
@@ -1,0 +1,45 @@
+<template>
+    <v-container class="px-0 py-2">
+        <v-row>
+            <v-col class="pb-3">
+                <v-subheader class="_miscellaneous-sensor-subheader">
+                    <v-icon small class="mr-2">{{ unitToSymbol(unit) }}</v-icon>
+                    <span>{{ convertName(name) }}</span>
+                    <v-spacer />
+                    <span>{{ output }}</span>
+                </v-subheader>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>
+
+<script lang="ts">
+import { convertName, unitToSymbol } from '@/plugins/helpers'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import {} from '@mdi/js'
+
+@Component()
+export default class MiscellaneousSensor extends Mixins(BaseMixin) {
+    convertName = convertName
+    unitToSymbol = unitToSymbol
+
+    @Prop({ type: String, required: true }) declare readonly name: string
+    @Prop({ type: Number, required: true }) declare readonly value: number
+    @Prop({ type: String, required: false }) declare readonly unit: string
+
+    get output() {
+        const value = isNaN(this.value) ? '---' : this.value
+
+        if (this.unit === null) return this.value
+
+        return `${value} ${this.unit}`
+    }
+}
+</script>
+
+<style scoped>
+._miscellaneous-sensor-subheader {
+    height: auto;
+}
+</style>

--- a/src/components/panels/Miscellaneous/MoonrakerSensorValue.vue
+++ b/src/components/panels/Miscellaneous/MoonrakerSensorValue.vue
@@ -1,29 +1,23 @@
 <template>
     <div class="d-flex w-100 flex-row align-center">
-        <v-icon small left>{{ symbol }}</v-icon>
+        <v-icon small left>{{ unitToSymbol(unit) }}</v-icon>
         <span class="flex-grow-1">{{ name }}:</span>
         <span>{{ output }}</span>
     </div>
 </template>
 
 <script lang="ts">
-import { convertName } from '@/plugins/helpers'
+import { convertName, unitToSymbol } from '@/plugins/helpers'
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { mdiGauge, mdiLightningBoltOutline, mdiFlash, mdiThermometer, mdiMeterElectricOutline } from '@mdi/js'
 
 @Component
 export default class MoonrakerSensorValue extends Mixins(BaseMixin) {
     convertName = convertName
+    unitToSymbol = unitToSymbol
 
     @Prop({ type: String, required: true }) declare readonly sensor: string
     @Prop({ type: String, required: true }) declare readonly valueName: string
-
-    mdiGauge = mdiGauge
-    mdiLightningBoltOutline = mdiLightningBoltOutline
-    mdiFlash = mdiFlash
-    mdiThermometer = mdiThermometer
-    mdiMeterElectricOutline = mdiMeterElectricOutline
 
     get sensorData() {
         const sensors = this.$store.state.server.sensor.sensors
@@ -67,26 +61,6 @@ export default class MoonrakerSensorValue extends Mixins(BaseMixin) {
 
     get name() {
         return this.convertName(this.valueName)
-    }
-
-    get symbol() {
-        if (['wh', 'kwh', 'mwh', 'j'].includes(this.unit?.toLowerCase())) {
-            return this.mdiLightningBoltOutline
-        }
-
-        if (['w', 'v'].includes(this.unit?.toLowerCase())) {
-            return this.mdiFlash
-        }
-
-        if (this.unit?.toLowerCase() === 'a') {
-            return this.mdiMeterElectricOutline
-        }
-
-        if (['°c', 'c', '°f', 'f', '°'].includes(this.unit?.toLowerCase())) {
-            return this.mdiThermometer
-        }
-
-        return this.mdiGauge
     }
 }
 </script>

--- a/src/components/panels/MiscellaneousPanel.vue
+++ b/src/components/panels/MiscellaneousPanel.vue
@@ -40,8 +40,19 @@
                 :enabled="sensor.enabled"
                 :filament_detected="sensor.filament_detected" />
         </div>
-        <div v-for="(sensor, index) of moonrakerSensors" :key="'moonraker_sensor_' + index">
+        <div v-for="(sensor, index) of miscellaneousSensors" :key="'miscellaneous_sensor_' + index">
             <v-divider v-if="index || miscellaneous.length || lights.length || filamentSensors.length" />
+            <miscellaneous-sensor :name="sensor.name" :value="sensor.value" :unit="sensor.unit" />
+        </div>
+        <div v-for="(sensor, index) of moonrakerSensors" :key="'moonraker_sensor_' + index">
+            <v-divider
+                v-if="
+                    index ||
+                    miscellaneous.length ||
+                    lights.length ||
+                    filamentSensors.length ||
+                    miscellaneousSensors.length
+                " />
             <moonraker-sensor :name="sensor" />
         </div>
     </panel>
@@ -53,11 +64,19 @@ import BaseMixin from '@/components/mixins/base'
 import MiscellaneousSlider from '@/components/inputs/MiscellaneousSlider.vue'
 import MiscellaneousLight from '@/components/inputs/MiscellaneousLight.vue'
 import FilamentSensor from '@/components/inputs/FilamentSensor.vue'
+import MiscellaneousSensor from '@/components/panels/Miscellaneous/MiscellaneousSensor.vue'
 import MoonrakerSensor from '@/components/panels/Miscellaneous/MoonrakerSensor.vue'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiDipSwitch } from '@mdi/js'
 @Component({
-    components: { Panel, FilamentSensor, MiscellaneousSlider, MiscellaneousLight, MoonrakerSensor },
+    components: {
+        Panel,
+        FilamentSensor,
+        MiscellaneousSlider,
+        MiscellaneousLight,
+        MiscellaneousSensor,
+        MoonrakerSensor,
+    },
 })
 export default class MiscellaneousPanel extends Mixins(BaseMixin) {
     mdiDipSwitch = mdiDipSwitch
@@ -72,6 +91,10 @@ export default class MiscellaneousPanel extends Mixins(BaseMixin) {
 
     get lights() {
         return this.$store.getters['printer/getLights'] ?? []
+    }
+
+    get miscellaneousSensors() {
+        return this.$store.getters['printer/getMiscellaneousSensors'] ?? []
     }
 
     get moonrakerSensors() {

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -1,5 +1,6 @@
 import { FileStateFile } from '@/store/files/types'
 import { PrinterStateMacroParams } from '@/store/printer/types'
+import { mdiFlash, mdiGauge, mdiLightningBoltOutline, mdiMeterElectricOutline, mdiScale, mdiThermometer } from '@mdi/js'
 import Vue from 'vue'
 
 export const setDataDeep = (currentState: any, payload: any) => {
@@ -290,4 +291,29 @@ export function escapePath(path: string): string {
         .split('/')
         .map((part) => encodeURIComponent(part))
         .join('/')
+}
+
+export const unitToSymbol = (unit: string): string => {
+    return (
+        {
+            // Energy
+            wh: mdiLightningBoltOutline,
+            kwh: mdiLightningBoltOutline,
+            mwh: mdiLightningBoltOutline,
+            j: mdiLightningBoltOutline,
+            // Power
+            w: mdiFlash,
+            // Electrical
+            v: mdiFlash,
+            a: mdiMeterElectricOutline,
+            // Temperature
+            '°c': mdiThermometer,
+            c: mdiThermometer,
+            '°f': mdiThermometer,
+            f: mdiThermometer,
+            '°': mdiThermometer,
+            // Mass
+            g: mdiScale,
+        }[unit?.toLowerCase()] ?? mdiGauge
+    )
 }

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -125,6 +125,13 @@ export interface PrinterStateMiscellaneous {
     max_power?: number
 }
 
+export interface PrinterStateMiscellaneousSensor {
+    type: string
+    name: string
+    value: number
+    unit: string
+}
+
 export interface PrinterStateFilamentSensors {
     name: string
     enabled: boolean


### PR DESCRIPTION
## Description

This adds a new general purpose `MiscellaneousSensor`, with support for only load_cell gram scales. This is just a simple single line entry in the MiscellaneousPanel, with a getter to extract the value from the printer state.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings

With an uncalibrated load cell:

<img width="846" alt="image" src="https://github.com/user-attachments/assets/ea6a70d6-48a7-401c-a4af-53d6a472a53c" />

After calibration:

<img width="846" alt="image" src="https://github.com/user-attachments/assets/66cd0b2f-1bf5-4782-80af-90d02cb9dcd1" />

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
