### PR TITLE
fix(socket): resync after long tab inactivity to avoid replay catch-up

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,8 @@ import { AppRoute } from '@/routes'
     },
 })
 export default class App extends Mixins(BaseMixin, ThemeMixin) {
+    private hiddenAt: number | null = null
+    private readonly longVisibilityGapMs = 180_000
     get title(): string {
         let title = this.$store.getters['getTitle']
 
@@ -387,11 +389,41 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
         })
     }
 
+    async onDocumentVisibilityChange() {
+        if (document.visibilityState === 'hidden') {
+            this.hiddenAt = Date.now()
+            return
+        }
+
+        const now = Date.now()
+        const hiddenGap = this.hiddenAt ? now - this.hiddenAt : 0
+        this.hiddenAt = null
+
+        if (hiddenGap < this.longVisibilityGapMs) return
+
+        this.$store.dispatch('socket/setData', { isResyncing: true })
+        this.$store.dispatch('socket/clearLoadings')
+
+        try {
+            await this.$store.dispatch('printer/init')
+            await this.$store.dispatch('server/init')
+        } finally {
+            this.$store.dispatch('socket/setData', { isResyncing: false })
+        }
+    }
+
     mounted(): void {
         this.drawFavicon(this.print_percent)
         this.appHeight()
         window.addEventListener('resize', this.appHeight)
         window.addEventListener('orientationchange', this.appHeight)
+        document.addEventListener('visibilitychange', this.onDocumentVisibilityChange)
+    }
+
+    beforeDestroy(): void {
+        window.removeEventListener('resize', this.appHeight)
+        window.removeEventListener('orientationchange', this.appHeight)
+        document.removeEventListener('visibilitychange', this.onDocumentVisibilityChange)
     }
 }
 </script>

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -44,7 +44,28 @@ export const actions: ActionTree<SocketState, RootState> = {
         commit('setDisconnected')
     },
 
-    onMessage({ commit, dispatch }, payload) {
+    onMessage({ commit, dispatch, state }, payload) {
+        const suppressDuringResync = [
+            'notify_status_update',
+            'notify_gcode_response',
+            'notify_proc_stat_update',
+            'notify_filelist_changed',
+            'notify_metadata_update',
+            'notify_power_changed',
+            'notify_history_changed',
+            'notify_service_state_changed',
+            'notify_timelapse_event',
+            'notify_job_queue_changed',
+            'notify_announcement_update',
+            'notify_announcement_dismissed',
+            'notify_announcement_wake',
+            'notify_webcams_changed',
+            'notify_active_spool_set',
+            'notify_sensor_update',
+        ]
+
+        if (state.isResyncing && suppressDuringResync.includes(payload.method)) return
+
         switch (payload.method) {
             case 'notify_status_update':
                 dispatch('printer/getData', payload.params[0], { root: true })

--- a/src/store/socket/index.ts
+++ b/src/store/socket/index.ts
@@ -24,6 +24,7 @@ export const getDefaultState = (): SocketState => {
         loadings: [],
         initializationList: ['server'],
         connection_id: null,
+        isResyncing: false,
     }
 }
 

--- a/src/store/socket/types.ts
+++ b/src/store/socket/types.ts
@@ -11,4 +11,5 @@ export interface SocketState {
     loadings: string[]
     initializationList: string[]
     connection_id: number | null
+    isResyncing: boolean
 }


### PR DESCRIPTION
*🐦‍⬛ Co-authored with Gravious.*

## Summary
- Adds a long-inactivity resume path that performs a full state resync.
- Suppresses incremental websocket notifications during resync to avoid catch-up replay artifacts.

## Problem
When the Mainsail UI is backgrounded/throttled (e.g. embedded webview or inactive tab) for long periods, returning can produce a burst of incremental updates that appear as rapid replay/fast-forward.

## Approach
- Track tab hidden/visible transitions.
- If hidden gap exceeds 180s, enter `socket.isResyncing` mode.
- While resyncing, ignore noisy incremental notify events.
- Trigger fresh state initialization via `printer/init` and `server/init`.
- Exit resync mode once complete.

## Notes
- Short tab switches are unaffected.
- This intentionally prefers authoritative snapshot state over stale incremental replay after long inactivity.

## Testing
- ESLint run on changed files passed.
- Manual code-path verification for visibility gap handling.
