### PR TITLE
chore: update ISSUE_TEMPLATEs zu use the type field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: You found an issue while using Mainsail? Report it here!
-labels: ['⚡ Type: Bug']
+type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: You found an issue while using Mainsail? Report it here!
-type: 'Bug'
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature request
 description: You have an idea for a new feature? Tell us here!
+type: feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: You have an idea for a new feature? Tell us here!
-labels: ['💡 Type: FR']
+type: 'Feature'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: You have an idea for a new feature? Tell us here!
-type: 'Feature'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Description

This PR change from labels to types in the issue tracker for new bugfixes and feature requests.

## Related Tickets & Documents

- Blogpost: https://github.blog/changelog/2025-01-12-evolving-github-issues-public-preview/#%f0%9f%93%81-organize-your-work-with-issue-types
- Public preview: https://github.com/orgs/community/discussions/148715

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
