### PR TITLE
feat: decouple websocket protocol from web UI origin

### DIFF
--- a/src/components/TheSelectPrinterDialog.vue
+++ b/src/components/TheSelectPrinterDialog.vue
@@ -72,13 +72,24 @@
                             </v-col>
                             <v-col class="col-4">
                                 <v-text-field
-                                    v-model="dialogAddPrinter.port"
+                                    v-model.number="dialogAddPrinter.port"
                                     :rules="[(v) => !!v || $t('SelectPrinterDialog.PortRequired')]"
                                     :label="$t('SelectPrinterDialog.Port')"
                                     hide-details="auto"
                                     required
                                     outlined
                                     dense />
+                            </v-col>
+                        </v-row>
+                        <v-row v-if="!isHttps" class="mt-0 pt-0">
+                            <v-col class="py-0">
+                                <v-checkbox
+                                    v-model="dialogAddPrinter.secure"
+                                    :label="$t('SelectPrinterDialog.SecureConnection')"
+                                    hide-details="auto"
+                                    class="mt-1"
+                                    dense
+                                    @change="onSecureChange('add')" />
                             </v-col>
                         </v-row>
                         <v-row v-if="showOptionalSettings">
@@ -136,13 +147,24 @@
                             </v-col>
                             <v-col class="col-4">
                                 <v-text-field
-                                    v-model="dialogEditPrinter.port"
+                                    v-model.number="dialogEditPrinter.port"
                                     :rules="[(v) => !!v || $t('SelectPrinterDialog.PortRequired')]"
                                     :label="$t('SelectPrinterDialog.Port')"
                                     required
                                     outlined
                                     dense
                                     hide-details="auto" />
+                            </v-col>
+                        </v-row>
+                        <v-row v-if="!isHttps" class="mt-0 pt-0">
+                            <v-col class="py-0">
+                                <v-checkbox
+                                    v-model="dialogEditPrinter.secure"
+                                    :label="$t('SelectPrinterDialog.SecureConnection')"
+                                    hide-details="auto"
+                                    class="mt-1"
+                                    dense
+                                    @change="onSecureChange('edit')" />
                             </v-col>
                         </v-row>
                         <v-row v-if="showOptionalSettings">
@@ -269,6 +291,7 @@ import BaseMixin from './mixins/base'
 import { FarmPrinterState } from '@/store/farm/printer/types'
 import Panel from '@/components/ui/Panel.vue'
 import { GuiRemoteprintersStatePrinter } from '@/store/gui/remoteprinters/types'
