### PR TITLE
feat(afc): enhance Spoolman lane details in AFC panel

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -13,9 +13,23 @@
                         </span>
                     </template>
                     <span>
-                        #{{ spoolId }} | {{ spoolVendor }}
+                        <strong>ID #{{ spoolId }}</strong>
                         <br />
+                        <template v-if="spoolFilamentVendor">{{ spoolFilamentVendor }} —</template>
                         {{ spoolFilamentName }}
+                        <template v-if="spoolMaterial">
+                            <br />
+                            {{ spoolMaterial }}
+                            <template v-if="spoolExtruderTemp != null">| {{ spoolExtruderTemp }}°C</template>
+                            <template v-if="spoolBedTemp != null">| {{ spoolBedTemp }}°C</template>
+                        </template>
+                        <template v-if="spoolRemainingWeight != null">
+                            <br />
+                            {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(spoolRemainingWeight) }) }}
+                            <template v-if="spoolUsedWeight != null">
+                                ({{ $t('Panels.AfcPanel.WeightUsed', { weight: Math.round(spoolUsedWeight) }) }})
+                            </template>
+                        </template>
                     </span>
                 </v-tooltip>
                 <spoolman-change-spool-dialog v-if="afcExistsSpoolman" v-model="showSpoolmanDialog" :afc-lane="name" />
@@ -27,8 +41,11 @@
                     <template v-else>{{ runoutLane }}</template>
                 </v-btn>
                 <afc-unit-lane-infinite-dialog v-model="showInfintiyDialog" :name="name" />
-                <span class="font-weight-bold">{{ spoolMaterial }}</span>
-                <span class="text--disabled">{{ spoolRemainingWeightOutput }}</span>
+                <span class="font-weight-bold">{{ spoolMaterial || '--' }}</span>
+                <span class="text--disabled">
+                    <template v-if="spoolRemainingWeight != null">{{ Math.round(spoolRemainingWeight) }} g</template>
+                    <template v-else>--</template>
+                </span>
                 <v-tooltip v-if="hasTd" top>
                     <template #activator="{ on, attr }">
                         <span class="d-flex align-center justify-center text--disabled" v-bind="attr" v-on="on">
@@ -42,7 +59,15 @@
         <v-row v-if="afcShowFilamentName" class="mb-0 mt-n3">
             <v-col class="px-6 pt-1">
                 <div class="position-relative pb-4">
-                    <span class="position-absolute text-truncate text-truncate-element text-center">
+                    <a
+                        v-if="spoolUrl"
+                        :href="spoolUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="position-absolute text-truncate text-truncate-element text-center text-decoration-none filament-link">
+                        {{ spoolFilamentName }}
+                    </a>
+                    <span v-else class="position-absolute text-truncate text-truncate-element text-center">
                         {{ spoolFilamentName }}
                     </span>
                 </div>
@@ -100,38 +125,49 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
         return this.lane.color || '#000000'
     }
 
