### PR TITLE
fix: fix Z offset panel error for generic_cartesian

### DIFF
--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -25,6 +25,7 @@ export default class ZoffsetMixin extends Vue {
 
     get stepper_name() {
         if (this.kinematics === 'delta') return 'stepper_a'
+        if (this.kinematics === 'generic_cartesian') return 'carriage carriage_z'
 
         return 'stepper_z'
     }
@@ -38,7 +39,7 @@ export default class ZoffsetMixin extends Vue {
     }
     get isEndstopProbe() {
         // remove spaces and search for probe:z_virtual_endstop
-        return this.endstop_pin.replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
+        return (this.endstop_pin ?? '').replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
     }
 
     get existZOffsetApplyProbe() {

--- a/tests/components/mixins/zoffset.spec.ts
+++ b/tests/components/mixins/zoffset.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import ZoffsetMixin from '@/components/mixins/zoffset'
+
+const createMixin = (printerState: Record<string, unknown>) => {
+    const mixin = new ZoffsetMixin()
+
+    Object.defineProperty(mixin, '$store', {
+        value: {
+            state: {
+                printer: printerState,
+            },
+        },
+    })
+
+    return mixin
+}
+
+describe('ZoffsetMixin', () => {
+    it('uses stepper_a for delta printers', () => {
+        const mixin = createMixin({
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'delta',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.stepper_name).toBe('stepper_a')
+    })
+
+    it('uses carriage carriage_z for generic_cartesian printers', () => {
+        const mixin = createMixin({
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'generic_cartesian',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.stepper_name).toBe('carriage carriage_z')
+    })
+
+    it('uses stepper_z for conventional cartesian-style printers', () => {
+        const mixin = createMixin({
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'corexy',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.stepper_name).toBe('stepper_z')
+    })
+
+    it('detects probe virtual endstops on generic_cartesian Z carriages', () => {
+        const mixin = createMixin({
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'generic_cartesian',
+                    },
+                    'carriage carriage_z': {
+                        endstop_pin: 'probe:z_virtual_endstop',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.endstop_pin).toBe('probe:z_virtual_endstop')
+        expect(mixin.isEndstopProbe).toBe(true)
+    })
+
+    it('does not throw when the Z endstop config is missing', () => {
+        const mixin = createMixin({
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'generic_cartesian',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.endstop_pin).toBeNull()
+        expect(mixin.isEndstopProbe).toBe(false)
+    })
+
+    it('shows the endstop save button for non-zero generic_cartesian gcode offsets', () => {
+        const mixin = createMixin({
+            gcode_move: {
+                homing_origin: [0, 0, -0.15],
+            },
+            gcode: {
+                commands: {
+                    Z_OFFSET_APPLY_ENDSTOP: {},
+                },
+            },
+            configfile: {
+                settings: {
+                    printer: {
+                        kinematics: 'generic_cartesian',
+                    },
+                    'carriage carriage_z': {
+                        endstop_pin: '^duet:PC5',
+                    },
+                },
+            },
+        })
+
+        expect(mixin.showSaveButton).toBe(true)
+        expect(mixin.autoSaveZOffsetOption).toBe('Z_OFFSET_APPLY_ENDSTOP')
+    })
+})


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description

This PR fixes the Z-offset panel for Klipper `generic_cartesian` kinematics.

The current Z-offset mixin assumes every non-delta printer exposes its Z endstop config through `configfile.settings.stepper_z`. For `generic_cartesian`, Klipper stores the Z endstop config in `configfile.settings["carriage carriage_z"]` instead.

When a live Z offset is non-zero, the panel evaluates the save-button state, reads a missing `stepper_z.endstop_pin`, and then crashes while calling `replaceAll()` on `null`.

This PR:
- uses `carriage carriage_z` as the Z config section for `generic_cartesian`
- keeps the existing `stepper_a` behavior for delta printers
- keeps the existing `stepper_z` behavior for conventional cartesian-style printers
- makes the endstop-probe check null-safe
- adds Vitest coverage for the affected paths

## Related Tickets & Documents

No existing issue.

## Mobile & Desktop Screenshots/Recordings

No visual layout changes.

Before this fix, a `generic_cartesian` printer with a non-zero live Z offset could trigger a console error similar to:

```text
TypeError: Cannot read properties of null (reading 'replaceAll')
```

After this fix, the Z-offset panel continues to show the live offset and the save button can use the endstop apply path.

## [optional] Are there any post-deployment tasks we need to perform?

No post-deployment tasks required.