+import { defaultMoonrakerPort, defaultSecureMoonrakerPort } from '@/store/variables'
 import {
     mdiCancel,
     mdiCheckboxMarkedCircle,
@@ -289,9 +312,10 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     dialogAddPrinter = {
         bool: false,
         hostname: '',
-        port: 7125,
+        port: defaultMoonrakerPort,
         path: '/',
         name: '',
+        secure: false,
     }
     editPrinterValid = false
     dialogEditPrinter = {
@@ -317,6 +341,10 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     mdiShowOptional = mdiCog
     mdiHideOptional = mdiCogOff
 
+    get isHttps() {
+        return window.location.protocol === 'https:'
+    }
+
     get printers() {
         return this.$store.getters['gui/remoteprinters/getRemoteprinters'] ?? []
     }
@@ -330,7 +358,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     }
 
     get defaultMoonrakerPort() {
-        return this.protocol === 'wss' ? 7130 : 7125
+        return this.protocol === 'wss' ? defaultSecureMoonrakerPort : defaultMoonrakerPort
     }
 
     get hostname() {
@@ -405,6 +433,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     createPrinter() {
         this.dialogAddPrinter.hostname = ''
         this.dialogAddPrinter.port = this.defaultMoonrakerPort
+        this.dialogAddPrinter.secure = false
         this.dialogAddPrinter.bool = true
     }
 
@@ -414,6 +443,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
             port: this.dialogAddPrinter.port,
             path: this.dialogAddPrinter.path,
             name: this.dialogAddPrinter.name,
+            protocol: this.isHttps || this.dialogAddPrinter.secure ? 'wss' : 'ws',
         }
         this.$store.dispatch('gui/remoteprinters/store', { values })
 
@@ -421,6 +451,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
         this.dialogAddPrinter.bool = false
         this.dialogAddPrinter.path = '/'
         this.dialogAddPrinter.name = ''
+        this.dialogAddPrinter.secure = false
     }
 
     editPrinter(printer: GuiRemoteprintersStatePrinter) {
@@ -429,6 +460,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
         this.dialogEditPrinter.id = printer.id ?? ''
         this.dialogEditPrinter.path = printer.path ?? '/'
         this.dialogEditPrinter.name = printer.name ?? ''
+        this.dialogEditPrinter.secure = printer.protocol === 'wss'
         this.dialogEditPrinter.bool = true
 
         this.showOptionalSettings = printer.name ? printer.name.length > 0 : false
@@ -441,6 +473,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
             path: this.dialogEditPrinter.path,
             id: this.dialogEditPrinter.id,
             name: this.dialogEditPrinter.name,
+            protocol: this.isHttps || this.dialogEditPrinter.secure ? 'wss' : 'ws',
         }
         this.$store.dispatch('gui/remoteprinters/update', {
             id: this.dialogEditPrinter.id,
@@ -455,15 +488,25 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
         this.dialogEditPrinter.bool = false
     }
 
+    onSecureChange(dialog: 'add' | 'edit') {
+        const d = dialog === 'add' ? this.dialogAddPrinter : this.dialogEditPrinter
+        if (d.secure && d.port === defaultMoonrakerPort) {
+            d.port = defaultSecureMoonrakerPort
+        } else if (!d.secure && d.port === defaultSecureMoonrakerPort) {
+            d.port = defaultMoonrakerPort
+        }
+    }
+
     connect(printer: FarmPrinterState) {
         this.$store.dispatch('socket/setData', {
             hostname: printer.socket.hostname,
             port: printer.socket.port,
             path: printer.socket.path,
+            protocol: printer.socket.protocol,
         })
         const normPath = printer.socket.path.replaceAll(/(^\/*)|(\/*$)/g, '')
         const url =
-            this.protocol +
+            printer.socket.protocol +
             '://' +
             printer.socket.hostname +
             ':' +

--- a/src/components/TheSelectPrinterDialog.vue
+++ b/src/components/TheSelectPrinterDialog.vue
@@ -359,7 +359,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     }
 
     get defaultMoonrakerPort() {
-        return this.protocol === 'wss' ? defaultSecureMoonrakerPort : defaultMoonrakerPort
+        return this.isHttps ? defaultSecureMoonrakerPort : defaultMoonrakerPort
     }
 
     get hostname() {
@@ -434,7 +434,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
     createPrinter() {
         this.dialogAddPrinter.hostname = ''
         this.dialogAddPrinter.port = this.defaultMoonrakerPort
-        this.dialogAddPrinter.secure = false
+        this.dialogAddPrinter.secure = this.isHttps
         this.dialogAddPrinter.bool = true
     }
 
@@ -461,20 +461,27 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
         this.dialogEditPrinter.id = printer.id ?? ''
         this.dialogEditPrinter.path = printer.path ?? '/'
         this.dialogEditPrinter.name = printer.name ?? ''
-        this.dialogEditPrinter.secure = printer.protocol === 'wss'
+        this.dialogEditPrinter.secure = this.isHttps || printer.protocol === 'wss'
         this.dialogEditPrinter.bool = true
 
         this.showOptionalSettings = printer.name ? printer.name.length > 0 : false
     }
 
     updatePrinter() {
+        const isSecure = this.isHttps || this.dialogEditPrinter.secure
+        
+        let port = this.dialogEditPrinter.port
+        if (this.isHttps && port === defaultMoonrakerPort) {
+            port = defaultSecureMoonrakerPort
+        }
+
         const values = {
             hostname: this.dialogEditPrinter.hostname,
-            port: this.dialogEditPrinter.port,
+            port: port,
             path: this.dialogEditPrinter.path,
             id: this.dialogEditPrinter.id,
             name: this.dialogEditPrinter.name,
-            protocol: this.isHttps || this.dialogEditPrinter.secure ? 'wss' : 'ws',
+            protocol: isSecure ? 'wss' : 'ws',
         }
         this.$store.dispatch('gui/remoteprinters/update', {
             id: this.dialogEditPrinter.id,

--- a/src/components/TheSelectPrinterDialog.vue
+++ b/src/components/TheSelectPrinterDialog.vue
@@ -325,6 +325,7 @@ export default class TheSelectPrinterDialog extends Mixins(BaseMixin) {
         port: 0,
         path: '/',
         name: '',
+        secure: false,
     }
     showOptionalSettings = false
 

--- a/src/components/mixins/webcam.ts
+++ b/src/components/mixins/webcam.ts
@@ -1,4 +1,5 @@
 import Component from 'vue-class-component'
+import { defaultMoonrakerPort, defaultSecureMoonrakerPort } from '@/store/variables'
 import {
     mdiAlbum,
     mdiCampfire,
@@ -25,8 +26,8 @@ export default class WebcamMixin extends Mixins(BaseMixin) {
 
         if (baseUrl.startsWith('/webcam')) {
             const ports = [80]
-            ports.push(this.$store.state.server.config?.config?.server?.port ?? 7125)
-            ports.push(this.$store.state.server.config?.config?.server?.ssl_port ?? 7130)
+            ports.push(this.$store.state.server.config?.config?.server?.port ?? defaultMoonrakerPort)
+            ports.push(this.$store.state.server.config?.config?.server?.ssl_port ?? defaultSecureMoonrakerPort)
 
             if (!ports.includes(this.hostPort)) url.port = this.hostPort.toString()
         }

--- a/src/components/settings/SettingsRemotePrintersTab.vue
+++ b/src/components/settings/SettingsRemotePrintersTab.vue
@@ -59,12 +59,21 @@
                 <v-divider class="my-2" />
                 <settings-row :title="$t('Settings.RemotePrintersTab.Port')">
                     <v-text-field
-                        v-model="form.port"
+                        v-model.number="form.port"
                         :rules="[(v) => !!v || 'Port is required']"
                         hide-details="auto"
                         required
                         dense
                         outlined />
+                    <template v-if="protocol === 'ws'">
+                        <v-checkbox
+                            v-model="form.secure"
+                            :label="$t('SelectPrinterDialog.SecureConnection')"
+                            hide-details="auto"
+                            class="mt-1"
+                            dense
+                            @change="onSecureChange" />
+                    </template>
                 </settings-row>
                 <v-divider class="my-2" />
                 <settings-row :title="$t('Settings.RemotePrintersTab.Path')">
@@ -102,6 +111,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '../mixins/base'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import { GuiRemoteprintersStatePrinter } from '@/store/gui/remoteprinters/types'
+import { defaultMoonrakerPort, defaultSecureMoonrakerPort } from '@/store/variables'
 import { mdiCancel, mdiCheckboxMarkedCircle, mdiDelete, mdiPencil, mdiAlertOutline } from '@mdi/js'
 
 interface printerForm {
@@ -112,6 +122,7 @@ interface printerForm {
     path: string | null
     id: string | null
     namespace: string | null
+    secure: boolean
 }
 
 @Component({
@@ -127,11 +138,12 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
     form: printerForm = {
         bool: false,
         hostname: '',
-        port: 7125,
+        port: defaultMoonrakerPort,
         path: '/',
         name: '',
         id: null,
         namespace: null,
+        secure: false,
     }
 
     get printers() {
@@ -143,7 +155,7 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
     }
 
     get protocol() {
-        return this.$store.state.socket.protocol ?? 'ws'
+        return document.location.protocol === 'https:' ? 'wss' : 'ws'
     }
 
     formatPrinterName(printer: GuiRemoteprintersStatePrinter) {
@@ -152,11 +164,12 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
 
     createPrinter() {
         this.form.hostname = ''
-        this.form.port = 7125
+        this.form.port = defaultMoonrakerPort
         this.form.path = '/'
         this.form.name = ''
         this.form.id = null
         this.form.namespace = null
+        this.form.secure = false
         this.form.bool = true
     }
 
@@ -166,14 +179,15 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
             port: this.form.port,
             name: this.form.name,
             path: this.form.path,
+            protocol: this.protocol === 'wss' || this.form.secure ? 'wss' : 'ws',
         }
 
         this.$store.dispatch('gui/remoteprinters/store', { values: printer })
 
-        this.form.hostname = ''
-        this.form.port = 7125
+        this.form.port = defaultMoonrakerPort
         this.form.name = ''
         this.form.id = null
+        this.form.secure = false
         this.form.bool = false
     }
 
@@ -183,6 +197,7 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
         this.form.port = printer.port
         this.form.path = printer.path ?? '/'
         this.form.name = printer.name ?? ''
+        this.form.secure = printer.protocol === 'wss'
         this.form.bool = true
     }
 
@@ -192,20 +207,30 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
             port: this.form.port,
             name: this.form.name,
             path: this.form.path,
+            protocol: this.protocol === 'wss' || this.form.secure ? 'wss' : 'ws',
         }
 
         this.$store.dispatch('gui/remoteprinters/update', { id: this.form.id, values })
 
         this.form.id = null
         this.form.hostname = ''
-        this.form.port = 7125
+        this.form.port = defaultMoonrakerPort
         this.form.path = '/'
         this.form.name = ''
+        this.form.secure = false
         this.form.bool = false
     }
 
     delPrinter(id: string) {
         this.$store.dispatch('gui/remoteprinters/delete', id)
+    }
+
+    onSecureChange() {
+        if (this.form.secure && this.form.port === defaultMoonrakerPort) {
+            this.form.port = defaultSecureMoonrakerPort
+        } else if (!this.form.secure && this.form.port === defaultSecureMoonrakerPort) {
+            this.form.port = defaultMoonrakerPort
+        }
     }
 }
 </script>

--- a/src/components/settings/SettingsRemotePrintersTab.vue
+++ b/src/components/settings/SettingsRemotePrintersTab.vue
@@ -158,18 +158,22 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
         return document.location.protocol === 'https:' ? 'wss' : 'ws'
     }
 
+    get defaultPort() {
+        return this.protocol === 'wss' ? defaultSecureMoonrakerPort : defaultMoonrakerPort
+    }
+
     formatPrinterName(printer: GuiRemoteprintersStatePrinter) {
         return printer.hostname + (printer.port !== 80 ? ':' + printer.port : '') + (printer.path ?? '')
     }
 
     createPrinter() {
         this.form.hostname = ''
-        this.form.port = defaultMoonrakerPort
+        this.form.port = this.defaultPort
         this.form.path = '/'
         this.form.name = ''
         this.form.id = null
         this.form.namespace = null
-        this.form.secure = false
+        this.form.secure = this.protocol === 'wss'
         this.form.bool = true
     }
 
@@ -184,10 +188,10 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
 
         this.$store.dispatch('gui/remoteprinters/store', { values: printer })
 
-        this.form.port = defaultMoonrakerPort
+        this.form.port = this.defaultPort
         this.form.name = ''
         this.form.id = null
-        this.form.secure = false
+        this.form.secure = this.protocol === 'wss'
         this.form.bool = false
     }
 
@@ -197,27 +201,34 @@ export default class SettingsRemotePrintersTab extends Mixins(BaseMixin) {
         this.form.port = printer.port
         this.form.path = printer.path ?? '/'
         this.form.name = printer.name ?? ''
-        this.form.secure = printer.protocol === 'wss'
+        this.form.secure = this.protocol === 'wss' || printer.protocol === 'wss'
         this.form.bool = true
     }
 
     updatePrinter() {
+        const isSecure = this.protocol === 'wss' || this.form.secure
+        
+        let port = this.form.port
+        if (this.protocol === 'wss' && port === defaultMoonrakerPort) {
+            port = defaultSecureMoonrakerPort
+        }
+
         const values = {
             hostname: this.form.hostname,
-            port: this.form.port,
+            port: port,
             name: this.form.name,
             path: this.form.path,
-            protocol: this.protocol === 'wss' || this.form.secure ? 'wss' : 'ws',
+            protocol: isSecure ? 'wss' : 'ws',
         }
 
         this.$store.dispatch('gui/remoteprinters/update', { id: this.form.id, values })
 
         this.form.id = null
         this.form.hostname = ''
-        this.form.port = defaultMoonrakerPort
+        this.form.port = this.defaultPort
         this.form.path = '/'
         this.form.name = ''
-        this.form.secure = false
+        this.form.secure = this.protocol === 'wss'
         this.form.bool = false
     }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1128,6 +1128,7 @@
         "Port": "Port",
         "PortRequired": "Port is required",
         "RememberToAdd": "Please remember to add '{cors}' in moonraker.conf within 'cors_domains'.",
+        "SecureConnection": "Secure connection (HTTPS)",
         "SelectPrinter": "Select Printer",
         "TryAgain": "try again",
         "UpdatePrinter": "Update Printer",

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -20,6 +20,7 @@ export const actions: ActionTree<RootState, RootState> = {
             hostname: printerSocket.hostname,
             port: printerSocket.port,
             path: printerSocket.path,
+            protocol: printerSocket.protocol,
         })
     },
 

--- a/src/store/farm/index.ts
+++ b/src/store/farm/index.ts
@@ -53,6 +53,7 @@ export const farm: Module<FarmState, RootState> = {
                 hostname: payload.values.hostname,
                 port: payload.values.port,
                 path: payload.values.path,
+                protocol: payload.values.protocol ?? (document.location.protocol === 'https:' ? 'wss' : 'ws'),
                 isConnecting: true,
             })
             dispatch(payload.id + '/reconnect')

--- a/src/store/farm/printer/index.ts
+++ b/src/store/farm/printer/index.ts
@@ -3,6 +3,7 @@ import { getDefaultState as getGuiDefaultState } from '@/store/gui/index'
 import { actions } from '@/store/farm/printer/actions'
 import { mutations } from '@/store/farm/printer/mutations'
 import { getters } from '@/store/farm/printer/getters'
+import { defaultMoonrakerPort } from '@/store/variables'
 import { Module } from 'vuex'
 import { RootState } from '@/store/types'
 
@@ -12,7 +13,7 @@ export const getDefaultState = (): FarmPrinterState => {
         socket: {
             instance: null,
             hostname: '',
-            port: 7125,
+            port: defaultMoonrakerPort,
             path: '',
             webPort: 80,
             protocol: document.location.protocol === 'https:' ? 'wss' : 'ws',

--- a/src/store/gui/remoteprinters/actions.ts
+++ b/src/store/gui/remoteprinters/actions.ts
@@ -3,6 +3,7 @@ import { RootState } from '@/store/types'
 import { v4 as uuidv4 } from 'uuid'
 import Vue from 'vue'
 import { GuiRemoteprintersState, GuiRemoteprintersStatePrinter } from '@/store/gui/remoteprinters/types'
+import { defaultMoonrakerPort } from '@/store/variables'
 
 export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
     reset({ commit, dispatch, state }) {
@@ -38,8 +39,9 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
                 {
                     id: printerId,
                     hostname: printer.hostname ?? '',
-                    port: printer.port ?? 7125,
+                    port: printer.port ?? defaultMoonrakerPort,
                     path: printer.path ?? '',
+                    protocol: printer.protocol ?? (document.location.protocol === 'https:' ? 'wss' : 'ws'),
                     settings: printer.settings ?? {},
                 },
                 { root: true }
@@ -57,6 +59,7 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
                     port: state.printers[id].port,
                     name: state.printers[id].name,
                     path: state.printers[id].path,
+                    protocol: state.printers[id].protocol,
                     settings: state.printers[id].settings,
                 })
             })
@@ -67,6 +70,7 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
                 hostname: state.printers[id].hostname,
                 port: state.printers[id].port,
                 path: state.printers[id].path,
+                protocol: state.printers[id].protocol ?? (document.location.protocol === 'https:' ? 'wss' : 'ws'),
                 settings: state.printers[id].settings ?? {},
             }
 
@@ -87,9 +91,10 @@ export const actions: ActionTree<GuiRemoteprintersState, RootState> = {
             {
                 id,
                 hostname: payload.values.hostname ?? '',
-                port: payload.values.port ?? 7125,
+                port: payload.values.port ?? defaultMoonrakerPort,
                 path: payload.values.path ?? '',
                 name: payload.values.name,
+                protocol: payload.values.protocol ?? (document.location.protocol === 'https:' ? 'wss' : 'ws'),
             },
             { root: true }
         )

--- a/src/store/gui/remoteprinters/types.ts
+++ b/src/store/gui/remoteprinters/types.ts
@@ -12,6 +12,7 @@ export interface GuiRemoteprintersStatePrinter {
     port: number
     path?: string | null
     name?: string | null
+    protocol?: string | null
     socket?: FarmPrinterStateSocket
     settings?: {
         [key: string]: unknown

--- a/src/store/gui/remoteprinters/types.ts
+++ b/src/store/gui/remoteprinters/types.ts
@@ -12,7 +12,7 @@ export interface GuiRemoteprintersStatePrinter {
     port: number
     path?: string | null
     name?: string | null
-    protocol?: string | null
+    protocol?: 'ws' | 'wss' | null
     socket?: FarmPrinterStateSocket
     settings?: {
         [key: string]: unknown

--- a/src/store/socket/getters.ts
+++ b/src/store/socket/getters.ts
@@ -10,7 +10,9 @@ export const getters: GetterTree<SocketState, RootState> = {
         // remove last / in path
         if (path.endsWith('/')) path = path.slice(0, -1)
 
-        return `//${state.hostname}${port}${path}`
+        const protocol = state.protocol === 'wss' ? 'https:' : 'http:'
+
+        return `${protocol}//${state.hostname}${port}${path}`
     },
 
     getHostUrl: (state) => {
@@ -19,7 +21,13 @@ export const getters: GetterTree<SocketState, RootState> = {
         return `${protocol}://${state.hostname}/`
     },
 
-    getWebsocketUrl: (state, getters) => {
-        return state.protocol + ':' + getters['getUrl'] + '/websocket'
+    getWebsocketUrl: (state) => {
+        const port = state.port !== 80 ? ':' + state.port : ''
+        let path = '/' + state.path.replace(/^\/|\/$/g, '')
+
+        // remove last / in path
+        if (path.endsWith('/')) path = path.slice(0, -1)
+
+        return `${state.protocol}://${state.hostname}${port}${path}/websocket`
     },
 }

--- a/src/store/socket/getters.ts
+++ b/src/store/socket/getters.ts
@@ -22,7 +22,8 @@ export const getters: GetterTree<SocketState, RootState> = {
     },
 
     getWebsocketUrl: (state) => {
-        const port = state.port !== 80 ? ':' + state.port : ''
+        const defaultPort = state.protocol === 'wss' ? 443 : 80
+        const port = state.port !== defaultPort ? ':' + state.port : ''
         let path = '/' + state.path.replace(/^\/|\/$/g, '')
 
         // remove last / in path

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -37,7 +37,7 @@ export interface ConfigJsonInstance {
     hostname: string
     port?: number
     path?: string
-    protocol?: string
+    protocol?: 'ws' | 'wss'
 }
 
 export interface Theme {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -37,6 +37,7 @@ export interface ConfigJsonInstance {
     hostname: string
     port?: number
     path?: string
+    protocol?: string
 }
 
 export interface Theme {

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -10,6 +10,9 @@ export const minKlipperVersion = 'v0.11.0-257'
 export const minMoonrakerVersion = 'v0.8.0-306'
 export const minBrowserVersions = [{ name: 'safari', version: '16.5.2' }]
 
+export const defaultMoonrakerPort = 7125
+export const defaultSecureMoonrakerPort = 7130
+
 export const colorArray = ['#F44336', '#8e379d', '#03DAC5', '#3F51B5', '#ffde03', '#009688', '#E91E63']
 
 export const colorHeaterBed = '#2196F3'


### PR DESCRIPTION
## Description

This PR decouples Mainsail's WebSocket protocol (`ws://` vs `wss://`) from the browser's `window.location.protocol`. 

Previously, Mainsail forced the connection protocol to match the web interface's hosting environment. This prevented users running Mainsail locally over plain HTTP from successfully connecting to remote printers that enforce secure (`wss`) connections.

**Key Changes:**
* **Explicit Protocol Construction:** Rewrote the `getUrl` and `getWebsocketUrl` getters in `src/store/socket/getters.ts`. `getUrl` no longer generates protocol-relative URLs (`//hostname...`), which previously caused API fetch requests to blindly inherit the UI's HTTP protocol. It now explicitly respects the printer's configured protocol flag.
* **Remote Printer UI:** Added a "Secure Connection" checkbox to the "Add/Edit Printer" dialogs (`TheSelectPrinterDialog.vue` and `SettingsRemotePrintersTab.vue`). 
* **Mixed Content Fallbacks:** The secure connection flag defaults to off when Mainsail is hosted on HTTP. If the user loads Mainsail over HTTPS, the checkbox is intentionally hidden and `wss` is forced, protecting the app from violating browser Mixed Content Policies.
* **State Propagation:** Ensures the custom `protocol` flag is appropriately persisted to local storage and hydrated correctly when editing existing printers.

*(Disclaimer: This feature was "vibe coded" with the assistance of an AI agent, but has been tested manually against a remote Moonraker instance requiring auth/WSS. Please scrutinize during code review!)*

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots showing the before and after -->
<img width="1278" height="882" alt="Screenshot from 2026-06-04 19-54-11" src="https://github.com/user-attachments/assets/7f2c8514-4d82-4cce-84e2-abbbd47e2f06" />

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
None.
