### PR TITLE
fix(HappyHare): Show spool for bypass empty/full based on loaded

### DIFF
--- a/src/components/panels/Mmu/MmuUnitGateSpool.vue
+++ b/src/components/panels/Mmu/MmuUnitGateSpool.vue
@@ -110,7 +110,7 @@
 import Component from 'vue-class-component'
 import { Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import MmuMixin, { GATE_EMPTY, GATE_UNKNOWN, NO_FILAMENT_COLOR } from '@/components/mixins/mmu'
+import MmuMixin, { TOOL_GATE_BYPASS, GATE_AVAILABLE, GATE_EMPTY, GATE_UNKNOWN, NO_FILAMENT_COLOR, FILAMENT_POS_LOADED } from '@/components/mixins/mmu'
 import { filamentTextColor } from '@/plugins/helpers'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 
@@ -130,7 +130,11 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get status() {
-        return this.mmu?.gate_status?.[this.gateIndex] ?? GATE_UNKNOWN
+        if (this.gateIndex === TOOL_GATE_BYPASS) {
+            if (this.mmuFilamentPos === FILAMENT_POS_LOADED) return GATE_AVAILABLE
+            return GATE_EMPTY
+        }
+        return this.mmu?.gate_status?.[this.gateIndex] ?? GATE_EMPTY
     }
 
     get isNotEmpty() {
@@ -250,7 +254,7 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
             output.push(`${this.$t('Panels.MmuPanel.ToolTip.Color')}: ${color}`)
         }
 
-        if (this.spoolId) {
+        if (this.spoolId > 0) {
             output.push(`${this.$t('Panels.MmuPanel.ToolTip.SpoolId')}: ${this.spoolId}`)
         }
 

--- a/src/components/panels/Mmu/MmuUnitGateSpool.vue
+++ b/src/components/panels/Mmu/MmuUnitGateSpool.vue
@@ -110,7 +110,13 @@
 import Component from 'vue-class-component'
 import { Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import MmuMixin, { TOOL_GATE_BYPASS, GATE_AVAILABLE, GATE_EMPTY, GATE_UNKNOWN, NO_FILAMENT_COLOR, FILAMENT_POS_LOADED } from '@/components/mixins/mmu'
+import MmuMixin, {
+    FILAMENT_POS_LOADED,
+    GATE_AVAILABLE,
+    GATE_EMPTY,
+    NO_FILAMENT_COLOR,
+    TOOL_GATE_BYPASS,
+} from '@/components/mixins/mmu'
 import { filamentTextColor } from '@/plugins/helpers'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 


### PR DESCRIPTION
## Description
This PR fixes the spool for the bypass gate and correctly shows filament or not based on whether the extruder is loaded.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
When loaded shows full, else will be empty spool
<img width="342" height="383" alt="Screenshot 2026-02-12 at 2 23 55 PM" src="https://github.com/user-attachments/assets/6b2182ce-93ee-4873-a984-656c13b00278" />

## [optional] Are there any post-deployment tasks we need to perform?
n/a
