### PR TITLE
fix(zoffset): guard isEndstopProbe against missing endstop_pin

### DIFF
--- a/src/components/mixins/zoffset.ts
+++ b/src/components/mixins/zoffset.ts
@@ -38,7 +38,9 @@ export default class ZoffsetMixin extends Vue {
     }
     get isEndstopProbe() {
         // remove spaces and search for probe:z_virtual_endstop
-        return this.endstop_pin.replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
+        // guard against a missing endstop_pin (null) which some Klipper-compatible
+        // backends omit from stepper config; null.replaceAll would otherwise throw
+        return (this.endstop_pin ?? '').replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
     }
 
     get existZOffsetApplyProbe() {


### PR DESCRIPTION
## Description

`ZoffsetMixin.isEndstopProbe` calls `.replaceAll(' ', '')` on `endstop_pin`, but the `endstop_pin` getter returns `null` when the active stepper config has no `endstop_pin`:

```js
get endstop_pin() {
    return this.settings[this.stepper_name]?.endstop_pin?.trim() ?? null
}
get isEndstopProbe() {
    return this.endstop_pin.replaceAll(' ', '').search('probe:z_virtual_endstop') !== -1
}
```

`null.replaceAll` throws `TypeError: Cannot read properties of null (reading 'replaceAll')`. Since `showSaveButton` evaluates `isEndstopProbe` only after `z_gcode_offset !== 0`, the error is latent until a non-zero Z offset exists, at which point the throw causes Vue to drop the entire Z-offset control from the Toolhead panel.

This coalesces `endstop_pin` to an empty string in `isEndstopProbe`, so a missing pin is treated as "not a probe" rather than crashing the component.

Fixes #2508

## Related Tickets & Documents

- #2508

## Steps to test / reproduce

Run a Klipper-API-compatible backend whose `configfile.settings.stepper_z` has no `endstop_pin`, set a non-zero gcode Z offset (e.g. after probe-based leveling), and open the dashboard. Before this change the Z-offset control disappears and the console shows the TypeError; after it, the control renders normally.

Seen in the wild with Anycubic GoKlipper, which omits `endstop_pin` from `stepper_z`. Vanilla Klipper always populates it, which is why this hasn't surfaced before.