### PR TITLE
feat(maintenance): add datetime picker for start_time

### DIFF
--- a/src/components/dialogs/HistoryListPanelAddMaintenance.vue
+++ b/src/components/dialogs/HistoryListPanelAddMaintenance.vue
@@ -29,6 +29,17 @@
                 </v-row>
                 <v-row>
                     <v-col>
+                        <v-text-field
+                            v-model="selectedDateTime"
+                            type="datetime-local"
+                            :label="$t('History.StartTime')"
+                            outlined
+                            dense
+                            hide-details="auto" />
+                    </v-col>
+                </v-row>
+                <v-row>
+                    <v-col>
                         <settings-row :title="$t('History.Reminder')">
                             <v-select
                                 v-model="reminder"
@@ -130,6 +141,7 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
 
     name: string = ''
     note: string = ''
+    selectedDateTime: string = ''
     reminder: 'one-time' | 'repeat' | null = null
 
     reminderFilament: boolean = false
@@ -187,13 +199,17 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
     }
 
     save() {
-        const date = new Date()
+        let startTime = Math.floor(Date.now() / 1000)
+        if (this.selectedDateTime) {
+            const parsed = Date.parse(this.selectedDateTime)
+            if (Number.isFinite(parsed)) startTime = Math.floor(parsed / 1000)
+        }
         this.$store.dispatch('gui/maintenance/store', {
             entry: {
                 name: this.name,
                 note: this.note,
                 // divided by 1000 to get seconds, because history entries are also in seconds
-                start_time: date.getTime() / 1000,
+                start_time: startTime,
                 end_time: null,
                 start_filament: this.totalFilamentUsed,
                 end_filament: null,
@@ -227,6 +243,7 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
     resetValues() {
         this.name = ''
         this.note = ''
+        this.selectedDateTime = this.toDatetimeLocalString(Math.floor(Date.now() / 1000))
         this.reminder = null
         this.reminderFilament = false
         this.reminderFilamentValue = 0
@@ -234,6 +251,12 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
         this.reminderPrinttimeValue = 0
         this.reminderDate = false
         this.reminderDateValue = 0
+    }
+
+    toDatetimeLocalString(timestamp: number): string {
+        const d = new Date(timestamp * 1000)
+        const pad = (n: number) => String(n).padStart(2, '0')
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
     }
 
     @Watch('showDialog')

--- a/src/components/dialogs/HistoryListPanelEditMaintenance.vue
+++ b/src/components/dialogs/HistoryListPanelEditMaintenance.vue
@@ -29,6 +29,17 @@
                 </v-row>
                 <v-row>
                     <v-col>
+                        <v-text-field
+                            v-model="selectedDateTime"
+                            type="datetime-local"
+                            :label="$t('History.StartTime')"
+                            outlined
+                            dense
+                            hide-details="auto" />
+                    </v-col>
+                </v-row>
+                <v-row>
+                    <v-col>
                         <settings-row :title="$t('History.Reminder')">
                             <v-select
                                 v-model="reminder"
@@ -148,6 +159,7 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
 
     name: string = ''
     note: string = ''
+    selectedDateTime: string = ''
     reminder: 'one-time' | 'repeat' | null = null
 
     reminderFilament: boolean = false
@@ -203,6 +215,10 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
 
         item.name = this.name
         item.note = this.note
+        if (this.selectedDateTime) {
+            const parsed = Date.parse(this.selectedDateTime)
+            if (Number.isFinite(parsed)) item.start_time = Math.floor(parsed / 1000)
+        }
         item.reminder = {
             type: this.reminder,
             filament: {
@@ -230,6 +246,7 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
 
         this.name = this.item.name
         this.note = this.item.note
+        this.selectedDateTime = this.toDatetimeLocalString(this.item.start_time)
         this.reminder = this.item.reminder?.type ?? null
         this.reminderFilament = this.item.reminder?.filament.bool ?? false
         this.reminderFilamentValue = this.item.reminder?.filament.value ?? 0
@@ -237,6 +254,12 @@ export default class HistoryListPanelAddMaintenance extends Mixins(BaseMixin) {
         this.reminderPrinttimeValue = this.item.reminder?.printtime.value ?? 0
         this.reminderDate = this.item.reminder?.date.bool ?? false
         this.reminderDateValue = this.item.reminder?.date.value ?? 0
+    }
+
+    toDatetimeLocalString(timestamp: number): string {
+        const d = new Date(timestamp * 1000)
+        const pad = (n: number) => String(n).padStart(2, '0')
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
     }
 }
 </script>


### PR DESCRIPTION
## Description

Adds a datetime picker to the Add and Edit maintenance dialogs, allowing users to set a custom start_time instead of always using the current time.

## Changes

- **HistoryListPanelAddMaintenance.vue**: Add datetime-local input, selectedDateTime property, validated date parsing with Date.parse + Math.floor
- **HistoryListPanelEditMaintenance.vue**: Same datetime picker, pre-populated from existing entry's start_time