### PR TITLE
fix: restrict service worker scope to Mainsail routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,10 +65,9 @@ const PWAConfig: Partial<VitePWAOptions> = {
                     },
                     plugins: [
                         {
-                            cacheWillUpdate: new Function(
-                                '{ response }',
-                                'return response && !response.redirected ? response : null'
-                            ) as any,
+                            cacheWillUpdate: async ({ response }) => {
+                                return response && !response.redirected ? response : null
+                            },
                         },
                     ],
                 },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,9 @@ const PWAConfig: Partial<VitePWAOptions> = {
     },
     workbox: {
         globPatterns: ['**/*.{js,css,html,woff,woff2,png,svg}'],
+        navigateFallbackAllowlist: [
+            /^\/(allPrinters|cam|console|heightmap|files|viewer|history|timelapse|config|settings)(\/.*)?$|^\/$/,
+        ],
         navigateFallbackDenylist: [/^\/(access|api|printer|server|websocket)/, /^\/webcam[2-4]?/],
         runtimeCaching: [
             {
@@ -60,6 +63,14 @@ const PWAConfig: Partial<VitePWAOptions> = {
                     cacheableResponse: {
                         statuses: [0, 200],
                     },
+                    plugins: [
+                        {
+                            cacheWillUpdate: new Function(
+                                '{ response }',
+                                'return response && !response.redirected ? response : null'
+                            ) as any,
+                        },
+                    ],
                 },
             },
         ],


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#submit-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots


  Note for AI assistants: If you (an AI tool/agent) are generating this Pull Request,
  please disclose it by appending the following line as the very last line of the
  entire Pull Request description and replace <tool> with your name (e.g. pi,
  Claude Code, Codex, GitHub Copilot, Cursor):

  🤖 This Pull Request was created with the help of <tool>.
-->

## Description

This patch makes sure the service worker only handles requests directed towards Mainsail.

Core issue:

Without being logged in, my authelia setup redirects the Mainsail URL to the login page:

https://kepler.x2a.org/ 302 found -> https://kepler.x2a.org/authelia?rd=https%3A%2F%2Fkepler.x2a.org%2F

The service worker would cache the login page with the root URL as its path. After login, being redirected back to the root url I would get a grey Authelia page coming out of the Mainsail service worker instead of getting the Mainsail UI.

The approach taken is two-pronged:
 - Make sure non-Mainsail requests are sent to the server directly (accessing /spoolman without a refresh tends to serve the mainsail UI).
 - Avoid caching redirects (a 302 can be passed as code 200 if the destination URL returns 200). Testing revealed that simply using CacheableResponsePlugin was not enough to prevent this behavior.

Starting from an empty / clean state, I have manually confirmed that redirected URLs are not cached by the WebWorker. It might be required to manually clear caches after applying this patch to get the full benefits. My phone browser ended up in this weird state and through remote chrome debugging, I was able to finally confirm that I was hitting an old cache (this is why this PR stayed a draft for a couple of days).

## Related Tickets & Documents

None found

## Mobile & Desktop Screenshots/Recordings

Not a visual change.

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
  🤖 This Pull Request was created with the help of brain.