-    get spoolRemainingWeight() {
-        if (this.afcExistsSpoolman && this.spool) {
-            return Math.round(this.spool.remaining_weight)
-        }
-
-        return Math.round(this.lane.weight ?? 0)
+    get spoolRemainingWeight(): number | undefined {
+        return this.spool?.remaining_weight ?? this.lane.weight ?? undefined
     }
 
-    get spoolRemainingWeightOutput() {
-        return `${this.spoolRemainingWeight} g`
-    }
-
-    get spoolFullWeight() {
-        return this.spool?.filament?.weight ?? 1000
+    get spoolFullWeight(): number | undefined {
+        return this.spool?.initial_weight ?? this.lane.initial_weight ?? undefined
     }
 
     get spoolPercent() {
+        if (this.spoolRemainingWeight == null || this.spoolFullWeight == null) return 100
         if (this.spoolFullWeight === 0) return 100
 
         return Math.round((this.spoolRemainingWeight / this.spoolFullWeight) * 100)
     }
 
-    get spoolMaterial() {
-        return this.lane.material || '--'
+    get spoolMaterial(): string {
+        return this.spool?.filament?.material ?? this.lane.material ?? ''
     }
 
-    get spoolVendor() {
-        return this.spool?.filament?.vendor?.name ?? 'Unknown'
+    get spoolFilamentVendor(): string | undefined {
+        return this.spool?.filament?.vendor?.name
     }
 
-    get spoolFilamentName() {
-        return this.spool?.filament?.name ?? 'Unknown'
+    get spoolFilamentName(): string | undefined {
+        return this.spool?.filament?.name || this.lane.filament_name || undefined
+    }
+
+    get spoolUrl(): string | undefined {
+        if (!this.spoolManagerUrl || !this.spoolId) return undefined
+
+        return `${this.spoolManagerUrl.replace(/\/$/, '')}/spool/show/${this.spoolId}`
+    }
+
+    get spoolExtruderTemp(): number | undefined {
+        return this.spool?.filament?.settings_extruder_temp
+    }
+
+    get spoolBedTemp(): number | undefined {
+        return this.spool?.filament?.settings_bed_temp
+    }
+
+    get spoolUsedWeight(): number | undefined {
+        return this.spool?.used_weight
     }
 
     get showTd1Color(): boolean {
@@ -169,5 +205,15 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
 .text-truncate-element {
     left: 0;
     right: 0;
+}
+
+.filament-link {
+    color: inherit !important;
+    cursor: pointer;
+}
+
+.filament-link:hover,
+.filament-link:focus {
+    text-decoration: underline !important;
 }
 </style>

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -13,23 +13,10 @@
                         </span>
                     </template>
                     <span>
-                        <strong>ID #{{ spoolId }}</strong>
-                        <br />
-                        <template v-if="spoolFilamentVendor">{{ spoolFilamentVendor }} —</template>
-                        {{ spoolFilamentName }}
-                        <template v-if="spoolMaterial">
-                            <br />
-                            {{ spoolMaterialOutput }}
-                            <template v-if="spoolExtruderTemp !== undefined">| {{ spoolExtruderTemp }}°C</template>
-                            <template v-if="spoolBedTemp !== undefined">| {{ spoolBedTemp }}°C</template>
-                        </template>
-                        <template v-if="spoolRemainingWeight !== undefined">
-                            <br />
-                            {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(spoolRemainingWeight) }) }}
-                            <template v-if="spoolUsedWeight !== undefined">
-                                ({{ $t('Panels.AfcPanel.WeightUsed', { weight: Math.round(spoolUsedWeight) }) }})
-                            </template>
-                        </template>
+                        <div class="font-weight-bold">{{ spoolFilamentHeadline }}</div>
+                        <div>{{ spoolFilamentName }}</div>
+                        <div v-if="spoolMaterial">{{ spoolMaterialDetails }}</div>
+                        <div v-if="spoolWeightsOutput !== undefined">{{ spoolWeightsOutput }}</div>
                     </span>
                 </v-tooltip>
                 <spoolman-change-spool-dialog v-if="afcExistsSpoolman" v-model="showSpoolmanDialog" :afc-lane="name" />
@@ -116,6 +103,13 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
         return spools.find((spool: ServerSpoolmanStateSpool) => spool.id === this.spoolId) || null
     }
 
+    get spoolFilamentHeadline(): string {
+        const array = [`#${this.spoolId}`]
+        if (this.spoolFilamentVendor) array.push(this.spoolFilamentVendor)
+
+        return array.join(' | ')
+    }
+
     get spoolColor() {
         if (this.hasTd && this.showTd1Color) return `#${this.tdColor}`
 
@@ -129,11 +123,29 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     get spoolRemainingWeightOutput(): string {
         if (this.spoolRemainingWeight === undefined) return '--'
 
-        return `${Math.round(this.spoolRemainingWeight)} g`
+        return `${Math.round(this.spoolRemainingWeight)}g`
     }
 
     get spoolFullWeight(): number | undefined {
         return this.spool?.initial_weight ?? this.lane.initial_weight ?? undefined
+    }
+
+    get spoolWeightsOutput(): string | undefined {
+        if (this.spoolRemainingWeight === undefined) return undefined
+
+        const array = [
+            this.$t('Panels.AfcPanel.WeightRemaining', {
+                weight: Math.round(this.spoolRemainingWeight ?? 0),
+            }).toString(),
+        ]
+
+        if (this.spoolUsedWeight !== undefined) {
+            array.push(
+                this.$t('Panels.AfcPanel.WeightUsed', { weight: Math.round(this.spoolUsedWeight ?? 0) }).toString()
+            )
+        }
+
+        return array.join(' | ')
     }
 
     get spoolPercent() {
@@ -151,12 +163,20 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
         return this.spoolMaterial || '--'
     }
 
+    get spoolMaterialDetails(): string {
+        const array = [this.spoolMaterialOutput]
+        if (this.spoolExtruderTemp !== undefined) array.push(`${this.spoolExtruderTemp}°C`)
+        if (this.spoolBedTemp !== undefined) array.push(`${this.spoolBedTemp}°C`)
+
+        return array.join(' | ')
+    }
+
     get spoolFilamentVendor(): string | undefined {
         return this.spool?.filament?.vendor?.name
     }
 
-    get spoolFilamentName(): string | undefined {
-        return this.spool?.filament?.name || this.lane.filament_name || undefined
+    get spoolFilamentName(): string {
+        return this.spool?.filament?.name || this.lane.filament_name || 'Unknown'
     }
 
     get spoolUrl(): string | undefined {

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -19,14 +19,14 @@
                         {{ spoolFilamentName }}
                         <template v-if="spoolMaterial">
                             <br />
-                            {{ spoolMaterial }}
-                            <template v-if="spoolExtruderTemp != null">| {{ spoolExtruderTemp }}°C</template>
-                            <template v-if="spoolBedTemp != null">| {{ spoolBedTemp }}°C</template>
+                            {{ spoolMaterialOutput }}
+                            <template v-if="spoolExtruderTemp !== undefined">| {{ spoolExtruderTemp }}°C</template>
+                            <template v-if="spoolBedTemp !== undefined">| {{ spoolBedTemp }}°C</template>
                         </template>
-                        <template v-if="spoolRemainingWeight != null">
+                        <template v-if="spoolRemainingWeight !== undefined">
                             <br />
                             {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(spoolRemainingWeight) }) }}
-                            <template v-if="spoolUsedWeight != null">
+                            <template v-if="spoolUsedWeight !== undefined">
                                 ({{ $t('Panels.AfcPanel.WeightUsed', { weight: Math.round(spoolUsedWeight) }) }})
                             </template>
                         </template>
@@ -41,11 +41,8 @@
                     <template v-else>{{ runoutLane }}</template>
                 </v-btn>
                 <afc-unit-lane-infinite-dialog v-model="showInfintiyDialog" :name="name" />
-                <span class="font-weight-bold">{{ spoolMaterial || '--' }}</span>
-                <span class="text--disabled">
-                    <template v-if="spoolRemainingWeight != null">{{ Math.round(spoolRemainingWeight) }} g</template>
-                    <template v-else>--</template>
-                </span>
+                <span class="font-weight-bold">{{ spoolMaterialOutput }}</span>
+                <span class="text--disabled">{{ spoolRemainingWeightOutput }}</span>
                 <v-tooltip v-if="hasTd" top>
                     <template #activator="{ on, attr }">
                         <span class="d-flex align-center justify-center text--disabled" v-bind="attr" v-on="on">
@@ -129,12 +126,18 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
         return this.spool?.remaining_weight ?? this.lane.weight ?? undefined
     }
 
+    get spoolRemainingWeightOutput(): string {
+        if (this.spoolRemainingWeight === undefined) return '--'
+
+        return `${Math.round(this.spoolRemainingWeight)} g`
+    }
+
     get spoolFullWeight(): number | undefined {
         return this.spool?.initial_weight ?? this.lane.initial_weight ?? undefined
     }
 
     get spoolPercent() {
-        if (this.spoolRemainingWeight == null || this.spoolFullWeight == null) return 100
+        if (this.spoolRemainingWeight === undefined || this.spoolFullWeight === undefined) return 100
         if (this.spoolFullWeight === 0) return 100
 
         return Math.round((this.spoolRemainingWeight / this.spoolFullWeight) * 100)
@@ -142,6 +145,10 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
 
     get spoolMaterial(): string {
         return this.spool?.filament?.material ?? this.lane.material ?? ''
+    }
+
+    get spoolMaterialOutput(): string {
+        return this.spoolMaterial || '--'
     }
 
     get spoolFilamentVendor(): string | undefined {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -677,7 +677,9 @@
             "Unloading": "Unloading",
             "UnloadLane": "Unload Lane",
             "Weight": "Weight",
-            "WeightSubtitle": "The weight of the filament in grams (without spool)."
+            "WeightRemaining": "{weight} g remaining",
+            "WeightSubtitle": "The weight of the filament in grams (without spool).",
+            "WeightUsed": "{weight} g used"
         },
         "ExtruderControlPanel": {
             "Allowed": "Allowed",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -677,9 +677,9 @@
             "Unloading": "Unloading",
             "UnloadLane": "Unload Lane",
             "Weight": "Weight",
-            "WeightRemaining": "{weight} g remaining",
+            "WeightRemaining": "{weight}g remaining",
             "WeightSubtitle": "The weight of the filament in grams (without spool).",
-            "WeightUsed": "{weight} g used"
+            "WeightUsed": "{weight}g used"
         },
         "ExtruderControlPanel": {
             "Allowed": "Allowed",


### PR DESCRIPTION
## Description

This PR enhances the Spoolman integration in the AFC panel lane widget:

- The spool tooltip now shows the spool ID, vendor and filament name, material with extruder/bed temperatures, and remaining/used weight from Spoolman.
- Spoolman data is preferred for remaining weight, initial weight, material and filament name, with a fallback to the AFC lane data when no Spoolman spool is assigned.
- When the filament name row is enabled, the name links to the spool page of the configured Spoolman instance.
- Material and weight show `--` when no data is available, and the spool fill percentage guards against missing weights.

This is the Mainsail port of fluidd-core/fluidd#1860.

## Related Tickets & Documents

- Counterpart in Fluidd: fluidd-core/fluidd#1860
- Includes and supersedes #2511 (the remaining-weight fix is folded into this change).

## Mobile & Desktop Screenshots/Recordings

The visual result matches the Fluidd counterpart, see screenshots in fluidd-core/fluidd#1860.

## [optional] Are there any post-deployment tasks we need to perform?

None.
