### PR TITLE
ci: use GITHUB_TOKEN in auto-analyze.yml

### DIFF
--- a/.github/workflows/auto-analyze.yml
+++ b/.github/workflows/auto-analyze.yml
@@ -33,4 +33,4 @@ jobs:
           strip-hash: "\\b\\w{8}\\."
           pattern: './dist/**/*.{js,css,html,json,woff2,svg,png}'
           exclude: '{./dist/manifest.json,./dist/build.zip,**/*.map,**/node_modules/**}'
-          repo-token: '${{ secrets.PAT }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR change back to the GITHUB_TOKEN in the auto-analyze.yml.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
