### PR TITLE
feat(spoolman): Write multi-tool spool info to moonraker database

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -206,18 +206,18 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
 
         // if tool is set, execute setMacroVariable, write to lane database and close, because it's not an active printing spool change
         if (this.tool) {
-            const filament = spool.filament;
+            const filament = spool.filament
             this.$socket.emit('server.database.post_item', {
-                "namespace": "lane_data",
-                "key": this.tool,
-                "value": {
-                    "lane": this.tool.substring(1),
-                    "color": filament.color_hex,
-                    "material": filament.material,
-                    "bed_temp": filament.settings_bed_temp,
-                    "nozzle_temp": filament.settings_extruder_temp,
-                }
-            });
+                namespace: 'lane_data',
+                key: this.tool,
+                value: {
+                    lane: this.tool.substring(1),
+                    color: filament.color_hex,
+                    material: filament.material,
+                    bed_temp: filament.settings_bed_temp,
+                    nozzle_temp: filament.settings_extruder_temp,
+                },
+            })
 
             this.setMacroVariable(spool)
             this.close()

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -204,8 +204,21 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
             return
         }
 
-        // if tool is set, execute setMacroVariable and close, because it's not an active printing spool change
+        // if tool is set, execute setMacroVariable, write to lane database and close, because it's not an active printing spool change
         if (this.tool) {
+            const filament = spool.filament;
+            this.$socket.emit('server.database.post_item', {
+                "namespace": "lane_data",
+                "key": this.tool,
+                "value": {
+                    "lane": this.tool.substring(1),
+                    "color": filament.color_hex,
+                    "material": filament.material,
+                    "bed_temp": filament.settings_bed_temp,
+                    "nozzle_temp": filament.settings_extruder_temp,
+                }
+            });
+
             this.setMacroVariable(spool)
             this.close()
             return

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -204,18 +204,23 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
             return
         }
 
-        // if tool is set, execute setMacroVariable, write to lane database and close, because it's not an active printing spool change
+        // if tool is set
+        // -> execute setMacroVariable
+        // -> write to lane database
+        // and close, because it's not an active printing spool change
         if (this.tool) {
-            const filament = spool.filament
+            // more infos can be found in the orcaslicer repo:
+            // https://github.com/OrcaSlicer/OrcaSlicer/blob/e700113b39f39b837175c680929538aa9655a9f9/src/slic3r/Utils/MoonrakerPrinterAgent.cpp#L727
             this.$socket.emit('server.database.post_item', {
                 namespace: 'lane_data',
                 key: this.tool,
                 value: {
+                    // must be a string for orcaslicer and this will be the filament slot number
                     lane: this.tool.substring(1),
-                    color: filament.color_hex,
-                    material: filament.material,
-                    bed_temp: filament.settings_bed_temp,
-                    nozzle_temp: filament.settings_extruder_temp,
+                    color: spool.filament.color_hex,
+                    material: spool.filament.material,
+                    bed_temp: spool.filament.settings_bed_temp,
+                    nozzle_temp: spool.filament.settings_extruder_temp,
                 },
             })
 


### PR DESCRIPTION
## Description

OrcaSlicer supports fetching selected filament(s) from the printer by querying the moonraker database.

HappyHare and AFC provide moonraker components which write filament information to the database.

This PR adds this functionality to the Spoolman spool selection panel for multi-tool printers. In addition to writing the spool's ID to `[gcode_macro T<tool>].spool_id`, it also places material, temperature and color information into the `lane_data` namespace of the moonraker database.

For a single toolhead, OrcaSlicer doesn't have the sync button.

For an actual AFC, the panel just calls the macro from the AFC plugin, which should already write to the database.

I don't know how the Mainsail + Spoolman workflow works for a combination of toolchanger and MMU, but if somebody is rocking that setup and could provide me with insights, I'd be happy to adapt this.

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

<img width="860" height="501" alt="2026-05-29_12-17" src="https://github.com/user-attachments/assets/17d2666b-5e51-423c-bb09-1a266e2e9cf4" />
<img width="782" height="198" alt="ezgif com-optimize" src="https://github.com/user-attachments/assets/c5aa503b-78bf-48a7-9e6e-4c2b2535e4e8" />

<!-- Visual changes require screenshots showing the before and after -->

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
