### PR TITLE
fix(AFC): this PR fix the AFC settings with many lanes

### DIFF
--- a/src/components/dialogs/AfcSettingsDialogExtruder.vue
+++ b/src/components/dialogs/AfcSettingsDialogExtruder.vue
@@ -4,16 +4,18 @@
         <settings-row
             :title="$t('Panels.AfcPanel.SettingsDialog.LoadUnloadLane')"
             :sub-title="$t('Panels.AfcPanel.SettingsDialog.LoadUnloadLaneDescription')">
-            <v-btn
-                v-for="lane in lanes"
-                :key="lane"
-                :disabled="!filledLanes.includes(lane)"
-                small
-                class="ma-1"
-                :color="lane_loaded === lane ? 'primary' : ''"
-                @click="toggleLane(lane)">
-                {{ lane }}
-            </v-btn>
+            <div class="d-flex flex-wrap">
+                <v-btn
+                    v-for="lane in lanes"
+                    :key="lane"
+                    :disabled="!filledLanes.includes(lane)"
+                    small
+                    class="ma-1"
+                    :color="lane_loaded === lane ? 'primary' : ''"
+                    @click="toggleLane(lane)">
+                    {{ lane }}
+                </v-btn>
+            </div>
         </settings-row>
         <v-divider class="my-3" />
         <settings-row :title="$t('Panels.AfcPanel.SettingsDialog.ToolStn')" :sub-title="toolStnSubTitle">


### PR DESCRIPTION
## Description

This PR fix an issue with "too many" lanes in the AFC-Settings pane. I added a div with "flex-wrap" so it can break the line when more lanes are added.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

old:
<img width="758" height="159" alt="image" src="https://github.com/user-attachments/assets/ccabfa1e-2d75-42a3-8ee9-f433ecdfaddd" />

new:
<img width="735" height="229" alt="image" src="https://github.com/user-attachments/assets/f0a05a06-75b8-474e-8f49-c9b177d548a8" />

## [optional] Are there any post-deployment tasks we need to perform?

none
