### PR TITLE
fix(UpdatePanel): add zip type to semver-based update checks

### DIFF
--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -10,14 +10,14 @@
                         {{ versionOutput }}
                     </a>
                 </template>
-                <template v-else-if="['executable', 'web', 'zip'].includes(type) && semverUpdatable">
-                    <a class="info--text text-decoration-none" :href="webLinkRelease" target="_blank">
+                <template v-else-if="type === 'python' && semverUpdatable">
+                    <a class="info--text text-decoration-none" :href="pythonChangelog" target="_blank">
                         <v-icon small color="info" class="mr-1">{{ mdiUpdate }}</v-icon>
                         {{ versionOutput }}
                     </a>
                 </template>
-                <template v-else-if="type === 'python' && semverUpdatable">
-                    <a class="info--text text-decoration-none" :href="pythonChangelog" target="_blank">
+                <template v-else-if="isSemverType && semverUpdatable">
+                    <a class="info--text text-decoration-none" :href="webLinkRelease" target="_blank">
                         <v-icon small color="info" class="mr-1">{{ mdiUpdate }}</v-icon>
                         {{ versionOutput }}
                     </a>

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -172,6 +172,10 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         return this.repo.configured_type
     }
 
+    get isSemverType() {
+        return ['executable', 'python', 'web', 'zip'].includes(this.type)
+    }
+
     get localVersion() {
         const version = this.repo.version ?? '?'
         if (!semver.valid(version, { loose: true })) return null
@@ -271,7 +275,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (['printing', 'paused'].includes(this.printer_state)) return true
         if (!this.isValid || this.isCorrupt || this.isDirty || this.commitsBehind.length) return false
 
-        if (['executable', 'python', 'web', 'zip'].includes(this.type)) return !this.semverUpdatable
+        if (this.isSemverType) return !this.semverUpdatable
 
         return this.commitsBehind.length === 0
     }
@@ -279,7 +283,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     get btnIcon() {
         if (this.isDetached || !this.isValid || this.isCorrupt || this.isDirty) return mdiCloseCircle
 
-        if (['executable', 'python', 'web', 'zip'].includes(this.type)) {
+        if (this.isSemverType) {
             if (this.semverUpdatable) return mdiProgressUpload
             else if (this.localVersion === null || this.remoteVersion === null) return mdiHelpCircleOutline
         }
@@ -292,7 +296,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     get btnColor() {
         if (this.isCorrupt || this.isDetached || this.isDirty || !this.isValid) return 'orange'
 
-        if (['executable', 'python', 'web', 'zip'].includes(this.type) && this.semverUpdatable) return 'primary'
+        if (this.isSemverType && this.semverUpdatable) return 'primary'
         if (this.type === 'git_repo' && this.commitsBehind.length) return 'primary'
 
         return 'green'
@@ -304,7 +308,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (this.isDirty) return this.$t('Machine.UpdatePanel.Dirty')
         if (!this.isValid) return this.$t('Machine.UpdatePanel.Invalid')
 
-        if (['executable', 'python', 'web', 'zip'].includes(this.type)) {
+        if (this.isSemverType) {
             if (this.semverUpdatable) return this.$t('Machine.UpdatePanel.Update')
             else if (this.localVersion === null || this.remoteVersion === null)
                 return this.$t('Machine.UpdatePanel.Unknown')

--- a/src/components/panels/Machine/UpdatePanel/Entry.vue
+++ b/src/components/panels/Machine/UpdatePanel/Entry.vue
@@ -10,7 +10,7 @@
                         {{ versionOutput }}
                     </a>
                 </template>
-                <template v-else-if="(type === 'web' || type === 'executable') && semverUpdatable">
+                <template v-else-if="['executable', 'web', 'zip'].includes(type) && semverUpdatable">
                     <a class="info--text text-decoration-none" :href="webLinkRelease" target="_blank">
                         <v-icon small color="info" class="mr-1">{{ mdiUpdate }}</v-icon>
                         {{ versionOutput }}
@@ -271,7 +271,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (['printing', 'paused'].includes(this.printer_state)) return true
         if (!this.isValid || this.isCorrupt || this.isDirty || this.commitsBehind.length) return false
 
-        if (['python', 'web', 'executable'].includes(this.type)) return !this.semverUpdatable
+        if (['executable', 'python', 'web', 'zip'].includes(this.type)) return !this.semverUpdatable
 
         return this.commitsBehind.length === 0
     }
@@ -279,7 +279,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     get btnIcon() {
         if (this.isDetached || !this.isValid || this.isCorrupt || this.isDirty) return mdiCloseCircle
 
-        if (['python', 'web', 'executable'].includes(this.type)) {
+        if (['executable', 'python', 'web', 'zip'].includes(this.type)) {
             if (this.semverUpdatable) return mdiProgressUpload
             else if (this.localVersion === null || this.remoteVersion === null) return mdiHelpCircleOutline
         }
@@ -292,7 +292,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
     get btnColor() {
         if (this.isCorrupt || this.isDetached || this.isDirty || !this.isValid) return 'orange'
 
-        if (['python', 'web', 'executable'].includes(this.type) && this.semverUpdatable) return 'primary'
+        if (['executable', 'python', 'web', 'zip'].includes(this.type) && this.semverUpdatable) return 'primary'
         if (this.type === 'git_repo' && this.commitsBehind.length) return 'primary'
 
         return 'green'
@@ -304,7 +304,7 @@ export default class UpdatePanelEntry extends Mixins(BaseMixin) {
         if (this.isDirty) return this.$t('Machine.UpdatePanel.Dirty')
         if (!this.isValid) return this.$t('Machine.UpdatePanel.Invalid')
 
-        if (['python', 'web', 'executable'].includes(this.type)) {
+        if (['executable', 'python', 'web', 'zip'].includes(this.type)) {
             if (this.semverUpdatable) return this.$t('Machine.UpdatePanel.Update')
             else if (this.localVersion === null || this.remoteVersion === null)
                 return this.$t('Machine.UpdatePanel.Unknown')


### PR DESCRIPTION
## Summary

Moonraker's type: zip deployments use semver versioning (via release_info.json) just like web and python types. However, the Update Manager panel only checks semver for web and python types, causing zip type entries to fall through to the git_repo code path which checks commitsBehind -- always empty for zip deployments.

This results in zip-type applications perpetually showing **UP-TO-DATE** even when a newer version is available on GitHub, with the update button permanently disabled.

### Root Cause

In Entry.vue, five computed properties gate on `['python', 'web'].includes(this.type)` for semver-based update detection. The zip type is not included, so it falls through to `commitsBehind.length === 0` which is always true for non-git deployments.

### Fix

Add zip to all five type-check arrays in Entry.vue:
- `btnDisabled` -- enables update button when semver detects newer version
- `btnIcon` -- shows upload icon instead of checkmark
- `btnColor` -- shows primary color instead of green
- `btnText` -- shows Update instead of Up-to-date
- Template version link -- makes version clickable to release page