### PR TITLE
feat: Support providing moonraker with an apikey

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -54,5 +54,6 @@ export const actions: ActionTree<RootState, RootState> = {
         if (payload.hostname) commit('socket/setData', { hostname: payload.hostname })
         if (payload.port) commit('socket/setData', { port: parseInt(payload.port.toString()) })
         if (payload.path) commit('socket/setData', { route_prefix: payload.path })
+        if (payload.apikey) commit('server/setData', { apikey: payload.apikey })
     },
 }

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -16,7 +16,7 @@ export const actions: ActionTree<ServerState, RootState> = {
         dispatch('updateManager/reset')
     },
 
-    async init({ commit, dispatch, rootState }) {
+    async init({ commit, dispatch, state, rootState }) {
         window.console.debug('init Server')
 
         // identify client
@@ -26,6 +26,7 @@ export const actions: ActionTree<ServerState, RootState> = {
                 version: rootState.packageVersion,
                 type: 'web',
                 url: 'https://github.com/mainsail-crew/mainsail',
+                api_key: state.apikey,
             })
             commit('setConnectionId', connection.connection_id)
         } catch (e: any) {

--- a/src/store/server/index.ts
+++ b/src/store/server/index.ts
@@ -28,6 +28,7 @@ export const getDefaultState = (): ServerState => {
         warnings: [],
         registered_directories: [],
         events: [],
+        apikey: null,
         config: {},
         system_info: null,
         system_boot_at: null,

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -15,6 +15,7 @@ export interface ServerState {
     warnings: string[]
     registered_directories: string[]
     events: ServerStateEvent[]
+    apikey: string | null
     config: {
         // eslint-disable-next-line
         [key: string]: any

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -31,6 +31,7 @@ export interface ConfigJson {
     path?: string | null
     instancesDB?: 'moonraker' | 'browser' | 'json'
     instances?: ConfigJsonInstance[]
+    apikey?: string | null
 }
 
 export interface ConfigJsonInstance {


### PR DESCRIPTION
## Description

This PR adds the authentication with api-key feature. 

Adds an optional ‘apikey’ value to the config.json file.  This is then passed through to the web socket connection, and given to moonraker to authenticate.

## Related Tickets & Documents

Fixes #2184
