### PR TITLE
feat: service worker navigation scoping and auth proxy redirect detection

### DIFF
--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -16,6 +16,14 @@ export class WebSocketClient {
     store: Store<RootState> | null = null
     waits: Wait[] = []
     heartbeatTimer: number | null = null
+    /** Pending reconnect timer handle; cleared on each fresh connect() call. */
+    private reconnectTimer: number | null = null
+    /**
+     * AbortController for the in-flight probe fetch; also doubles as the
+     * "probe already launched" flag (null = not yet probed this sequence).
+     * Aborted and nulled on fresh connect(); nulled on successful open.
+     */
+    private probeController: AbortController | null = null
 
     constructor(options: WebSocketPluginOptions) {
         this.url = options.url
@@ -91,7 +99,26 @@ export class WebSocketClient {
         this.removeWaitById(wait.id)
     }
 
-    async connect() {
+    /**
+     * Open (or re-open) the WebSocket connection.
+     *
+     * @param reconnecting - Pass `true` only when called from the internal
+     *   reconnect timer. When `false` (the default), counters are reset so
+     *   that manual "Try Again" attempts start a fresh sequence.
+     */
+    async connect(reconnecting = false) {
+        if (!reconnecting) {
+            // Fresh connection attempt: cancel any in-flight probe and
+            // pending reconnect timer from the previous sequence.
+            this.probeController?.abort()
+            this.probeController = null
+            this.reconnects = 0
+            if (this.reconnectTimer !== null) {
+                clearTimeout(this.reconnectTimer)
+                this.reconnectTimer = null
+            }
+        }
+
         this.store?.dispatch('socket/setData', {
             isConnecting: true,
         })
@@ -101,18 +128,36 @@ export class WebSocketClient {
 
         this.instance.onopen = () => {
             this.reconnects = 0
+            this.probeController?.abort()
+            this.probeController = null
             this.store?.dispatch('socket/onOpen', event)
         }
 
         this.instance.onclose = (e) => {
-            if (e.wasClean || this.reconnects >= this.maxReconnects) {
+            // Clean close (intentional disconnect) — no probing needed.
+            if (e.wasClean) {
+                this.store?.dispatch('socket/onClose', e)
+                return
+            }
+
+            // On the first unclean failure, fire the HTTP probe in parallel
+            // with the reconnect loop. This lets us distinguish:
+            //   • Permanent failure (auth proxy redirect) → navigate immediately.
+            //   • Temporary failure (server down/starting) → probe throws or
+            //     returns non-redirected; reconnect loop continues normally.
+            if (this.probeController === null) {
+                this.probeAndRedirect()
+            }
+
+            if (this.reconnects >= this.maxReconnects) {
                 this.store?.dispatch('socket/onClose', e)
                 return
             }
 
             this.reconnects++
-            setTimeout(() => {
-                this.connect()
+            this.reconnectTimer = window.setTimeout(() => {
+                this.reconnectTimer = null
+                this.connect(true)
             }, this.reconnectInterval)
         }
 
@@ -141,6 +186,50 @@ export class WebSocketClient {
 
     close(): void {
         this.instance?.close()
+    }
+
+    /**
+     * Converts the WebSocket URL to its HTTP(S) equivalent and fetches
+     * /server/info. If the response was redirected (e.g. by an auth proxy),
+     * the whole page is navigated to the redirect target so the user can
+     * authenticate and return to Mainsail.
+     *
+     * Stores an AbortController so a subsequent fresh connect() can cancel
+     * the fetch before it resolves.
+     */
+    private async probeAndRedirect(): Promise<void> {
+        this.probeController = new AbortController()
+        const probeUrl = this.url
+            .replace(/^wss:/, 'https:')
+            .replace(/^ws:/, 'http:')
+            .replace(/\/websocket$/, '/server/info')
+
+        try {
+            const response = await fetch(probeUrl, { method: 'GET', redirect: 'follow', signal: this.probeController.signal })
+            if (response.redirected) {
+                // Auth proxies embed the original URL somewhere in their
+                // redirect URL (e.g. ?rd=, ?return=, ?next=). To handle this
+                // generically, we iterate through the query parameters and
+                // replace the one matching the probe URL (or its path) with
+                // the current page.
+                const authUrl = new URL(response.url)
+                const probeUrlObj = new URL(probeUrl)
+                for (const [key, value] of authUrl.searchParams.entries()) {
+                    if (value === probeUrl) {
+                        authUrl.searchParams.set(key, window.location.href)
+                        break
+                    } else if (value === probeUrlObj.pathname) {
+                        // If the proxy used a relative path, give it a relative
+                        // path back to avoid triggering open-redirect protections.
+                        authUrl.searchParams.set(key, window.location.pathname + window.location.search + window.location.hash)
+                        break
+                    }
+                }
+                window.location.href = authUrl.toString()
+            }
+        } catch {
+            // Network unreachable or aborted — no redirect to follow.
+        }
     }
 
     getWaitById(id: number): Wait | null {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,13 +75,26 @@ const PWAConfig: Partial<VitePWAOptions> = {
             },
             {
                 // Avoid caching auth redirects on HTML navigation requests.
-                urlPattern: ({ request, url }) => request.mode === 'navigate' && MAINSAIL_ROUTES.test(url.pathname),
+                urlPattern: new Function(
+                    '{ request, url }',
+                    `return request.mode === 'navigate' && ${MAINSAIL_ROUTES}.test(url.pathname)`
+                ) as any,
                 handler: 'NetworkFirst',
                 options: {
                     cacheName: 'mainsail-navigation-cache',
                     cacheableResponse: {
                         statuses: [200],
                     },
+                    plugins: [
+                        {
+                            cacheWillUpdate: async ({ response }) => {
+                                if (response && response.redirected) {
+                                    return null
+                                }
+                                return response
+                            },
+                        },
+                    ],
                 },
             },
         ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,14 @@ import buildReleaseInfo from './src/plugins/build-release_info'
 import { VitePWA, VitePWAOptions } from 'vite-plugin-pwa'
 import postcssNesting from 'postcss-nesting'
 
+/**
+ * Matches URL pathnames that belong to Mainsail's client-side router.
+ * Used by both navigateFallbackAllowlist and the navigation runtime cache
+ * so the service worker never intercepts paths owned by co-hosted apps
+ * (e.g. /spoolman, /authelia).
+ */
+const MAINSAIL_ROUTES = /^\/(allPrinters|cam|console|heightmap|files|viewer|history|timelapse|config|settings)(\/.*)?$|^\/$/
+
 const PWAConfig: Partial<VitePWAOptions> = {
     registerType: 'autoUpdate',
     includeAssets: ['fonts/**/*.woff2', 'img/**/*.svg', 'img/**/*.png'],
@@ -52,10 +60,7 @@ const PWAConfig: Partial<VitePWAOptions> = {
         globPatterns: ['**/*.{js,css,html,woff,woff2,png,svg}'],
         // Only handle Mainsail's own client-side routes; all other paths
         // (e.g. /spoolman, /authelia) must reach the real server.
-        navigateFallbackAllowlist: [
-            /^\/$/,
-            /^\/(allPrinters|cam|console|heightmap|files|viewer|history|timelapse|config|settings)(\/.*)?$/,
-        ],
+        navigateFallbackAllowlist: [MAINSAIL_ROUTES],
         navigateFallbackDenylist: [/^\/(access|api|printer|server|websocket)/, /^\/webcam[2-4]?/],
         runtimeCaching: [
             {
@@ -70,11 +75,10 @@ const PWAConfig: Partial<VitePWAOptions> = {
             },
             {
                 // Avoid caching auth redirects on HTML navigation requests.
-                urlPattern: ({ request }) => request.mode === 'navigate',
+                urlPattern: ({ request, url }) => request.mode === 'navigate' && MAINSAIL_ROUTES.test(url.pathname),
                 handler: 'NetworkFirst',
                 options: {
                     cacheName: 'mainsail-navigation-cache',
-                    // CRITICAL: This prevent redirects (301, 302) or auth failures from being cached
                     cacheableResponse: {
                         statuses: [200],
                     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,12 @@ const PWAConfig: Partial<VitePWAOptions> = {
     },
     workbox: {
         globPatterns: ['**/*.{js,css,html,woff,woff2,png,svg}'],
+        // Only handle Mainsail's own client-side routes; all other paths
+        // (e.g. /spoolman, /authelia) must reach the real server.
+        navigateFallbackAllowlist: [
+            /^\/$/,
+            /^\/(allPrinters|cam|console|heightmap|files|viewer|history|timelapse|config|settings)(\/.*)?$/,
+        ],
         navigateFallbackDenylist: [/^\/(access|api|printer|server|websocket)/, /^\/webcam[2-4]?/],
         runtimeCaching: [
             {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,18 @@ const PWAConfig: Partial<VitePWAOptions> = {
                     },
                 },
             },
+            {
+                // Avoid caching auth redirects on HTML navigation requests.
+                urlPattern: ({ request }) => request.mode === 'navigate',
+                handler: 'NetworkFirst',
+                options: {
+                    cacheName: 'mainsail-navigation-cache',
+                    // CRITICAL: This prevent redirects (301, 302) or auth failures from being cached
+                    cacheableResponse: {
+                        statuses: [200],
+                    },
+                },
+            },
         ],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
     },


### PR DESCRIPTION
## Description

This PR fixes two issues that arise when Mainsail is deployed behind an authentication proxy (e.g. Authelia) alongside other apps on the same subdomain.

### Service worker navigation scope (`vite.config.ts`)

The Workbox-generated service worker previously intercepted **all** navigation requests and served Mainsail's `index.html` for every path not in the denylist. This broke co-hosted apps (e.g. Spoolman at `/spoolman`, Authelia at `/authelia`).

- Added a `navigateFallbackAllowlist` so the SW only handles paths that Mainsail actually owns (`/`, `/allPrinters`, `/cam`, `/console`, `/heightmap`, `/files`, `/viewer`, `/history`, `/timelapse`, `/config`, `/settings`). Any other path now falls through to the real server.
- The existing denylist for Moonraker backend paths is retained as a belt-and-suspenders measure.
- Added a `NetworkFirst` runtime caching rule for navigation requests to prevent auth redirects (301/302) from being cached by the service worker.

### Auth proxy redirect detection on WebSocket failure (`webSocketClient.ts`)

When an auth proxy intercepts a WebSocket upgrade request, it returns an HTTP redirect. The browser's WebSocket API cannot follow redirects — it sees a non-101 response and fires `onerror`/`onclose` with `wasClean=false` (code 1006), with no HTTP status or redirect URL exposed to JavaScript. Mainsail previously treated this identically to a temporary network failure and would loop through all reconnect attempts before showing a generic "Cannot connect" dialog.

**Probe mechanism:** On the first unclean WebSocket close, an HTTP probe is launched in parallel with the reconnect loop:

- `fetch(probeUrl, { redirect: 'follow' })` where `probeUrl` is the WebSocket URL rewritten to `https://.../server/info`
- If `response.redirected === true`, the user is navigated to the auth portal with the return URL rewritten to point back to Mainsail
- If the fetch throws or returns without a redirect, the reconnect loop continues normally

**Cancellation:** `probeController` (`AbortController | null`) governs the probe lifecycle — aborted on fresh `connect()` calls and successful opens to prevent stale probes from navigating the user away after recovery.

**Bug fix:** Also fixes a pre-existing bug where `reconnects` was never reset when `connect()` was called manually ("Try Again"), so a second manual attempt after exhausting all retries would immediately give up without retrying.

## Related Tickets & Documents

_No related issues yet._

## Mobile & Desktop Screenshots/Recordings

_No visual changes — this PR only affects service worker configuration and WebSocket connection logic._

## [optional] Are there any post-deployment tasks we need to perform?

Users behind auth proxies should clear their browser's service worker cache after updating to ensure the old SW (which cached all navigation routes) is replaced. This can be done via the browser DevTools (Application → Service Workers → Unregister) or will happen automatically on the next SW update cycle.