### PR TITLE
fix(afc): pull remaining weight from Spoolman when enabled

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -101,9 +101,10 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolRemainingWeight() {
-        if (this.afcExistsSpoolman && this.spool?.remaining_weight != null) {
+        if (this.afcExistsSpoolman && this.spool) {
             return Math.round(this.spool.remaining_weight)
         }
+
         return Math.round(this.lane.weight ?? 0)
     }
 

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -101,6 +101,9 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolRemainingWeight() {
+        if (this.afcExistsSpoolman && this.spool?.remaining_weight != null) {
+            return Math.round(this.spool.remaining_weight)
+        }
         return Math.round(this.lane.weight ?? 0)
     }
 


### PR DESCRIPTION
## Description

This PR fixes the AFC lane weight display to pull `remaining_weight`
from Spoolman when Spoolman is enabled, instead of always using the
`weight` value from the AFC lane state.

When Spoolman is configured, `spoolRemainingWeight` now reads
`spool.remaining_weight` from the Spoolman spool data. This keeps
the displayed weight and spool fill percentage in sync with
Spoolman's tracking (which accounts for filament consumed across all
prints), rather than relying solely on the value AFC reports for the
lane.

Falls back to `lane.weight` when Spoolman is not enabled or no spool
is linked to the lane.

## Related Tickets & Documents

- https://github.com/fluidd-core/fluidd/pull/1855

## Mobile & Desktop Screenshots/Recordings

No visual layout change — only the weight value source changes when
Spoolman is active.

Signed-off-by: paxx12 <paxx12dev@gmail.com>