### PR TITLE
feat: add SHT4X to additional sensors list

### DIFF
--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -29,6 +29,7 @@ export const additionalSensors = [
     'htu21d',
     'sgp40',
     'sht3x',
+    'sht4x',
     'temperature_combined',
 ]
 


### PR DESCRIPTION
## Description

Adds `sht4x` to the `additionalSensors` list so Mainsail recognizes SHT4X-family sensors (SHT40 / SHT41 / SHT45) and displays their **humidity** value alongside temperature, exactly as it already does for `sht3x`.

The SHT4X driver (registered as `sensor_type: SHT4X`) exposes `temperature` and `humidity` in its status, identical in shape to the existing `sht3x` driver. Without this entry, the temperature is shown but the humidity value is silently dropped by the UI.

Klipper-side driver support is in progress here: Klipper3d/klipper#7009.

## Type
- [x] feature (one-line addition to the supported additional-sensor list)

## Testing
Verified on a Klipper host running a SHT40 on software I2C: `printer/objects/query?sht4x chamber` returns `temperature` + `humidity`; after this change the humidity is rendered in the temperature panel.