### PR TITLE
feat: Automatic print start dialog on upload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
             <the-editor />
             <the-timelapse-rendering-snackbar />
             <the-fullscreen-upload />
+            <the-launch-file-handler />
             <the-upload-snackbar />
             <the-manual-probe-dialog />
             <the-bed-screws-dialog />
@@ -38,6 +39,7 @@ import TheEditor from '@/components/TheEditor.vue'
 import { panelToolbarHeight, topbarHeight, navigationItemHeight } from '@/store/variables'
 import TheTimelapseRenderingSnackbar from '@/components/TheTimelapseRenderingSnackbar.vue'
 import TheFullscreenUpload from '@/components/TheFullscreenUpload.vue'
+import TheLaunchFileHandler from '@/components/TheLaunchFileHandler.vue'
 import TheUploadSnackbar from '@/components/TheUploadSnackbar.vue'
 import TheManualProbeDialog from '@/components/dialogs/TheManualProbeDialog.vue'
 import TheBedScrewsDialog from '@/components/dialogs/TheBedScrewsDialog.vue'
@@ -59,6 +61,7 @@ Component.registerHooks(['metaInfo'])
         TheTopbar,
         TheSidebar,
         TheFullscreenUpload,
+        TheLaunchFileHandler,
         TheUploadSnackbar,
         TheManualProbeDialog,
         TheBedScrewsDialog,

--- a/src/components/TheFullscreenUpload.vue
+++ b/src/components/TheFullscreenUpload.vue
@@ -8,12 +8,12 @@
 <script lang="ts">
 import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
+import FilesMixin from '@/components/mixins/files'
 import Component from 'vue-class-component'
-import { validGcodeExtensions } from '@/store/variables'
 import { mdiTrayArrowDown } from '@mdi/js'
 
 @Component
