### PR TITLE
feat(afc): support multiple tools per lane via `map` array

### DIFF
--- a/src/components/dialogs/AfcUnitLaneMappingToolDialog.vue
+++ b/src/components/dialogs/AfcUnitLaneMappingToolDialog.vue
@@ -58,7 +58,8 @@ export default class AfcUnitLaneMappingToolDialog extends Mixins(BaseMixin, AfcM
 
     get mappedTools(): string[] {
         const map = this.lane.map
-        if (map == null) return []
+        if (!map) return []
+
         return Array.isArray(map) ? map.map((t: string) => t.toLowerCase()) : [map.toLowerCase()]
     }
 

--- a/src/components/dialogs/AfcUnitLaneMappingToolDialog.vue
+++ b/src/components/dialogs/AfcUnitLaneMappingToolDialog.vue
@@ -21,7 +21,7 @@
                         <v-btn
                             v-for="tool in afcMapList"
                             :key="tool"
-                            :disabled="tool.toLowerCase() === mappedTool.toLowerCase()"
+                            :disabled="mappedTools.includes(tool.toLowerCase())"
                             color="primary"
                             class="ma-2"
                             @click="mapTool(tool)">
@@ -56,8 +56,10 @@ export default class AfcUnitLaneMappingToolDialog extends Mixins(BaseMixin, AfcM
         return this.getAfcLaneObject(this.name)
     }
 
-    get mappedTool() {
-        return this.lane.map ?? '--'
+    get mappedTools(): string[] {
+        const map = this.lane.map
+        if (map == null) return []
+        return Array.isArray(map) ? map.map((t: string) => t.toLowerCase()) : [map.toLowerCase()]
     }
 
     mapTool(newTool: string) {

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -69,16 +69,19 @@ export default class AfcMixin extends Vue {
 
     get afcMapList(): string[] {
         const lanes = this.afc.lanes ?? []
+        const seen = new Set<string>()
 
-        const mapList = []
         for (const laneName of lanes) {
             const lane = this.getAfcLaneObject(laneName)
-            if (lane === null) continue
+            if (lane?.map == null) continue
 
-            mapList.push(lane.map)
+            const tools = Array.isArray(lane.map) ? lane.map : [lane.map]
+            for (const tool of tools) {
+                seen.add(tool)
+            }
         }
 
-        return mapList.sort()
+        return [...seen].sort()
     }
 
     get afcExistsSpoolman() {

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -77,11 +77,11 @@ export default class AfcMixin extends Vue {
 
             const tools = Array.isArray(lane.map) ? lane.map : [lane.map]
             for (const tool of tools) {
-                seen.add(tool)
+                if (tool != null && tool !== '') seen.add(tool)
             }
         }
 
-        return [...seen].sort()
+        return [...seen].sort((a, b) => a.localeCompare(b))
     }
 
     get afcExistsSpoolman() {

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -73,11 +73,11 @@ export default class AfcMixin extends Vue {
 
         for (const laneName of lanes) {
             const lane = this.getAfcLaneObject(laneName)
-            if (lane?.map == null) continue
+            if (!lane?.map) continue
 
             const tools = Array.isArray(lane.map) ? lane.map : [lane.map]
             for (const tool of tools) {
-                if (tool != null && tool !== '') seen.add(tool)
+                if (tool) seen.add(tool)
             }
         }
 

--- a/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
@@ -2,7 +2,7 @@
     <v-row class="flex-grow-0">
         <v-col class="px-6 pt-6 pb-3 py-4">
             <v-btn dense small class="w-100 elevation-0" @click="showDialog = true">
-                {{ name }} > {{ mappedTool }}
+                {{ mappedTool }} > {{ name }}
             </v-btn>
             <afc-unit-lane-mapping-tool-dialog v-model="showDialog" :name="name" />
         </v-col>

--- a/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
@@ -24,7 +24,9 @@ export default class AfcPanelUnitLaneHeader extends Mixins(BaseMixin, AfcMixin) 
     }
 
     get mappedTool() {
-        return this.lane.map ?? '--'
+        const map = this.lane.map
+        if (map == null || map.length === 0) return 'NONE'
+        return Array.isArray(map) ? map.join(', ') : map
     }
 }
 </script>

--- a/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneHeader.vue
@@ -25,7 +25,8 @@ export default class AfcPanelUnitLaneHeader extends Mixins(BaseMixin, AfcMixin) 
 
     get mappedTool() {
         const map = this.lane.map
-        if (map == null || map.length === 0) return 'NONE'
+        if (!map || map.length === 0) return 'NONE'
+
         return Array.isArray(map) ? map.join(', ') : map
     }
 }


### PR DESCRIPTION
## Description

Broadens `AfcLaneState.map` from `string | null` to `string | string[] | null` so the backend can assign multiple tools to a single lane. This is backwards-compatible — existing firmware that sends a plain string continues to work without changes.

## Related Tickets & Documents

This is to provide support for mapping logical tools (provided by slicer) to physical topology (actual filament loaded): 

- https://github.com/AFCProject/AFC-Klipper-Add-On/issues/605
- https://github.com/fluidd-core/fluidd/pull/1856

## Mobile & Desktop Screenshots/Recordings

The behavior of mapping, whether the tool is remapped, or moved depends purely on how `AFC` executes the `SET_MAP`. This basically allows to visualise `map: string[]` values, and select from those values.

<img width="2152" height="1212" alt="Screen Recording 2026-05-30 at 17 35 26" src="https://github.com/user-attachments/assets/61260a33-64b9-4725-9267-53a79f246036" />
