### PR TITLE
ci(check-locale): fix issues with i18n-extract workflow

### DIFF
--- a/.github/workflows/check_locale.yml
+++ b/.github/workflows/check_locale.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir ./i18n-extract
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            npm vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --exclude '_last_update' --output './i18n-extract/${file##*/}'
+            vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --exclude '_last_update' --output './i18n-extract/${file##*/}'
             MISSING=$(cat i18n-extract/${file##*/} | jq '.missingKeys | length')
             UNUSED=$(cat i18n-extract/${file##*/} | jq '.unusedKeys | length')
             echo "$file=|${file##*/}|${MISSING}|${UNUSED}|" >> $GITHUB_OUTPUT

--- a/.github/workflows/check_locale.yml
+++ b/.github/workflows/check_locale.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir ./i18n-extract
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --exclude '_last_update' --output './i18n-extract/${file##*/}'
+            vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --output './i18n-extract/${file##*/}'
             MISSING=$(cat i18n-extract/${file##*/} | jq '.missingKeys | length')
             UNUSED=$(cat i18n-extract/${file##*/} | jq '.unusedKeys | length')
             echo "$file=|${file##*/}|${MISSING}|${UNUSED}|" >> $GITHUB_OUTPUT

--- a/.github/workflows/check_locale.yml
+++ b/.github/workflows/check_locale.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir ./i18n-extract
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            npm run i18n-extract -- --languageFiles=src/locales/${file##*/} --output=i18n-extract/${file##*/}
+            npm vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --exclude '_last_update' --output './i18n-extract/${file##*/}'
             MISSING=$(cat i18n-extract/${file##*/} | jq '.missingKeys | length')
             UNUSED=$(cat i18n-extract/${file##*/} | jq '.unusedKeys | length')
             echo "$file=|${file##*/}|${MISSING}|${UNUSED}|" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ package-lock.json
 cypress/screenshots/
 cypress/videos/
 components.d.ts
+i18n-extract

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint --ignore-path .gitignore src",
         "lint:fix": "npm run lint -- --fix",
         "build.zip": "cd ./dist && zip -r mainsail.zip ./ -x '**.DS_Store' ./ && cd ..",
-        "i18n-extract": "vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/*.json' --exclude '_last_update'",
+        "i18n-extract": "vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/*.json'",
         "preview": "vite preview",
         "start": "vite build && vite preview",
         "test": "start-server-and-test preview http://127.0.0.1:4173/ 'cypress run'",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint --ignore-path .gitignore src",
         "lint:fix": "npm run lint -- --fix",
         "build.zip": "cd ./dist && zip -r mainsail.zip ./ -x '**.DS_Store' ./ && cd ..",
-        "i18n-extract": "vue-i18n-extract use-config",
+        "i18n-extract": "vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/*.json' --exclude '_last_update'",
         "preview": "vite preview",
         "start": "vite build && vite preview",
         "test": "start-server-and-test preview http://127.0.0.1:4173/ 'cypress run'",

--- a/vue-i18n-extract.config.js
+++ b/vue-i18n-extract.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-    vueFiles: './src/**/{*.?(js|ts|vue),.i18nignore}',
-    languageFiles: './src/locales/*.json',
-    exclude: ['_last_update'],
-    output: false,
-    add: false,
-    ci: false,
-}


### PR DESCRIPTION
## Description

This PR fix the workflow "check_locale". This was broken until i uploaded all dependencies (#2168). It looks like a bug in the current vue-i18n-extract package with the glob dependencies.

I removed the "use-config" attribute and use the config inline, which is a workaround for the current issue in vue-i18n-extract package.

## Related Tickets & Documents

- issue in vue-i18n-extract repo: https://github.com/Spittal/vue-i18n-extract/issues/159
- happy hair PR which failed with the current workflow: https://github.com/mainsail-crew/mainsail/pull/2158

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
