### PR TITLE
feat(webcam): full width on smaller viewports for multi cams

### DIFF
--- a/src/components/webcams/WebcamWrapper.vue
+++ b/src/components/webcams/WebcamWrapper.vue
@@ -33,7 +33,7 @@ import WebcamWrapperItem from '@/components/webcams/WebcamWrapperItem.vue'
 })
 export default class WebcamWrapper extends Mixins(BaseMixin) {
     @Prop({ type: Object, required: true }) webcam!: GuiWebcamStateWebcam
-    @Prop({ type: Boolean, default: true }) showFps!: Boolean
+    @Prop({ type: Boolean, default: true }) showFps!: boolean
     @Prop({ type: String, default: null }) printerUrl!: string | null
     @Prop({ type: String, default: null }) page!: string | null
 

--- a/src/components/webcams/WebcamWrapper.vue
+++ b/src/components/webcams/WebcamWrapper.vue
@@ -3,7 +3,7 @@
         <template v-if="webcam.service === 'grid'">
             <v-container v-if="webcams" fluid class="pb-4">
                 <v-row dense>
-                    <v-col v-for="gridWebcam in webcams" :key="gridWebcam.name" cols="6" class="webcam-grid-col">
+                    <v-col v-for="gridWebcam in webcams" :key="gridWebcam.name" class="col-12 col-md-6">
                         <webcam-wrapper-item
                             :webcam="gridWebcam"
                             :printer-url="printerUrl"
@@ -42,12 +42,3 @@ export default class WebcamWrapper extends Mixins(BaseMixin) {
     }
 }
 </script>
-
-<style scoped>
-@media (orientation: portrait) {
-    .webcam-grid-col {
-        flex: 0 0 100% !important;
-        max-width: 100% !important;
-    }
-}
-</style>

--- a/src/components/webcams/WebcamWrapper.vue
+++ b/src/components/webcams/WebcamWrapper.vue
@@ -3,7 +3,7 @@
         <template v-if="webcam.service === 'grid'">
             <v-container v-if="webcams" fluid class="pb-4">
                 <v-row dense>
-                    <v-col v-for="gridWebcam in webcams" :key="gridWebcam.name" cols="6">
+                    <v-col v-for="gridWebcam in webcams" :key="gridWebcam.name" cols="6" class="webcam-grid-col">
                         <webcam-wrapper-item
                             :webcam="gridWebcam"
                             :printer-url="printerUrl"
@@ -33,7 +33,7 @@ import WebcamWrapperItem from '@/components/webcams/WebcamWrapperItem.vue'
 })
 export default class WebcamWrapper extends Mixins(BaseMixin) {
     @Prop({ type: Object, required: true }) webcam!: GuiWebcamStateWebcam
-    @Prop({ type: Boolean, default: true }) showFps!: boolean
+    @Prop({ type: Boolean, default: true }) showFps!: Boolean
     @Prop({ type: String, default: null }) printerUrl!: string | null
     @Prop({ type: String, default: null }) page!: string | null
 
@@ -43,4 +43,11 @@ export default class WebcamWrapper extends Mixins(BaseMixin) {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+@media (orientation: portrait) {
+    .webcam-grid-col {
+        flex: 0 0 100% !important;
+        max-width: 100% !important;
+    }
+}
+</style>


### PR DESCRIPTION
## Description

This PR changes how multiple webcams are displayed for portrait view to allow stacking the camera feeds. When portrait is detected it will stack them to make better use of the space.

I created this with mobile in mind but works with portrait sized desktop windows too.


## Mobile & Desktop Screenshots/Recordings
Mobile
Before
<img width="540" height="1170" alt="Screenshot 2026-04-28 010042" src="https://github.com/user-attachments/assets/57b49350-a419-4fe8-b477-a3df99dded0b" />

After
<img width="496" height="1074" alt="Screenshot 2026-04-28 011419" src="https://github.com/user-attachments/assets/dff95216-30ff-4e82-8cff-0dbac198a4f4" />

Desktop
Before
<img width="1124" height="1366" alt="image" src="https://github.com/user-attachments/assets/19b8a938-ab28-4f7c-88c5-9abf832a74b4" />
<img width="2380" height="1366" alt="image" src="https://github.com/user-attachments/assets/227eb13d-5987-4e99-9e83-9526c8d553a0" />

After
<img width="1148" height="2088" alt="image" src="https://github.com/user-attachments/assets/daf1e20e-a445-4b96-b087-43343e320af3" />
<img width="2413" height="2088" alt="image" src="https://github.com/user-attachments/assets/55417b38-92b4-46eb-9566-e2c26596abe6" />


Signed-off-by: Chris Brown ChrisIB"AT"outlook.com