-export default class TheFullscreenUpload extends Mixins(BaseMixin) {
+export default class TheFullscreenUpload extends Mixins(BaseMixin, FilesMixin) {
     mdiTrayArrowDown = mdiTrayArrowDown
     private visible = false
 
@@ -77,28 +77,13 @@ export default class TheFullscreenUpload extends Mixins(BaseMixin) {
         if (e.dataTransfer?.files?.length) {
             const files = [...e.dataTransfer.files]
 
-            await this.$store.dispatch('socket/addLoading', { name: 'gcodeUpload' })
-            await this.$store.dispatch('files/uploadSetCurrentNumber', 0)
-            await this.$store.dispatch('files/uploadSetMaxNumber', files.length)
-
-            for (const file of files) {
-                const extensionPos = file.name.lastIndexOf('.')
-                const extension = file.name.slice(extensionPos)
-                const isGcode = validGcodeExtensions.includes(extension)
-
+            await this.uploadFiles(files, (file) => {
+                const isGcode = this.isGcodeFilename(file.name)
                 let path = ''
                 if (this.currentRoute === '/files' && isGcode) path = this.currentPathGcodes
                 else if (this.currentRoute === '/config' && !isGcode) path = this.currentPathConfig
-
-                const root = isGcode ? 'gcodes' : 'config'
-                await this.$store.dispatch('files/uploadIncrementCurrentNumber')
-                const result = await this.$store.dispatch('files/uploadFile', { file, path, root })
-
-                if (result !== false)
-                    this.$toast.success(this.$t('Files.SuccessfullyUploaded', { filename: result }).toString())
-            }
-
-            await this.$store.dispatch('socket/removeLoading', { name: 'gcodeUpload' })
+                return { path, root: isGcode ? 'gcodes' : 'config' }
+            })
         }
     }
 }

--- a/src/components/TheLaunchFileHandler.vue
+++ b/src/components/TheLaunchFileHandler.vue
@@ -1,0 +1,123 @@
+<template>
+    <start-print-dialog
+        v-if="showPrintDialog"
+        :bool="showPrintDialog"
+        :file="file"
+        current-path=""
+        @closeDialog="onCloseDialog" />
+</template>
+
+<script lang="ts">
+import { Mixins, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import FilesMixin from '@/components/mixins/files'
+import Component from 'vue-class-component'
+import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
+import { FileStateGcodefile } from '@/store/files/types'
+import { launchCount } from '@/plugins/pwaLaunchCount'
+
+@Component({
+    components: {
+        StartPrintDialog,
+    },
+})
+export default class TheLaunchFileHandler extends Mixins(BaseMixin, FilesMixin) {
+    item: FileStateGcodefile | null = null
+    private uploadedFile: null | { path: string; filename: string } = null
+
+    get fileReady() {
+        return this.file && this.file.metadataPulled
+    }
+
+    get file() {
+        if (!this.uploadedFile) return null
+        const { path, filename } = this.uploadedFile
+        const files = this.$store.getters['files/getGcodeFiles'](path ? `/${path}` : path, false, true)
+        return files.find((f: FileStateGcodefile) => f.filename === filename)
+    }
+
+    get canPrint() {
+        return !this.isUpdating && !['error', 'printing', 'paused'].includes(this.printer_state)
+    }
+
+    get isUpdating() {
+        return Boolean(this.$store.state.server.updateManager.updateResponse.application ?? '')
+    }
+
+    get showPrintDialog() {
+        return this.fileReady && this.canPrint
+    }
+
+    @Watch('file')
+    onFileChange(file: FileStateGcodefile) {
+        if (file && !file.metadataPulled && !file.metadataRequested) {
+            const filename = ['gcodes', file.path, file.filename].filter(Boolean).join('/')
+            this.$store.dispatch('files/requestMetadata', [{ filename }])
+        }
+    }
+
+    mounted() {
+        window.launchQueue?.setConsumer(this.onLaunch)
+    }
+
+    beforeDestroy() {
+        window.launchQueue?.setConsumer(() => undefined)
+    }
+
+    /**
+     * Determine if the launch is a new file launch. This is somewhat quirky because the launch queue is is re-sent
+     * when the page is reloaded, so to prevent re-processing the same launch when the page is reloaded, we calculate a
+     * launch key, save it to session storage, and compare it to the last launch key. And we also check the launch count
+     * to see if this is the first launch or a subsequent launch. This is needed because the launch queue is re-sent
+     * when the page is reloaded, so we need to differentiate between the first launch and subsequent launches.
+     *
+     * @param files The files to check.
+     */
+    isNewFileLaunch(files: File[]) {
+        const lastLaunchKey = sessionStorage.getItem('launchKey')
+        const launchKey = files
+            .map(({ name, lastModified, size }: File) => [name, lastModified, size].join('::'))
+            .sort()
+            .join(',')
+        sessionStorage.setItem('launchKey', launchKey)
+
+        return launchCount.value > 1 || launchKey !== lastLaunchKey
+    }
+
+    isGcodeFileHandle(file: FileSystemHandle): file is FileSystemFileHandle {
+        if (file.kind !== 'file') return false
+        return this.isGcodeFilename(file.name) //
+    }
+
+    onCloseDialog() {
+        this.uploadedFile = null
+    }
+
+    async onLaunch(launchParams: LaunchParams) {
+        // increment the launch count
+        launchCount.value++
+
+        // Nothing to do when the queue is empty.
+        if (!launchParams.files || !launchParams.files.length) {
+            return
+        }
+
+        // Filter to only gcode files and get the files from the file handles
+        const files = await Promise.all(
+            launchParams.files.filter(this.isGcodeFileHandle).map((file: FileSystemFileHandle) => file.getFile())
+        )
+
+        if (!this.isNewFileLaunch(files)) {
+            console.log('Repeated first launch key, ignoring because the page was probably just reloaded.')
+            return
+        }
+        this.uploadedFile = null
+
+        const root = 'gcodes'
+        const path = ''
+        const uploadedFiles = await this.uploadFiles(files, { root, path })
+
+        if (uploadedFiles.length > 0) this.uploadedFile = { path, filename: uploadedFiles[0].name }
+    }
+}
+</script>

--- a/src/components/mixins/files.ts
+++ b/src/components/mixins/files.ts
@@ -1,0 +1,46 @@
+import { validGcodeExtensions } from '@/store/variables'
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+type FileUploadRoot = 'gcodes' | 'config'
+type FileUploadDestination = { root: FileUploadRoot; path?: string }
+type FileUploadDestinationGetter = (file: File) => FileUploadDestination
+
+@Component
+export default class FilesMixins extends Vue {
+    loadingKeyForRoot(root?: FileUploadRoot) {
+        if (root === 'config') {
+            return 'configFileUpload'
+        }
+        return 'gcodeUpload'
+    }
+
+    isGcodeFilename(filename: string) {
+        const extensionPos = filename.lastIndexOf('.')
+        const extension = filename.slice(extensionPos)
+        return validGcodeExtensions.includes(extension)
+    }
+
+    async uploadFiles(files: File[], destination: Partial<FileUploadDestination> | FileUploadDestinationGetter = {}) {
+        const loadingKey = this.loadingKeyForRoot(typeof destination === 'object' ? destination.root : 'gcodes')
+        await this.$store.dispatch('socket/addLoading', { name: loadingKey })
+        await this.$store.dispatch('files/uploadSetCurrentNumber', 0)
+        await this.$store.dispatch('files/uploadSetMaxNumber', files.length)
+
+        const uploadedFiles = []
+        for (const file of files) {
+            await this.$store.dispatch('files/uploadIncrementCurrentNumber')
+            const { path = '', root } = typeof destination === 'function' ? destination(file) : destination
+            const pathWithoutPrefix = path.slice(0, 1) === '/' ? path.slice(1) : path
+            const result = await this.$store.dispatch('files/uploadFile', { file, path: pathWithoutPrefix, root })
+
+            if (result !== false) {
+                this.$toast.success(this.$t('Files.SuccessfullyUploaded', { filename: result }).toString())
+                uploadedFiles.push(file)
+            }
+        }
+
+        await this.$store.dispatch('socket/removeLoading', { name: loadingKey })
+        return uploadedFiles
+    }
+}

--- a/src/components/settings/SettingsUiSettingsTab.vue
+++ b/src/components/settings/SettingsUiSettingsTab.vue
@@ -329,6 +329,13 @@
                     :dynamic-slot-width="true">
                     <v-switch v-model="hideOtherInstances" hide-details class="mt-0" />
                 </settings-row>
+                <v-divider class="my-2" />
+                <settings-row
+                    :title="$t('Settings.UiSettingsTab.ShowPrintOnUpload')"
+                    :sub-title="$t('Settings.UiSettingsTab.ShowPrintOnUploadDescription')"
+                    :dynamic-slot-width="true">
+                    <v-switch v-model="showPrintOnUpload" hide-details class="mt-0" />
+                </settings-row>
             </v-card-text>
         </v-card>
     </div>
@@ -709,6 +716,14 @@ export default class SettingsUiSettingsTab extends Mixins(BaseMixin, ThemeMixin)
 
     set hideOtherInstances(newVal) {
         this.$store.dispatch('gui/saveSetting', { name: 'uiSettings.hideOtherInstances', value: newVal })
+    }
+
+    get showPrintOnUpload() {
+        return this.$store.state.gui.uiSettings.showPrintOnUpload ?? false
+    }
+
+    set showPrintOnUpload(newVal) {
+        this.$store.dispatch('gui/saveSettingInLocalStorage', { name: 'uiSettings.showPrintOnUpload', value: newVal })
     }
 
     clearColorObject(color: any): string {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1528,6 +1528,8 @@
             "ProgressAsFaviconDescription": "Change the Mainsail logo favicon to a progress circle.",
             "ScrewsTiltAdjustDialog": "Screws Tilt Adjust Dialog",
             "ScrewsTiltAdjustDialogDescription": "Display helper dialog for SCREWS_TILT_CALCULATE.",
+            "ShowPrintOnUpload": "Show Print on Upload",
+            "ShowPrintOnUploadDescription": "Display the show print dialog after uploading a file. This setting is local to the browser.",
             "TempchartHeight": "Height Temperature Chart",
             "TempchartHeightDescription": "Modify the height of the temperature chart on the Dashboard.",
             "Theme": "Theme",

--- a/src/plugins/pwaLaunchCount.ts
+++ b/src/plugins/pwaLaunchCount.ts
@@ -1,0 +1,8 @@
+import { ref } from 'vue'
+
+// This file is used to track the number of times the PWA has been launched
+// via launchQueue. This has been extracted from the launch handler because
+// if it is present in the launch handler, it will be reset during hot reload.
+// This throws off the functionality that determines if it is a new launch,
+// causing new launches to be treated as a relaunch and get ignored.
+export const launchCount = ref(0)

--- a/src/store/farm/printer/index.ts
+++ b/src/store/farm/printer/index.ts
@@ -32,6 +32,7 @@ export const getDefaultState = (): FarmPrinterState => {
         settings: {},
         databases: [],
         current_file: {
+            path: '',
             isDirectory: false,
             filename: '',
             modified: new Date(),

--- a/src/store/files/index.ts
+++ b/src/store/files/index.ts
@@ -16,6 +16,7 @@ export const getDefaultState = (): FileState => {
             percent: 0,
             speed: 0,
         },
+        latestGcodeFile: null,
     }
 }
 

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -3,7 +3,7 @@ import { getDefaultState } from './index'
 import { findDirectory } from '@/plugins/helpers'
 import { MutationTree } from 'vuex'
 import { FileState, FileStateFile } from '@/store/files/types'
-import { allowedMetadata } from '@/store/variables'
+import { allowedMetadata, validGcodeExtensions } from '@/store/variables'
 
 export const mutations: MutationTree<FileState> = {
     reset(state) {
@@ -68,6 +68,20 @@ export const mutations: MutationTree<FileState> = {
             filename = payload.item.path.substr(payload.item.path.lastIndexOf('/')).replace('/', '')
         const path = payload.item.path.substr(0, payload.item.path.lastIndexOf('/'))
         const parent = findDirectory(state.filetree, (payload.item.root + '/' + path).split('/'))
+
+        if (payload.item.root === 'gcodes') {
+            const extension = filename.substring(filename.lastIndexOf('.'))
+            const lastModified = state.latestGcodeFile?.modified ?? 0
+            if (validGcodeExtensions.includes(extension) && payload.item.modified > lastModified) {
+                state.latestGcodeFile = {
+                    path,
+                    filename,
+                    modified: payload.item.modified,
+                    size: payload.item.size,
+                    permissions: payload.item.permissions,
+                }
+            }
+        }
 
         if (parent) {
             const indexFile = parent.findIndex(

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -12,6 +12,7 @@ export const mutations: MutationTree<FileState> = {
 
     createRootDir(state, payload) {
         state.filetree.push({
+            path: '',
             isDirectory: true,
             filename: payload.name,
             modified: new Date(),
@@ -77,6 +78,7 @@ export const mutations: MutationTree<FileState> = {
                 const modified = new Date(payload.item.modified * 1000)
 
                 parent.push({
+                    path,
                     isDirectory: false,
                     filename: filename,
                     modified: modified,
@@ -213,6 +215,7 @@ export const mutations: MutationTree<FileState> = {
 
         if (parent) {
             parent.push({
+                path,
                 isDirectory: true,
                 filename: dirname,
                 modified: payload.item.modified ?? new Date(),

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -11,6 +11,7 @@ export interface FileState {
         percent: number
         speed: number
     }
+    latestGcodeFile: FileStateSimpleFile | null
 }
 
 export interface FileStateFile {
@@ -110,6 +111,14 @@ export interface ApiGetDirectoryReturnFile {
     modified: number
     size: number
     filename: string
+    permissions: string
+}
+
+export interface FileStateSimpleFile {
+    modified: number
+    size: number
+    filename: string
+    path: string
     permissions: string
 }
 

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -14,6 +14,7 @@ export interface FileState {
 }
 
 export interface FileStateFile {
+    path: string
     isDirectory: boolean
     filename: string
     modified: Date

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -107,6 +107,19 @@ export const actions: ActionTree<GuiState, RootState> = {
             })
         }
 
+        // load local storage gui settings
+        if (localStorage.getItem('guiSettings')) {
+            const localGuiSettings = JSON.parse(localStorage.getItem('guiSettings') ?? '{}')
+            if (localGuiSettings) {
+                for (const key in localGuiSettings) {
+                    dispatch('saveSettingWithoutUpload', {
+                        name: key,
+                        value: localGuiSettings[key],
+                    })
+                }
+            }
+        }
+
         await commit('setData', payload.value)
         await dispatch('socket/removeInitModule', 'gui/init', { root: true })
     },
@@ -183,6 +196,13 @@ export const actions: ActionTree<GuiState, RootState> = {
 
     saveSettingWithoutUpload({ commit }, payload) {
         commit('saveSetting', payload)
+    },
+
+    saveSettingInLocalStorage({ commit }, payload) {
+        commit('saveSetting', payload)
+        const localGuiSettings = JSON.parse(localStorage.getItem('guiSettings') ?? '{}')
+        localGuiSettings[payload.name] = payload.value
+        localStorage.setItem('guiSettings', JSON.stringify(localGuiSettings))
     },
 
     updateSettings(_, payload) {

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -188,6 +188,8 @@ export const getDefaultState = (): GuiState => {
             dashboardFilesFilter: ['new', 'failed', 'completed'],
             dashboardHistoryLimit: 5,
             hideOtherInstances: false,
+            // default to showPrintOnUpload if the user agent appears to be a slicer
+            showPrintOnUpload: navigator.userAgent.toLowerCase().includes('slicer'),
         },
         view: {
             afc: {

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -130,6 +130,7 @@ export interface GuiState {
         dashboardFilesFilter: GuiStateUiSettingsDashboardFilesFilter[]
         dashboardHistoryLimit: number
         hideOtherInstances: boolean
+        showPrintOnUpload: boolean
     }
     view: {
         afc: {

--- a/src/types/wicg-web-app-launch.d.ts
+++ b/src/types/wicg-web-app-launch.d.ts
@@ -1,0 +1,19 @@
+interface LaunchParams {
+    targetURL?: string
+    files: readonly (FileSystemFileHandle | FileSystemDirectoryHandle)[]
+}
+
+interface LaunchConsumer {
+    (params: LaunchParams): any
+}
+
+interface LaunchQueue {
+    setConsumer(consumer: LaunchConsumer): void
+}
+
+interface Window {
+    readonly launchQueue?: LaunchQueue
+
+    LaunchQueue?: LaunchQueue
+    LaunchParams?: LaunchParams
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,17 @@ const PWAConfig: Partial<VitePWAOptions> = {
                 purpose: 'any maskable',
             },
         ],
+        file_handlers: [
+            {
+                action: '/',
+                accept: {
+                    'text/gcode': ['.gcode', '.g', '.gco', '.ufp', '.nc'],
+                },
+            },
+        ],
+        launch_handler: {
+            client_mode: ['focus-existing'],
+        },
     },
     workbox: {
         globPatterns: ['**/*.{js,css,html,woff,woff2,png,svg}'],


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

This PR adds a couple ways to have the start print dialog automatically open.

1. When the app is installed as a Progressive Web App on a desktop/laptop, the app will now be associated with gcode files. If you open a gcode file with Mainsail, the gcode file will be uploaded to the printer and the start print dialog will be presented to the user.
2. When the new configuration option "Show Print on Upload" is enabled, then when a new gcode file is recognized by Mainsail, we will open the start print dialog for that new file. This can be useful to help streamline tool mapping when starting MMU prints.
  * I felt like this may not be a feature a user would want in all instances of mainsail, so I've made this setting browser local (by saving to `localStorage`). I would expect people would want it enabled in their slicer, but probably not anywhere else. By default if the browser user agent contains "slicer", then I am enabling this setting (but can be overwritten by toggling the setting). Note: I only verified Orca Slicer, but it presents a user agent that starts with "BBL-Slicer". 

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

> [!NOTE]
> The recordings show the application with the new Happy Hare functionality, but none of my changes are dependent on that functionality. I've just simply cherry-picked my commits from my HH fork onto a new branch from the mainline `develop` branch.

<!-- Visual changes require screenshots showing the before and after -->

### PWA "Open With"

This demonstrates opening a gcode file with the "installed" Mainsail application (side note: I believe a user would need to re-install the application for it to set up that file type association).

https://github.com/user-attachments/assets/5c0ae29a-894a-4ed3-9d00-6345e66a73ac

### Show Print on Upload

This demonstrates slicing a file and then using the "upload" along with the option to show the device page after uploading, which then automatically takes you to Mainsail after uploading and the start print dialog is displayed and the user may then start the print, perform tool mapping and then start the print, etc.

https://github.com/user-attachments/assets/0622d3a9-969a-4887-919e-33e48931fe04


## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
