### PR TITLE
feat(tempgroups): add user-organizable temperature tabs

### DIFF
--- a/src/components/TheSettingsMenu.vue
+++ b/src/components/TheSettingsMenu.vue
@@ -81,6 +81,7 @@ import SettingsGCodeViewerTab from '@/components/settings/SettingsGCodeViewerTab
 import SettingsEditorTab from '@/components/settings/SettingsEditorTab.vue'
 import SettingsTimelapseTab from '@/components/settings/SettingsTimelapseTab.vue'
 import SettingsNavigationTab from '@/components/settings/SettingsNavigationTab.vue'
+import SettingsTempgroupsTab from '@/components/settings/SettingsTempgroupsTab.vue'
 
 import Panel from '@/components/ui/Panel.vue'
 import {
@@ -101,6 +102,7 @@ import {
     mdiDipSwitch,
     mdiMenu,
     mdiGrid,
+    mdiThermometer,
 } from '@mdi/js'
 import SettingsMiscellaneousTab from '@/components/settings/SettingsMiscellaneousTab.vue'
 import SettingsHeightmapTab from '@/components/settings/SettingsHeightmapTab.vue'
@@ -123,6 +125,7 @@ import SettingsHeightmapTab from '@/components/settings/SettingsHeightmapTab.vue
         SettingsMiscellaneousTab,
         SettingsNavigationTab,
         SettingsHeightmapTab,
+        SettingsTempgroupsTab,
     },
 })
 export default class TheSettingsMenu extends Mixins(BaseMixin) {
@@ -210,6 +213,11 @@ export default class TheSettingsMenu extends Mixins(BaseMixin) {
                 icon: mdiGrid,
                 name: 'heightmap',
                 title: this.$t('Settings.HeightmapTab.Heightmap'),
+            },
+            {
+                icon: mdiThermometer,
+                name: 'tempgroups',
+                title: this.$t('Settings.TempgroupsTab.TempGroups'),
             },
         ]
 

--- a/src/components/charts/TempChart.vue
+++ b/src/components/charts/TempChart.vue
@@ -14,7 +14,7 @@
 <script lang="ts">
 import { convertName } from '@/plugins/helpers'
 import Component from 'vue-class-component'
-import { Mixins, Watch } from 'vue-property-decorator'
+import { Mixins, Prop, Watch } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import { PrinterTempHistoryStateSourceEntry } from '@/store/printer/tempHistory/types'
 
@@ -35,6 +35,8 @@ export default class TempChart extends Mixins(BaseMixin, ThemeMixin) {
     declare $refs: {
         tempchart: any
     }
+
+    @Prop({ default: null }) declare readonly sensorFilter: string[] | null
 
     hoverChart = false
     private isVisible = true
@@ -75,7 +77,7 @@ export default class TempChart extends Mixins(BaseMixin, ThemeMixin) {
             dataset: {
                 source: [],
             },
-            series: this.series,
+            series: this.filteredSeries,
         }
     }
 
