### PR TITLE
fix(Files): fix disk usage in new directories

### DIFF
--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -235,6 +235,13 @@ export const actions: ActionTree<FileState, RootState> = {
 
             case 'create_dir':
                 commit('setCreateDir', payload)
+
+                // request the directory to get the files in it and more important the usage
+                Vue.$socket.emit(
+                    'server.files.get_directory',
+                    { path: `${payload.item.root}/${payload.item.path}` },
+                    { action: 'files/getDirectory' }
+                )
                 break
 
             case 'move_dir':

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -236,7 +236,7 @@ export const actions: ActionTree<FileState, RootState> = {
             case 'create_dir':
                 commit('setCreateDir', payload)
 
-                // request the directory to get the files in it and more important the usage
+                // Request directory details to update disk usage
                 Vue.$socket.emit(
                     'server.files.get_directory',
                     { path: `${payload.item.root}/${payload.item.path}` },

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -13,18 +13,19 @@ import { escapePath } from '@/plugins/helpers'
 // eslint-disable-next-line
 export const getters: GetterTree<FileState, any> = {
     getDirectory: (state) => (requestedPath: string) => {
-        if (requestedPath.startsWith('/')) requestedPath = requestedPath.substr(1)
-        if (requestedPath.endsWith('/')) requestedPath = requestedPath.substr(0, requestedPath.length - 1)
+        if (requestedPath.startsWith('/')) requestedPath = requestedPath.substring(1)
+        if (requestedPath.endsWith('/')) requestedPath = requestedPath.substring(0, requestedPath.length - 1)
 
         const findDirectory = function (filetree: FileStateFile, pathArray: string[]): FileStateFile | null {
             if (pathArray.length) {
                 const newFiletree = filetree?.childrens?.find(
                     (element: FileStateFile) => element.isDirectory && element.filename === pathArray[0]
                 )
-                if (newFiletree) {
-                    pathArray.shift()
-                    return findDirectory(newFiletree, pathArray)
-                } else return null
+
+                if (!newFiletree) return null
+
+                pathArray.shift()
+                return findDirectory(newFiletree, pathArray)
             }
 
             return filetree


### PR DESCRIPTION
## Description

This PR fix the disk usage in the file manager panel, when you create a new directory and open it directly after that.

## Related Tickets & Documents

fixes #2214 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
