### PR TITLE
fix(Webcam): fix portrait webcam rotation in mjpegstreamer-adaptive

### DIFF
--- a/src/components/mixins/webcam.ts
+++ b/src/components/mixins/webcam.ts
@@ -56,14 +56,18 @@ export default class WebcamMixin extends Mixins(BaseMixin) {
         }
     }
 
-    generateTransform(flip_horizontal: boolean, flip_vertical: boolean, rotation: number) {
-        let transforms = ''
-        if (flip_horizontal) transforms += ' scaleX(-1)'
-        if (flip_vertical) transforms += ' scaleY(-1)'
-        if (rotation === 180) transforms += ' rotate(180deg)'
+    generateTransform(flip_horizontal: boolean, flip_vertical: boolean, rotation: number, aspect_ratio: number = 1) {
+        const transforms = []
+        if (flip_horizontal) transforms.push('scaleX(-1)')
+        if (flip_vertical) transforms.push('scaleY(-1)')
+        if (rotation != 0) {
+            transforms.push(`rotate(${rotation}deg)`)
+
+            if (aspect_ratio != 1) transforms.push(`scale(${1 / aspect_ratio})`)
+        }
 
         // return transform when exist
-        if (transforms.trimStart().length) return transforms.trimStart()
+        if (transforms.length) return transforms.join(' ')
 
         // return none as fallback
         return 'none'

--- a/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
+++ b/src/components/webcams/streamers/MjpegstreamerAdaptive.vue
@@ -1,5 +1,8 @@
 <template>
-    <div v-observe-visibility="viewportVisibilityChanged" class="d-flex justify-center webcamBackground">
+    <div
+        v-observe-visibility="viewportVisibilityChanged"
+        class="d-flex justify-center webcamBackground"
+        :style="wrapperStyle">
         <img
             v-show="status === 'connected'"
             ref="image"
@@ -55,31 +58,28 @@ export default class MjpegstreamerAdaptive extends Mixins(BaseMixin, WebcamMixin
 
     @Ref('image') readonly image!: HTMLImageElement
 
+    get wrapperStyle() {
+        if (this.aspectRatio !== null && this.aspectRatio < 1 && [90, 270].includes(this.camSettings.rotation)) {
+            return {
+                aspectRatio: 1 / this.aspectRatio,
+                maxHeight: `${window.innerHeight - 155}px`,
+            }
+        }
+
+        return {
+            maxHeight: `${window.innerHeight - 155}px`,
+        }
+    }
+
     get webcamStyle() {
-        const output = {
+        return {
             transform: this.generateTransform(
                 this.camSettings.flip_horizontal ?? false,
                 this.camSettings.flip_vertical ?? false,
-                this.camSettings.rotation ?? 0
+                this.camSettings.rotation ?? 0,
+                this.aspectRatio ?? 1
             ),
-            aspectRatio: 16 / 9,
-            maxHeight: window.innerHeight - 155 + 'px',
-            maxWidth: 'auto',
         }
-
-        if (this.aspectRatio) {
-            output.aspectRatio = this.aspectRatio
-            output.maxWidth = (window.innerHeight - 155) * this.aspectRatio + 'px'
-        }
-
-        if (this.aspectRatio && [90, 270].includes(this.camSettings.rotation)) {
-            if (output.transform === 'none') output.transform = ''
-
-            const scale = 1 / this.aspectRatio
-            output.transform += ' rotate(' + this.camSettings.rotation + 'deg) scale(' + scale + ')'
-        }
-
-        return output
     }
 
     get fpsOutput() {
@@ -233,10 +233,14 @@ export default class MjpegstreamerAdaptive extends Mixins(BaseMixin, WebcamMixin
 .webcamBackground {
     position: relative;
     background: rgba(0, 0, 0, 0.8);
+    overflow: hidden;
+    margin: 0 auto;
 }
 
 .webcamImage {
     width: 100%;
+    transform-origin: center center;
+    object-fit: contain;
 }
 
 ._webcam_mjpegstreamer_output {


### PR DESCRIPTION
## Description

This PR fix the issue with too big image, when you rotate a portrait stream 90° or 270°. It also simplify the generateTransform function in the webcam mixin.

## Related Tickets & Documents

fixes #2156 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
