### PR TITLE
fix(spoolman): Handle undefined filament vendor in custom filter

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -175,7 +175,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
             item.id.toString(),
             item.comment,
             item.filament.name,
-            item.filament.vendor.name,
+            item.filament.vendor?.name,
             item.filament.material,
             item.location,
         ]


### PR DESCRIPTION
## Description
 Spoolman allows for a filament spool to exist without vendor, as I found out when importing some unlabeled spools I found in a box.

This PR prevents such a spool from crashing the entire Spoolman search.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots showing the before and after -->

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