@@ -219,7 +221,22 @@ export default class TempChart extends Mixins(BaseMixin, ThemeMixin) {
     }
 
     get series() {
-        return this.$store.state.printer.tempHistory.series ?? {}
+        return this.$store.state.printer.tempHistory.series ?? []
+    }
+    get filteredSeries() {
+        const allSeries = this.series
+
+        if (!this.sensorFilter || this.sensorFilter.length === 0) {
+            return allSeries
+        }
+
+        return allSeries.filter((serie: { name: string }) => {
+            const lastDashIndex = serie.name.lastIndexOf('-')
+            if (lastDashIndex === -1) return false
+
+            const sensorName = serie.name.substring(0, lastDashIndex)
+            return this.sensorFilter!.includes(sensorName)
+        })
     }
 
     get source() {

--- a/src/components/panels/Temperature/TemperaturePanelList.vue
+++ b/src/components/panels/Temperature/TemperaturePanelList.vue
@@ -22,24 +22,24 @@
                 </thead>
                 <tbody>
                     <temperature-panel-list-item
-                        v-for="objectName in heaterObjects"
+                        v-for="objectName in filteredHeaterObjects"
                         :key="objectName"
                         :object-name="objectName"
                         :input-digits="inputFieldDigits"
                         :is-responsive-mobile="el.is.mobile ?? false" />
                     <temperature-panel-list-item-nevermore
-                        v-for="objectName in nevermoreObjects"
+                        v-for="objectName in filteredNevermoreObjects"
                         :key="objectName"
                         :object-name="objectName"
                         :is-responsive-mobile="el.is.mobile ?? false" />
                     <temperature-panel-list-item
-                        v-for="objectName in temperature_sensors"
+                        v-for="objectName in filteredTemperatureSensors"
                         :key="objectName"
                         :object-name="objectName"
                         :is-responsive-mobile="el.is.mobile ?? false" />
                     <template v-if="!hideMonitors">
                         <temperature-panel-list-item
-                            v-for="objectName in monitors"
+                            v-for="objectName in filteredMonitors"
                             :key="objectName"
                             :object-name="objectName"
                             :is-responsive-mobile="el.is.mobile ?? false" />
@@ -52,7 +52,7 @@
 
 <script lang="ts">
 import Component from 'vue-class-component'
-import { Mixins } from 'vue-property-decorator'
+import { Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import TemperaturePanelListItemNevermore from '@/components/panels/Temperature/TemperaturePanelListItemNevermore.vue'
 
@@ -60,6 +60,8 @@ import TemperaturePanelListItemNevermore from '@/components/panels/Temperature/T
     components: { TemperaturePanelListItemNevermore },
 })
 export default class TemperaturePanelList extends Mixins(BaseMixin) {
+    @Prop({ default: null }) declare readonly sensorFilter: string[] | null
+
     get available_heaters() {
         return this.$store.state.printer?.heaters?.available_heaters ?? []
     }
@@ -116,6 +118,26 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
 
     get nevermoreObjects() {
         return this.filterNamesAndSort(this.available_nevermores)
+    }
+
+    get filteredHeaterObjects(): string[] {
+        if (!this.sensorFilter) return this.heaterObjects
+        return this.heaterObjects.filter((name) => this.sensorFilter!.includes(name))
+    }
+
+    get filteredNevermoreObjects(): string[] {
+        if (!this.sensorFilter) return this.nevermoreObjects
+        return this.nevermoreObjects.filter((name) => this.sensorFilter!.includes(name))
+    }
+
+    get filteredTemperatureSensors(): string[] {
+        if (!this.sensorFilter) return this.temperature_sensors
+        return this.temperature_sensors.filter((name) => this.sensorFilter!.includes(name))
+    }
+
+    get filteredMonitors(): string[] {
+        if (!this.sensorFilter) return this.monitors
+        return this.monitors.filter((name) => this.sensorFilter!.includes(name))
     }
 
     get settings() {

--- a/src/components/panels/Temperature/TemperaturePanelTabs.vue
+++ b/src/components/panels/Temperature/TemperaturePanelTabs.vue
@@ -1,0 +1,73 @@
+<template>
+    <v-tabs v-model="activeTab" show-arrows background-color="transparent" class="temperature-panel-tabs" height="36">
+        <v-tab v-if="showAllTab" :key="'all'" class="text-none">
+            {{ $t('Panels.TemperaturePanel.All') }}
+        </v-tab>
+        <v-tab v-for="group in sortedGroups" :key="group.id" class="text-none">
+            {{ group.name }}
+        </v-tab>
+    </v-tabs>
+</template>
+
+<script lang="ts">
+import Component from 'vue-class-component'
+import { Mixins } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import { GuiTempgroup } from '@/store/gui/tempgroups/types'
+
+@Component
+export default class TemperaturePanelTabs extends Mixins(BaseMixin) {
+    get activeTab(): number {
+        const activeGroupId = this.$store.state.gui.tempgroups.activeGroupId
+
+        if (this.showAllTab && !activeGroupId) {
+            return 0
+        }
+
+        const groupIndex = this.sortedGroups.findIndex((g) => g.id === activeGroupId)
+
+        if (this.showAllTab) {
+            return groupIndex !== -1 ? groupIndex + 1 : 0
+        }
+
+        return groupIndex !== -1 ? groupIndex : 0
+    }
+
+    set activeTab(index: number) {
+        if (this.showAllTab && index === 0) {
+            this.$store.dispatch('gui/tempgroups/setActiveGroup', null)
+            return
+        }
+
+        const groupIndex = this.showAllTab ? index - 1 : index
+
+        const group = this.sortedGroups[groupIndex]
+        if (group) {
+            this.$store.dispatch('gui/tempgroups/setActiveGroup', group.id)
+        }
+    }
+
+    get showAllTab(): boolean {
+        return this.$store.state.gui.tempgroups.showAllTab ?? true
+    }
+
+    get sortedGroups(): GuiTempgroup[] {
+        return this.$store.getters['gui/tempgroups/getSortedGroups'] ?? []
+    }
+}
+</script>
+
+<style scoped>
+.temperature-panel-tabs {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.theme--light .temperature-panel-tabs {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.temperature-panel-tabs ::v-deep .v-slide-group__prev,
+.temperature-panel-tabs ::v-deep .v-slide-group__next {
+    min-width: 32px;
+}
+</style>

--- a/src/components/panels/TemperaturePanel.vue
+++ b/src/components/panels/TemperaturePanel.vue
@@ -10,10 +10,11 @@
             <temperature-panel-settings />
         </template>
         <v-card-text class="pa-0">
-            <temperature-panel-list />
+            <temperature-panel-tabs v-if="shouldShowTabs" />
+            <temperature-panel-list :sensor-filter="sensorFilter" />
             <template v-if="boolTempchart">
                 <v-divider class="my-0" />
-                <temp-chart />
+                <temp-chart :sensor-filter="sensorFilter" />
             </template>
         </v-card-text>
     </panel>
@@ -31,9 +32,10 @@ import Panel from '@/components/ui/Panel.vue'
 import Responsive from '@/components/ui/Responsive.vue'
 import { mdiCloseThick, mdiThermometerLines } from '@mdi/js'
 import TemperaturePanelPresets from '@/components/panels/Temperature/TemperaturePanelPresets.vue'
+import TemperaturePanelTabs from '@/components/panels/Temperature/TemperaturePanelTabs.vue'
 
 @Component({
-    components: { Panel, TempChart, TemperatureInput, Responsive, TemperaturePanelPresets },
+    components: { Panel, TempChart, TemperatureInput, Responsive, TemperaturePanelPresets, TemperaturePanelTabs },
 })
 export default class TemperaturePanel extends Mixins(BaseMixin, ControlMixin) {
     mdiCloseThick = mdiCloseThick
@@ -44,6 +46,14 @@ export default class TemperaturePanel extends Mixins(BaseMixin, ControlMixin) {
 
     get boolTempchart(): boolean {
         return this.$store.state.gui.view.tempchart.boolTempchart ?? false
+    }
+
+    get shouldShowTabs(): boolean {
+        return this.$store.getters['gui/tempgroups/shouldShowTabs'] ?? false
+    }
+
+    get sensorFilter(): string[] | null {
+        return this.$store.getters['gui/tempgroups/getActiveSensorFilter'] ?? null
     }
 }
 </script>

--- a/src/components/settings/SettingsTempgroupsTab.vue
+++ b/src/components/settings/SettingsTempgroupsTab.vue
@@ -1,0 +1,144 @@
+<template>
+    <div>
+        <settings-tempgroups-tab-edit v-if="boolFormEdit" :group-id="editGroupId" @close="closeEdit" />
+        <v-card v-else flat>
+            <v-card-text>
+                <h3 class="text-h5 mb-3">{{ $t('Settings.TempgroupsTab.General') }}</h3>
+                <settings-row :title="$t('Settings.TempgroupsTab.ShowAllTab')">
+                    <v-checkbox v-model="showAllTab" hide-details class="mt-0"></v-checkbox>
+                </settings-row>
+                <v-divider class="my-2"></v-divider>
+                <h3 class="text-h5 mt-6 mb-3">{{ $t('Settings.TempgroupsTab.Groups') }}</h3>
+                <template v-if="groups.length">
+                    <draggable
+                        v-model="groupsList"
+                        handle=".handle"
+                        ghost-class="ghost"
+                        :force-fallback="true"
+                        @end="onGroupsReordered">
+                        <div v-for="(group, index) in groupsList" :key="group.id">
+                            <v-divider v-if="index" class="my-2"></v-divider>
+                            <v-row class="my-2 mx-0" :style="draggableBgStyle">
+                                <v-col class="col-auto pr-0 d-flex py-2">
+                                    <v-icon class="handle">{{ mdiDragVertical }}</v-icon>
+                                </v-col>
+                                <v-col class="py-2">
+                                    <settings-row
+                                        :title="
+                                            group.name !== ''
+                                                ? group.name
+                                                : '<' + $t('Settings.TempgroupsTab.UnknownGroup') + '>'
+                                        "
+                                        :sub-title="
+                                            $tc(
+                                                'Settings.TempgroupsTab.CountSensors',
+                                                group.sensors ? group.sensors.length : 0,
+                                                {
+                                                    count: group.sensors ? group.sensors.length : 0,
+                                                }
+                                            )
+                                        "
+                                        :dynamic-slot-width="true">
+                                        <v-btn small outlined class="ml-3" @click="editGroup(group)">
+                                            <v-icon left small>{{ mdiPencil }}</v-icon>
+                                            {{ $t('Settings.Edit') }}
+                                        </v-btn>
+                                        <v-btn
+                                            small
+                                            outlined
+                                            class="ml-3 minwidth-0 px-2"
+                                            color="error"
+                                            @click="deleteGroup(group.id)">
+                                            <v-icon small>{{ mdiDelete }}</v-icon>
+                                        </v-btn>
+                                    </settings-row>
+                                </v-col>
+                            </v-row>
+                        </div>
+                    </draggable>
+                </template>
+                <template v-else>
+                    <v-row>
+                        <v-col>
+                            <p class="mb-0 text-center font-italic">{{ $t('Settings.TempgroupsTab.NoGroups') }}</p>
+                        </v-col>
+                    </v-row>
+                </template>
+            </v-card-text>
+            <v-card-actions class="d-flex justify-end">
+                <v-btn text color="primary" @click="addGroup">{{ $t('Settings.TempgroupsTab.AddGroup') }}</v-btn>
+            </v-card-actions>
+        </v-card>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Watch } from 'vue-property-decorator'
+import BaseMixin from '../mixins/base'
+import ThemeMixin from '@/components/mixins/theme'
+import draggable from 'vuedraggable'
+import SettingsRow from '@/components/settings/SettingsRow.vue'
+import SettingsTempgroupsTabEdit from '@/components/settings/SettingsTempgroupsTabEdit.vue'
+import { GuiTempgroup } from '@/store/gui/tempgroups/types'
+import { mdiDelete, mdiDragVertical, mdiPencil } from '@mdi/js'
+
+@Component({
+    components: { SettingsRow, SettingsTempgroupsTabEdit, draggable },
+})
+export default class SettingsTempgroupsTab extends Mixins(BaseMixin, ThemeMixin) {
+    mdiPencil = mdiPencil
+    mdiDelete = mdiDelete
+    mdiDragVertical = mdiDragVertical
+
+    private boolFormEdit = false
+    private editGroupId: string | null = null
+    private groupsList: GuiTempgroup[] = []
+
+    @Watch('groups', { immediate: true })
+    onGroupsChanged(newVal: GuiTempgroup[]) {
+        this.groupsList = [...newVal]
+    }
+
+    get showAllTab(): boolean {
+        return this.$store.state.gui?.tempgroups?.showAllTab ?? true
+    }
+
+    set showAllTab(newVal: boolean) {
+        this.$store.dispatch('gui/tempgroups/setShowAllTab', newVal)
+    }
+
+    get groups(): GuiTempgroup[] {
+        return this.$store.getters['gui/tempgroups/getSortedGroups'] ?? []
+    }
+
+    onGroupsReordered() {
+        const orderedIds = this.groupsList.map((g) => g.id)
+        this.$store.dispatch('gui/tempgroups/reorderGroups', orderedIds)
+    }
+
+    async addGroup() {
+        this.editGroupId = await this.$store.dispatch('gui/tempgroups/groupStore', {
+            values: {
+                name: '',
+                showChart: true,
+            },
+        })
+        this.boolFormEdit = true
+    }
+
+    editGroup(group: GuiTempgroup) {
+        this.editGroupId = group.id
+        this.boolFormEdit = true
+    }
+
+    deleteGroup(id: string) {
+        this.$store.dispatch('gui/tempgroups/groupDelete', id)
+    }
+
+    closeEdit() {
+        this.boolFormEdit = false
+        this.editGroupId = null
+        this.$emit('scrollToTop')
+    }
+}
+</script>

--- a/src/components/settings/SettingsTempgroupsTabEdit.vue
+++ b/src/components/settings/SettingsTempgroupsTabEdit.vue
@@ -1,0 +1,344 @@
+<template>
+    <v-card-text>
+        <h3 class="text-h5 mb-3">{{ $t('Settings.TempgroupsTab.EditGroup') }}</h3>
+        <settings-row :title="$t('Settings.TempgroupsTab.Name')">
+            <v-text-field
+                v-model="groupName"
+                hide-details="auto"
+                :rules="[rules.required, rules.groupUnique]"
+                dense
+                outlined></v-text-field>
+        </settings-row>
+        <v-divider class="my-2"></v-divider>
+        <settings-row :title="$t('Settings.TempgroupsTab.ShowChart')">
+            <v-checkbox v-model="showChart" hide-details class="mt-0"></v-checkbox>
+        </settings-row>
+        <v-divider class="my-2"></v-divider>
+        <h3 class="text-h5 mt-6 mb-3">{{ $t('Settings.TempgroupsTab.GroupSensors') }}</h3>
+        <template v-if="sensorsList.length">
+            <draggable
+                v-model="sensorsList"
+                handle=".handle"
+                ghost-class="ghost"
+                group="sensors"
+                :force-fallback="true"
+                @end="updateSensorOrder">
+                <v-row
+                    v-for="(sensor, index) in sensorsList"
+                    :key="sensor.name"
+                    class="my-2 mx-0"
+                    :style="draggableBgStyle">
+                    <v-col class="col-auto pr-0 d-flex py-2">
+                        <v-icon class="handle">{{ mdiDragVertical }}</v-icon>
+                    </v-col>
+                    <v-col class="py-2">
+                        <settings-row
+                            :key="'groupSensor_' + index"
+                            :title="sensor.displayName || formatSensorName(sensor.name)"
+                            :sub-title="sensor.displayName ? sensor.name : null"
+                            :dynamic-slot-width="true">
+                            <v-tooltip top>
+                                <template #activator="{ on, attrs }">
+                                    <v-btn
+                                        small
+                                        outlined
+                                        v-bind="attrs"
+                                        class="ml-3 minwidth-0 px-2"
+                                        v-on="on"
+                                        @click="editSensorDisplayName(sensor)">
+                                        <v-icon small>{{ mdiPencil }}</v-icon>
+                                    </v-btn>
+                                </template>
+                                <span>{{ $t('Settings.TempgroupsTab.EditDisplayName') }}</span>
+                            </v-tooltip>
+                            <v-tooltip top>
+                                <template #activator="{ on, attrs }">
+                                    <v-btn
+                                        small
+                                        outlined
+                                        v-bind="attrs"
+                                        class="ml-3 minwidth-0 px-2"
+                                        color="error"
+                                        v-on="on"
+                                        @click="removeSensor(sensor)">
+                                        <v-icon small>{{ mdiDelete }}</v-icon>
+                                    </v-btn>
+                                </template>
+                                <span>{{ $t('Settings.TempgroupsTab.RemoveSensor') }}</span>
+                            </v-tooltip>
+                        </settings-row>
+                    </v-col>
+                </v-row>
+            </draggable>
+        </template>
+        <template v-else>
+            <v-row>
+                <v-col>
+                    <p class="mb-0 text-center font-italic">{{ $t('Settings.TempgroupsTab.NoSensorsInGroup') }}</p>
+                </v-col>
+            </v-row>
+        </template>
+        <v-row class="mt-6 mb-3 flex-column flex-md-row">
+            <v-col class="py-0 align-content-center mb-3 mb-md-0">
+                <h3 class="text-h5">{{ $t('Settings.TempgroupsTab.AvailableSensors') }}</h3>
+            </v-col>
+            <v-col class="py-0">
+                <v-text-field
+                    v-model="searchSensors"
+                    :append-icon="mdiMagnify"
+                    :label="$t('Settings.TempgroupsTab.Search')"
+                    single-line
+                    outlined
+                    clearable
+                    hide-details
+                    dense />
+            </v-col>
+        </v-row>
+        <template v-if="filteredAvailableSensors.length">
+            <template v-for="(sensor, index) in filteredAvailableSensors">
+                <v-divider v-if="index" :key="'availableSensor_divider_' + index" class="my-2"></v-divider>
+                <settings-row
+                    :key="'availableSensor_' + index"
+                    :title="formatSensorName(sensor)"
+                    :sub-title="sensor"
+                    :dynamic-slot-width="true">
+                    <v-btn small outlined class="ml-3" @click="addSensor(sensor)">
+                        <v-icon left small>{{ mdiPlus }}</v-icon>
+                        {{ $t('Settings.TempgroupsTab.Add') }}
+                    </v-btn>
+                </settings-row>
+            </template>
+        </template>
+        <template v-else>
+            <v-row>
+                <v-col>
+                    <p class="mb-0 text-center font-italic">{{ $t('Settings.TempgroupsTab.NoAvailableSensors') }}</p>
+                </v-col>
+            </v-row>
+        </template>
+        <v-card-actions class="d-flex justify-end mt-3 px-0">
+            <v-btn text @click="close">{{ $t('Buttons.Close') }}</v-btn>
+        </v-card-actions>
+
+        <v-dialog v-model="displayNameDialog" max-width="400" persistent>
+            <v-card>
+                <v-card-title>{{ $t('Settings.TempgroupsTab.EditDisplayName') }}</v-card-title>
+                <v-card-text>
+                    <v-text-field
+                        v-model="editingDisplayName"
+                        :label="$t('Settings.TempgroupsTab.DisplayName')"
+                        :placeholder="formatSensorName(editingSensorName)"
+                        outlined
+                        dense
+                        hide-details
+                        clearable></v-text-field>
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn text @click="cancelDisplayNameEdit">{{ $t('Buttons.Cancel') }}</v-btn>
+                    <v-btn color="primary" text @click="saveDisplayName">{{ $t('Buttons.Save') }}</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+    </v-card-text>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
+import BaseMixin from '../mixins/base'
+import ThemeMixin from '@/components/mixins/theme'
+import draggable from 'vuedraggable'
+import SettingsRow from '@/components/settings/SettingsRow.vue'
+import { GuiTempgroup, GuiTempgroupSensor } from '@/store/gui/tempgroups/types'
+import { mdiDelete, mdiDragVertical, mdiMagnify, mdiPencil, mdiPlus } from '@mdi/js'
+import { Debounce } from 'vue-debounce-decorator'
+
+@Component({
+    components: { SettingsRow, draggable },
+})
+export default class SettingsTempgroupsTabEdit extends Mixins(BaseMixin, ThemeMixin) {
+    @Prop({ required: true }) readonly groupId!: string | null
+
+    mdiPencil = mdiPencil
+    mdiDelete = mdiDelete
+    mdiDragVertical = mdiDragVertical
+    mdiPlus = mdiPlus
+    mdiMagnify = mdiMagnify
+
+    private rules = {
+        required: (value: string) => value !== '' || this.$t('Settings.TempgroupsTab.NameRequired'),
+        groupUnique: (value: string) => !this.existsGroupName(value) || this.$t('Settings.TempgroupsTab.NameExists'),
+    }
+
+    private searchSensors: string = ''
+    private displayNameDialog = false
+    private editingSensorName: string = ''
+    private editingDisplayName: string = ''
+    private sensorsList: GuiTempgroupSensor[] = []
+
+    @Watch('groupSensors', { immediate: true })
+    onGroupSensorsChanged(newVal: GuiTempgroupSensor[]) {
+        this.sensorsList = [...newVal]
+    }
+
+    @Watch('group', { immediate: true })
+    onGroupChanged(newVal: GuiTempgroup | null) {
+        this.localGroupName = newVal?.name ?? ''
+    }
+
+    get group(): GuiTempgroup | null {
+        if (!this.groupId) return null
+        return this.$store.getters['gui/tempgroups/getGroup'](this.groupId)
+    }
+
+    private localGroupName: string = ''
+
+    get groupName(): string {
+        return this.localGroupName
+    }
+
+    set groupName(newVal: string) {
+        this.localGroupName = newVal
+        this.updateGroupNameDebounced(newVal)
+    }
+
+    @Debounce(250)
+    updateGroupNameDebounced(newVal: string) {
+        if (!this.groupId) return
+        this.$store.dispatch('gui/tempgroups/groupUpdate', {
+            id: this.groupId,
+            values: { name: newVal },
+        })
+    }
+
+    get showChart(): boolean {
+        return this.group?.showChart ?? true
+    }
+
+    set showChart(newVal: boolean) {
+        if (!this.groupId) return
+        this.$store.dispatch('gui/tempgroups/groupUpdate', {
+            id: this.groupId,
+            values: { showChart: newVal },
+        })
+    }
+
+    get groupSensors(): GuiTempgroupSensor[] {
+        if (!this.group?.sensors) return []
+        return [...this.group.sensors].sort((a, b) => a.pos - b.pos)
+    }
+
+    get allGroups(): GuiTempgroup[] {
+        return this.$store.getters['gui/tempgroups/getSortedGroups'] ?? []
+    }
+
+    get allSensors(): string[] {
+        const sensors: string[] = []
+
+        const heaters = this.$store.state.printer?.heaters?.available_heaters || []
+        sensors.push(...heaters)
+
+        const tempSensors = this.$store.state.printer?.heaters?.available_sensors || []
+        tempSensors.forEach((sensor: string) => {
+            if (!sensors.includes(sensor)) {
+                sensors.push(sensor)
+            }
+        })
+
+        return sensors
+    }
+
+    get usedSensorsInGroup(): string[] {
+        return this.sensorsList.map((s) => s.name)
+    }
+
+    get availableSensors(): string[] {
+        return this.allSensors.filter((sensor) => !this.usedSensorsInGroup.includes(sensor))
+    }
+
+    get filteredAvailableSensors(): string[] {
+        if (!this.searchSensors) return this.availableSensors
+
+        const search = this.searchSensors.toLowerCase()
+        return this.availableSensors.filter(
+            (sensor) =>
+                sensor.toLowerCase().includes(search) || this.formatSensorName(sensor).toLowerCase().includes(search)
+        )
+    }
+
+    existsGroupName(name: string): boolean {
+        return this.allGroups.some((group) => group.name === name && group.id !== this.groupId)
+    }
+
+    formatSensorName(name: string): string {
+        let displayName = name
+
+        const prefixes = ['temperature_sensor ', 'temperature_fan ', 'heater_generic ']
+        for (const prefix of prefixes) {
+            if (displayName.startsWith(prefix)) {
+                displayName = displayName.substring(prefix.length)
+                break
+            }
+        }
+
+        return displayName.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+    }
+
+    updateSensorOrder() {
+        if (!this.groupId) return
+        const reorderedSensors = this.sensorsList.map((s, index) => ({
+            ...s,
+            pos: index,
+        }))
+        this.$store.dispatch('gui/tempgroups/reorderSensorsInGroup', {
+            id: this.groupId,
+            sensors: reorderedSensors,
+        })
+    }
+
+    addSensor(sensorName: string) {
+        if (!this.groupId) return
+        this.$store.dispatch('gui/tempgroups/addSensorToGroup', {
+            id: this.groupId,
+            sensorName,
+        })
+    }
+
+    removeSensor(sensor: GuiTempgroupSensor) {
+        if (!this.groupId) return
+        this.$store.dispatch('gui/tempgroups/removeSensorFromGroup', {
+            id: this.groupId,
+            sensorName: sensor.name,
+        })
+    }
+
+    editSensorDisplayName(sensor: GuiTempgroupSensor) {
+        this.editingSensorName = sensor.name
+        this.editingDisplayName = sensor.displayName || ''
+        this.displayNameDialog = true
+    }
+
+    cancelDisplayNameEdit() {
+        this.displayNameDialog = false
+        this.editingSensorName = ''
+        this.editingDisplayName = ''
+    }
+
+    saveDisplayName() {
+        if (!this.groupId || !this.editingSensorName) return
+
+        this.$store.dispatch('gui/tempgroups/updateSensorInGroup', {
+            id: this.groupId,
+            sensorName: this.editingSensorName,
+            option: 'displayName',
+            value: this.editingDisplayName || undefined,
+        })
+
+        this.cancelDisplayNameEdit()
+    }
+
+    close() {
+        this.$emit('close')
+    }
+}
+</script>

--- a/src/components/settings/SettingsTempgroupsTabEdit.vue
+++ b/src/components/settings/SettingsTempgroupsTabEdit.vue
@@ -170,7 +170,7 @@ export default class SettingsTempgroupsTabEdit extends Mixins(BaseMixin, ThemeMi
         groupUnique: (value: string) => !this.existsGroupName(value) || this.$t('Settings.TempgroupsTab.NameExists'),
     }
 
-    private searchSensors: string = ''
+    private searchSensors: string | null = ''
     private displayNameDialog = false
     private editingSensorName: string = ''
     private editingDisplayName: string = ''

--- a/src/components/settings/SettingsTempgroupsTabEdit.vue
+++ b/src/components/settings/SettingsTempgroupsTabEdit.vue
@@ -205,6 +205,7 @@ export default class SettingsTempgroupsTabEdit extends Mixins(BaseMixin, ThemeMi
     @Debounce(250)
     updateGroupNameDebounced(newVal: string) {
         if (!this.groupId) return
+        if (newVal.trim() === '' || this.existsGroupName(newVal)) return
         this.$store.dispatch('gui/tempgroups/groupUpdate', {
             id: this.groupId,
             values: { name: newVal },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1021,6 +1021,7 @@
             "Unknown": "Unknown"
         },
         "TemperaturePanel": {
+            "All": "All",
             "AutoscaleChart": "Autoscale Chart",
             "Avg": "Avg",
             "Cooldown": "Cooldown",
@@ -1381,6 +1382,30 @@
             "UseConfigJson": "InstanceDB = JSON detected. Please use the config.json to modify the printers list."
         },
         "Store": "store",
+        "TempgroupsTab": {
+            "Add": "add",
+            "AddGroup": "add group",
+            "AvailableSensors": "Available Sensors",
+            "CountSensors": "no sensors added | {count} sensor | {count} sensors",
+            "DisplayName": "Display name",
+            "EditDisplayName": "Edit display name",
+            "EditGroup": "Edit Group",
+            "General": "General",
+            "Groups": "Groups",
+            "GroupSensors": "Group Sensors",
+            "Name": "Name",
+            "NameExists": "Name already exists",
+            "NameRequired": "Name is required",
+            "NoAvailableSensors": "No available sensors.",
+            "NoGroups": "No groups found...",
+            "NoSensorsInGroup": "No sensors in this group.",
+            "RemoveSensor": "Remove sensor from group",
+            "Search": "Search",
+            "ShowAllTab": "Show 'All' tab",
+            "ShowChart": "Show chart",
+            "TempGroups": "Temp Groups",
+            "UnknownGroup": "Unknown Group"
+        },
         "TimelapseTab": {
             "Autorender": "Autorender",
             "AutorenderDescription": "If enabled, the timelapse video will automatically render at the end of the print",
@@ -1580,6 +1605,21 @@
             "WebrtcJanus": "WebRTC (janus-gateway)",
             "WebrtcMediaMTX": "WebRTC (MediaMTX)"
         }
+    },
+    "Tempgroups": {
+        "AddGroup": "Add Group",
+        "AvailableSensors": "Available sensors",
+        "CreateGroup": "Create Group",
+        "DeleteGroup": "Delete Group",
+        "DeleteGroupQuestion": "Do you really want to delete the group \"{name}\"?",
+        "DisplayName": "Display Name",
+        "EditGroup": "Edit Group",
+        "GroupName": "Group Name",
+        "NoSensorsAdded": "No sensors added to this group.",
+        "SensorsInGroup": "Sensors in this group",
+        "ShowAllTab": "Show \"All\" tab",
+        "ShowChart": "Show Chart",
+        "Title": "Temperature Groups"
     },
     "Timelapse": {
         "AllFiles": "All",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -21,6 +21,7 @@ import { notifications } from '@/store/gui/notifications'
 import { presets } from '@/store/gui/presets'
 import { remoteprinters } from '@/store/gui/remoteprinters'
 import { maintenance } from '@/store/gui/maintenance'
+import { tempgroups } from '@/store/gui/tempgroups'
 import { webcams } from '@/store/gui/webcams'
 import { heightmap } from '@/store/gui/heightmap'
 
@@ -336,6 +337,7 @@ export const gui: Module<GuiState, any> = {
         notifications,
         presets,
         remoteprinters,
+        tempgroups,
         webcams,
         heightmap,
     },

--- a/src/store/gui/tempgroups/actions.ts
+++ b/src/store/gui/tempgroups/actions.ts
@@ -1,0 +1,113 @@
+import { ActionTree } from 'vuex'
+import { RootState } from '@/store/types'
+import { v4 as uuidv4 } from 'uuid'
+import Vue from 'vue'
+import { GuiTempgroupsState, GuiTempgroup, GuiTempgroupSensor } from '@/store/gui/tempgroups/types'
+
+export const actions: ActionTree<GuiTempgroupsState, RootState> = {
+    reset({ commit }) {
+        commit('reset')
+    },
+
+    saveSetting({ dispatch }, payload: { name: string; value: any }) {
+        dispatch(
+            'gui/saveSetting',
+            {
+                name: 'tempgroups.' + payload.name,
+                value: payload.value,
+            },
+            { root: true }
+        )
+    },
+
+    setActiveGroup({ commit, dispatch }, groupId: string | null) {
+        commit('setActiveGroup', groupId)
+        dispatch('saveSetting', { name: 'activeGroupId', value: groupId })
+    },
+
+    setShowAllTab({ commit, dispatch }, show: boolean) {
+        commit('setShowAllTab', show)
+        dispatch('saveSetting', { name: 'showAllTab', value: show })
+    },
+
+    groupUpload({ state }, id: string) {
+        Vue.$socket.emit('server.database.post_item', {
+            namespace: 'mainsail',
+            key: 'tempgroups.groups.' + id,
+            value: state.groups[id],
+        })
+    },
+
+    async groupStore({ commit, state, dispatch }, payload: { values: Partial<GuiTempgroup> }) {
+        const id = uuidv4()
+        const maxPosition = Object.values(state.groups).reduce((max, g) => Math.max(max, g.position), -1)
+
+        const group: GuiTempgroup = {
+            id,
+            name: payload.values.name || 'New Group',
+            position: maxPosition + 1,
+            color: payload.values.color,
+            showChart: payload.values.showChart ?? true,
+            sensors: payload.values.sensors ?? [],
+        }
+
+        await commit('groupStore', { id, values: group })
+        await dispatch('groupUpload', id)
+
+        return id
+    },
+
+    groupUpdate({ commit, dispatch }, payload: { id: string; values: Partial<GuiTempgroup> }) {
+        commit('groupUpdate', payload)
+        dispatch('groupUpload', payload.id)
+    },
+
+    groupDelete({ commit }, id: string) {
+        commit('groupDelete', id)
+        Vue.$socket.emit('server.database.delete_item', {
+            namespace: 'mainsail',
+            key: 'tempgroups.groups.' + id,
+        })
+    },
+
+    addSensorToGroup({ commit, dispatch }, payload: { id: string; sensorName: string; displayName?: string }) {
+        const sensor: GuiTempgroupSensor = {
+            pos: 0,
+            name: payload.sensorName,
+            displayName: payload.displayName,
+        }
+
+        commit('addSensorToGroup', { id: payload.id, sensor })
+        dispatch('groupUpload', payload.id)
+    },
+
+    updateSensorInGroup(
+        { commit, dispatch },
+        payload: {
+            id: string
+            sensorName: string
+            option: keyof GuiTempgroupSensor
+            value: any
+        }
+    ) {
+        commit('updateSensorInGroup', payload)
+        dispatch('groupUpload', payload.id)
+    },
+
+    removeSensorFromGroup({ commit, dispatch }, payload: { id: string; sensorName: string }) {
+        commit('removeSensorFromGroup', payload)
+        dispatch('groupUpload', payload.id)
+    },
+
+    reorderSensorsInGroup({ commit, dispatch }, payload: { id: string; sensors: GuiTempgroupSensor[] }) {
+        commit('reorderSensorsInGroup', payload)
+        dispatch('groupUpload', payload.id)
+    },
+
+    reorderGroups({ commit, dispatch }, orderedIds: string[]) {
+        commit('reorderGroups', orderedIds)
+        orderedIds.forEach((id) => {
+            dispatch('groupUpload', id)
+        })
+    },
+}

--- a/src/store/gui/tempgroups/actions.ts
+++ b/src/store/gui/tempgroups/actions.ts
@@ -51,7 +51,7 @@ export const actions: ActionTree<GuiTempgroupsState, RootState> = {
             sensors: payload.values.sensors ?? [],
         }
 
-        await commit('groupStore', { id, values: group })
+        commit('groupStore', { id, values: group })
         await dispatch('groupUpload', id)
 
         return id

--- a/src/store/gui/tempgroups/getters.ts
+++ b/src/store/gui/tempgroups/getters.ts
@@ -1,0 +1,71 @@
+import { GetterTree } from 'vuex'
+import { GuiTempgroupsState, GuiTempgroup } from '@/store/gui/tempgroups/types'
+import { RootState } from '@/store/types'
+
+// eslint-disable-next-line
+export const getters: GetterTree<GuiTempgroupsState, RootState> = {
+    getSortedGroups(state): GuiTempgroup[] {
+        return Object.values(state.groups).sort((a, b) => a.position - b.position)
+    },
+
+    getActiveGroup(state): GuiTempgroup | null {
+        if (!state.activeGroupId) return null
+        return state.groups[state.activeGroupId] || null
+    },
+
+    getGroup:
+        (state) =>
+        (id: string): GuiTempgroup | null => {
+            return state.groups[id] || null
+        },
+
+    getActiveSensorFilter(state): string[] | null {
+        if (!state.activeGroupId) return null
+
+        const group = state.groups[state.activeGroupId]
+        if (!group) return null
+
+        return group.sensors
+            .slice()
+            .sort((a, b) => a.pos - b.pos)
+            .map((s) => s.name)
+    },
+
+    isSensorInAnyGroup:
+        (state) =>
+        (sensorName: string): boolean => {
+            return Object.values(state.groups).some((group) => group.sensors.some((s) => s.name === sensorName))
+        },
+
+    getSensorDisplayName:
+        (state) =>
+        (sensorName: string): string => {
+            for (const group of Object.values(state.groups)) {
+                const sensor = group.sensors.find((s) => s.name === sensorName)
+                if (sensor?.displayName) {
+                    return sensor.displayName
+                }
+            }
+            return sensorName
+        },
+
+    getUngroupedSensors(state, getters, rootState): string[] {
+        const allSensors: string[] = []
+
+        const heaters = rootState.printer?.heaters?.available_heaters || []
+        allSensors.push(...heaters)
+
+        const sensors = rootState.printer?.heaters?.available_sensors || []
+        sensors.forEach((sensor: string) => {
+            if (!allSensors.includes(sensor)) {
+                allSensors.push(sensor)
+            }
+        })
+
+        return allSensors.filter((name) => !getters.isSensorInAnyGroup(name))
+    },
+
+    shouldShowTabs(state): boolean {
+        return Object.keys(state.groups).length > 0
+    },
+}

--- a/src/store/gui/tempgroups/index.ts
+++ b/src/store/gui/tempgroups/index.ts
@@ -1,0 +1,24 @@
+import { Module } from 'vuex'
+import { actions } from '@/store/gui/tempgroups/actions'
+import { mutations } from '@/store/gui/tempgroups/mutations'
+import { getters } from '@/store/gui/tempgroups/getters'
+import { GuiTempgroupsState } from '@/store/gui/tempgroups/types'
+
+export const getDefaultState = (): GuiTempgroupsState => {
+    return {
+        showAllTab: true,
+        activeGroupId: null,
+        groups: {},
+    }
+}
+
+const state = getDefaultState()
+
+// eslint-disable-next-line
+export const tempgroups: Module<GuiTempgroupsState, any> = {
+    namespaced: true,
+    state,
+    getters,
+    actions,
+    mutations,
+}

--- a/src/store/gui/tempgroups/mutations.ts
+++ b/src/store/gui/tempgroups/mutations.ts
@@ -1,0 +1,110 @@
+import { getDefaultState } from './index'
+import { MutationTree } from 'vuex'
+import Vue from 'vue'
+import { GuiTempgroupsState, GuiTempgroup, GuiTempgroupSensor } from '@/store/gui/tempgroups/types'
+
+export const mutations: MutationTree<GuiTempgroupsState> = {
+    reset(state) {
+        Object.assign(state, getDefaultState())
+    },
+
+    setActiveGroup(state, groupId: string | null) {
+        state.activeGroupId = groupId
+    },
+
+    setShowAllTab(state, show: boolean) {
+        state.showAllTab = show
+    },
+
+    groupStore(state, payload: { id: string; values: GuiTempgroup }) {
+        Vue.set(state.groups, payload.id, payload.values)
+    },
+
+    groupUpdate(state, payload: { id: string; values: Partial<GuiTempgroup> }) {
+        if (payload.id in state.groups) {
+            const group = { ...state.groups[payload.id] }
+            Object.assign(group, payload.values)
+            Vue.set(state.groups, payload.id, group)
+        }
+    },
+
+    groupDelete(state, groupId: string) {
+        if (groupId in state.groups) {
+            Vue.delete(state.groups, groupId)
+        }
+
+        if (state.activeGroupId === groupId) {
+            state.activeGroupId = null
+        }
+    },
+
+    addSensorToGroup(state, payload: { id: string; sensor: GuiTempgroupSensor }) {
+        const group = state.groups[payload.id]
+        if (group) {
+            const sensors = [...(group.sensors ?? [])]
+            const maxPos = sensors.reduce((max, s) => Math.max(max, s.pos), -1)
+            payload.sensor.pos = maxPos + 1
+            sensors.push(payload.sensor)
+
+            Vue.set(state.groups[payload.id], 'sensors', sensors)
+        }
+    },
+
+    updateSensorInGroup(
+        state,
+        payload: {
+            id: string
+            sensorName: string
+            option: keyof GuiTempgroupSensor
+            value: any
+        }
+    ) {
+        const group = state.groups[payload.id]
+        if (group) {
+            const sensors = [...(group.sensors ?? [])]
+            const sensorIndex = sensors.findIndex((s) => s.name === payload.sensorName)
+            if (sensorIndex !== -1) {
+                const sensor = sensors[sensorIndex]
+                // @ts-ignore
+                sensor[payload.option] = payload.value
+                Vue.set(state.groups[payload.id], 'sensors', sensors)
+            }
+        }
+    },
+
+    removeSensorFromGroup(state, payload: { id: string; sensorName: string }) {
+        const group = state.groups[payload.id]
+        if (group) {
+            const sensors = [...(group.sensors ?? [])]
+            const deletedIndex = sensors.findIndex((s) => s.name === payload.sensorName)
+            if (deletedIndex !== -1) {
+                const oldPos = sensors[deletedIndex].pos
+                sensors.splice(deletedIndex, 1)
+
+                sensors
+                    .filter((s) => s.pos > oldPos)
+                    .forEach((s) => {
+                        s.pos = s.pos - 1
+                    })
+            }
+
+            Vue.set(state.groups[payload.id], 'sensors', sensors)
+        }
+    },
+
+    reorderSensorsInGroup(state, payload: { id: string; sensors: GuiTempgroupSensor[] }) {
+        const group = state.groups[payload.id]
+        if (group) {
+            const reorderedSensors = payload.sensors.map((s, i) => ({ ...s, pos: i }))
+            Vue.set(state.groups[payload.id], 'sensors', reorderedSensors)
+        }
+    },
+
+    reorderGroups(state, orderedIds: string[]) {
+        orderedIds.forEach((id, index) => {
+            if (state.groups[id]) {
+                Vue.set(state.groups[id], 'position', index)
+            }
+        })
+    },
+}

--- a/src/store/gui/tempgroups/mutations.ts
+++ b/src/store/gui/tempgroups/mutations.ts
@@ -43,8 +43,7 @@ export const mutations: MutationTree<GuiTempgroupsState> = {
         if (group) {
             const sensors = [...(group.sensors ?? [])]
             const maxPos = sensors.reduce((max, s) => Math.max(max, s.pos), -1)
-            payload.sensor.pos = maxPos + 1
-            sensors.push(payload.sensor)
+            sensors.push({ ...payload.sensor, pos: maxPos + 1 })
 
             Vue.set(state.groups[payload.id], 'sensors', sensors)
         }
@@ -64,9 +63,10 @@ export const mutations: MutationTree<GuiTempgroupsState> = {
             const sensors = [...(group.sensors ?? [])]
             const sensorIndex = sensors.findIndex((s) => s.name === payload.sensorName)
             if (sensorIndex !== -1) {
-                const sensor = sensors[sensorIndex]
-                // @ts-ignore
-                sensor[payload.option] = payload.value
+                sensors[sensorIndex] = {
+                    ...sensors[sensorIndex],
+                    [payload.option]: payload.value,
+                }
                 Vue.set(state.groups[payload.id], 'sensors', sensors)
             }
         }

--- a/src/store/gui/tempgroups/types.ts
+++ b/src/store/gui/tempgroups/types.ts
@@ -1,0 +1,22 @@
+export interface GuiTempgroupsState {
+    showAllTab: boolean
+    activeGroupId: string | null
+    groups: {
+        [key: string]: GuiTempgroup
+    }
+}
+
+export interface GuiTempgroup {
+    id: string
+    name: string
+    position: number
+    color?: string
+    showChart: boolean
+    sensors: GuiTempgroupSensor[]
+}
+
+export interface GuiTempgroupSensor {
+    pos: number
+    name: string
+    displayName?: string
+}

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -2,6 +2,7 @@ import { GuiMacrosState } from '@/store/gui/macros/types'
 import { GuiConsoleState } from '@/store/gui/console/types'
 import { GuiPresetsState } from '@/store/gui/presets/types'
 import { GuiRemoteprintersState } from '@/store/gui/remoteprinters/types'
+import { GuiTempgroupsState } from '@/store/gui/tempgroups/types'
 import { ServerHistoryStateJob } from '@/store/server/history/types'
 import { GuiNotificationState } from '@/store/gui/notifications/types'
 import { FileStateFile, FileStateGcodefile } from '@/store/files/types'
@@ -98,6 +99,7 @@ export interface GuiState {
     notifications?: GuiNotificationState
     presets?: GuiPresetsState
     remoteprinters?: GuiRemoteprintersState
+    tempgroups?: GuiTempgroupsState
     uiSettings: {
         mode: 'dark' | 'light'
         theme: string


### PR DESCRIPTION
## Summary

Adds ability to organize temperature sensors into custom groups (tabs), addressing the issue of cluttered temperature panels with many sensors.

- Create, edit, and delete temperature groups via Settings → Temp Groups
- Drag & drop to reorder groups and sensors within groups
- Optional "All" tab showing all sensors (default behavior preserved)
- Custom display names for sensors (solves issue with non-renamable sensors like Cartographer)
- Per-group chart visibility toggle
- Graph Y-axis scales appropriately for filtered sensor range
- Full backwards compatibility - no tabs shown without configured groups

### Screenshots
<img width="683" height="621" alt="image" src="https://github.com/user-attachments/assets/8f7c9ae8-a7ce-4043-8d42-8127feb29f68" />
<img width="683" height="473" alt="image" src="https://github.com/user-attachments/assets/2ee3d1ac-50ec-42d5-bbf2-786493e4cbbb" />
<img width="903" height="547" alt="image" src="https://github.com/user-attachments/assets/a0f64093-7d3c-432d-8184-aa156df92426" />
<img width="903" height="547" alt="image" src="https://github.com/user-attachments/assets/35dfa49a-7424-4d78-9828-794ce4e8827b" />

## Test plan

- [x] Create a new temperature group
- [x] Add sensors to the group
- [x] Verify only grouped sensors appear in the tab
- [x] Verify graph filters correctly for the active tab
- [x] Test drag & drop reordering of groups and sensors
- [x] Test custom display names for sensors
- [x] Verify "Show All tab" toggle works
- [x] Verify settings persist after browser reload
- [x] Test on mobile (responsive tabs)

Closes #2376