### PR TITLE
ci(check-locale): fix path to vue-i18n-extract script

### DIFF
--- a/.github/workflows/check_locale.yml
+++ b/.github/workflows/check_locale.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir ./i18n-extract
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            ./node_modules/vue-i18n-extract/bin/vue-i18n-extract.js --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --output './i18n-extract/${file##*/}'
+            npx vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --output './i18n-extract/${file##*/}'
             MISSING=$(cat i18n-extract/${file##*/} | jq '.missingKeys | length')
             UNUSED=$(cat i18n-extract/${file##*/} | jq '.unusedKeys | length')
             echo "$file=|${file##*/}|${MISSING}|${UNUSED}|" >> $GITHUB_OUTPUT

--- a/.github/workflows/check_locale.yml
+++ b/.github/workflows/check_locale.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir ./i18n-extract
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --output './i18n-extract/${file##*/}'
+            ./node_modules/vue-i18n-extract/bin/vue-i18n-extract.js --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/${file##*/}' --output './i18n-extract/${file##*/}'
             MISSING=$(cat i18n-extract/${file##*/} | jq '.missingKeys | length')
             UNUSED=$(cat i18n-extract/${file##*/} | jq '.unusedKeys | length')
             echo "$file=|${file##*/}|${MISSING}|${UNUSED}|" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

This PR fix the path to the vue-i18n-extract script, because this script will not be installed global.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
