### PR TITLE
chore: remove deprecated @types/cypress package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
             },
             "devDependencies": {
                 "@mdi/js": "^7.0.0",
-                "@types/cypress": "^1.1.6",
                 "@types/file-saver": "^2.0.5",
                 "@types/jmuxer": "^2.0.3",
                 "@types/lodash.kebabcase": "^4.1.6",
@@ -3012,16 +3011,6 @@
                 }
             }
         },
-        "node_modules/@rollup/pluginutils": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.35.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.35.0.tgz",
@@ -3308,16 +3297,6 @@
             "dev": true,
             "dependencies": {
                 "sourcemap-codec": "^1.4.8"
-            }
-        },
-        "node_modules/@types/cypress": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.6.tgz",
-            "integrity": "sha512-CfeLLD3+6vIWe2AO5hR63f1c8EbRzrp/j1ExubAwOTpwZFZvF3Nm9cOPQiUwzNmAUmZuhO0QVH98Qlujni6nPw==",
-            "deprecated": "This is a stub types definition. cypress provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "cypress": "*"
             }
         },
         "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     },
     "devDependencies": {
         "@mdi/js": "^7.0.0",
-        "@types/cypress": "^1.1.6",
         "@types/file-saver": "^2.0.5",
         "@types/jmuxer": "^2.0.3",
         "@types/lodash.kebabcase": "^4.1.6",


### PR DESCRIPTION
## Description

This PR just remove the deprecated package `@types/cypress`. This is already included in the cypress package.

## Related Tickets & Documents

More infos about it here: https://www.npmjs.com/package/@types/cypress

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
