### PR TITLE
feat: add -unprivileged docker image to conform with restrired pod security standard

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
+          tags: &tags |
             type=edge,branch=develop
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -56,5 +56,24 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
+          target: runner
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for unprivileged Docker
+        id: meta-unprivileged
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-unprivileged
+          tags: *tags
+
+      - name: Build and push unprivileged Docker image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          push: ${{ github.event_name != 'pull_request' }}
+          target: unprivileged
+          tags: ${{ steps.meta-unprivileged.outputs.tags }}
+          labels: ${{ steps.meta-unprivileged.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,16 @@ COPY ./ /app/
 
 RUN npm run build
 
+# set port to >1024 port for non root running
+RUN sed 's/80/8080/g' .docker/nginx.conf > .docker/nginx.conf.unprivileged
+
 #
 # Unprivileged runner stage, runs the application in nginx
 #
 FROM nginxinc/nginx-unprivileged:stable-alpine AS unprivileged
 
-COPY --link --from=builder /app/.docker/nginx.conf  /etc/nginx/conf.d/default.conf
+COPY --link --from=builder /app/.docker/nginx.conf.unprivileged  /etc/nginx/conf.d/default.conf
 COPY --link --from=builder /app/dist/ /usr/share/nginx/html/
-
-# set port to >1024 port for non root running
-RUN sed -i 's/80/8080/g' /etc/nginx/conf.d/default.conf
 
 USER nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder stage, builds the application in node
 #
-FROM --platform=$BUILDPLATFORM node:20-alpine as builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 
 RUN apk add zip
 
@@ -15,9 +15,22 @@ COPY ./ /app/
 RUN npm run build
 
 #
+# Unprivileged runner stage, runs the application in nginx
+#
+FROM nginxinc/nginx-unprivileged:stable-alpine AS unprivileged
+
+COPY --link --from=builder /app/.docker/nginx.conf  /etc/nginx/conf.d/default.conf
+COPY --link --from=builder /app/dist/ /usr/share/nginx/html/
+
+# set port to >1024 port for non root running
+RUN sed -i 's/80/8080/g' /etc/nginx/conf.d/default.conf
+
+USER nginx
+
+#
 # Runner stage, runs the application in nginx
 #
-FROM nginx:stable-alpine as runner
+FROM nginx:stable-alpine AS runner
 
 COPY --from=builder /app/.docker/nginx.conf  /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist/ /usr/share/nginx/html/


### PR DESCRIPTION
## Description

This makes the image compliant with the restricted pod security standard:
https://kubernetes.io/docs/concepts/security/pod-security-standards/

There is major difference to the current image in that it now listens on port 8080 since ports below 1024 can only be opened by privileged users. I don't really know how to proceed with this.
Is this something that can be released with a note in the releasenotes and an update to the docs? Or I could setup a separate image which uses a `-unprivileged` postfix on the tags and keep the current image the same.
Or update the current image but setup a `-privileged` postfix with the root running image as a legacy option?

Besides that this is a good security practice, this enabled this image to run in more restricted environments where the pod security standard is enforced (Kubernetes mostly). The Talos Kubernetes enforces the restricted profile by default for example.

## Related Tickets & Documents

Fixes: #1212

## Are there any post-deployment tasks we need to perform?

A docs update is needed (which I can do) but we need to decide what the approach will be first :)
