### PR TITLE
chore(vouch): implement contributor trust system

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,12 @@
 <!--
+  ⚠️ IMPORTANT: Pull requests from contributors who are not on the vouched list
+  (.github/VOUCHED.td) are automatically closed. See the Contributing Guidelines
+  for details:
+  https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#vouch
+  If your PR gets closed, a maintainer can vouch for you; afterward reopen it
+  or comment /recheck.
+
+
   For Work In Progress Pull Requests, please use the Draft PR feature,
   see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
 

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,18 @@
+# The list of vouched (or actively denounced) users for this repository.
+#
+# Only vouched users can open pull requests. A denounced user is explicitly
+# blocked. Bots and collaborators with write access are always allowed.
+# Issues remain open for everyone.
+#
+# Syntax:
+#  - One handle per line (without @). Sorted alphabetically.
+#  - Optionally specify platform: `platform:username` (e.g., `github:ragilo`).
+#  - To denounce a user, prefix with minus: `-username` or `-platform:username`.
+#  - Optionally, add details after a space following the handle.
+#
+# Maintainers can vouch via issue/PR comments: "vouch", "vouch @user",
+# or denounce via "denounce" / "denounce @user".
+moggieuk Maintainer from Happy Hare
+mspi92
+paxx12 Maintainer from Snapmaker community firmware
+ragilo

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -12,7 +12,14 @@
 #
 # Maintainers can vouch via issue/PR comments: "vouch", "vouch @user",
 # or denounce via "denounce" / "denounce @user".
+bigtreetech
+jimmyjon711 Maintainer from AFC
+jomik
+julianschill LED effects Maintainer
 moggieuk Maintainer from Happy Hare
 mspi92
 paxx12 Maintainer from Snapmaker community firmware
 ragilo
+rcloran
+samuel-0-0 Long-time Chinese (zh) localization contributor
+xtrack33

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -18,8 +18,10 @@ jomik
 julianschill LED effects Maintainer
 moggieuk Maintainer from Happy Hare
 mspi92
+pataar
 paxx12 Maintainer from Snapmaker community firmware
 ragilo
 rcloran
 samuel-0-0 Long-time Chinese (zh) localization contributor
+Sindarius
 xtrack33

--- a/.github/vouch-pr-unvouched.md
+++ b/.github/vouch-pr-unvouched.md
@@ -1,0 +1,10 @@
+Hi @{author}, thanks for your interest in contributing to Mainsail! 👋
+
+This pull request has been **automatically closed** because pull requests may only be opened by vouched contributors, and you are not yet on our [vouched list](https://github.com/{owner}/{repo}/blob/{default_branch}/.github/VOUCHED.td).
+
+This is **not** a rejection of your work. A maintainer can vouch for you and once that happens, simply reopen this PR or comment `/recheck`.
+
+Please see our contributing guidelines for more details:
+
+- 📖 [CONTRIBUTING.md](https://github.com/{owner}/{repo}/blob/{default_branch}/CONTRIBUTING.md#vouch)
+- 📖 [Contributing Documentation](https://docs.mainsail.xyz/development/contributing/#contributor-trust-vouch-system)

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,28 @@
+name: Vouch Check PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    # Run on PR open/reopen, or when a maintainer comments "/recheck" on a PR
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -21,12 +21,24 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/recheck'))
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout Repo for Vouch Templates
+        uses: actions/checkout@v6
 
-      - uses: mitchellh/vouch/action/check-pr@v1
+      - name: Execute Vouch Check PR Action
+        id: vouch
+        uses: mitchellh/vouch/action/check-pr@v1
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           auto-close: true
           template-file: .github/vouch-pr-unvouched.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label unvouched PR
+        if: steps.vouch.outputs.status == 'closed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          gh pr edit "$PR" --repo "$REPO" --add-label "unvouched"

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   check:
@@ -20,9 +21,12 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/recheck'))
     steps:
+      - uses: actions/checkout@v6
+
       - uses: mitchellh/vouch/action/check-pr@v1
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           auto-close: true
+          template-file: .github/vouch-pr-unvouched.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,27 @@
+name: Vouch Manage by Issue
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-issue@v1
+        with:
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -17,7 +17,7 @@ jobs:
   manage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: mitchellh/vouch/action/manage-by-issue@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,9 +89,22 @@ To protect the project from low-quality and automated spam contributions, Mainsa
 The list of vouched contributors is maintained in
 [`.github/VOUCHED.td`](https://github.com/mainsail-crew/mainsail/blob/develop/.github/VOUCHED.td).
 
-If your PR was closed because you are not yet vouched, this is **not** a rejection of your work. A maintainer can
-vouch for you, after which you can reopen the PR or comment `/recheck` to have it checked again. Becoming an active,
-trusted member of the community, for example through issues is the path to being vouched.
+#### How to Become a Trusted Contributor
+
+If your PR was closed because you are not yet vouched, this is **not** a rejection of your work, and it is not
+permanent. The vouch system simply asks new contributors to build a little trust with the project first. Here is how
+you can get vouched:
+
+- **Engage with the community.** Open well-described issues, help others reproduce or diagnose bugs, and join the
+  discussion on our [Discord server](https://discord.gg/mainsail). Issues are open to everyone and are a great first
+  step.
+- **Start small.** Smaller, focused, and well-documented pull requests are easier to review and help maintainers get
+  to know your work.
+- **Be responsive.** Reply to questions and review feedback on your issues and PRs.
+
+Once a maintainer vouches for you, you become a trusted contributor. You can then reopen your closed PR or comment
+`/recheck` to have it re-evaluated, and your future pull requests will no longer be closed automatically. If you
+believe you should already be vouched, feel free to reach out to a maintainer on Discord.
 
 ## <a name="financial"></a> Financial Contribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ make sure to read through our contribution guidelines:
 - [Submission Guidelines](#submit)
   - [Submit an Issue](#submit-issue)
   - [Submit a Pull Request](#submit-pr)
+  - [Contributor Trust (Vouch System)](#vouch)
 - [Financial Contributions](#financial)
 - [Credits](https://docs.mainsail.xyz/credits)
 
@@ -76,6 +77,21 @@ Before you work on a PR and submit it, please pay attention to the following gui
    - The sign-off certifies that you agree with the [developer certificate of origin](https://github.com/mainsail-crew/mainsail/blob/develop/.github/DEVELOPER_CERTIFICATE_OF_ORIGIN.md).
    - If you provide a translation, a sign-off is not necessarily required.
 8. When opening a pull request, keep `Allow edits and access to secrets by maintainers` **enabled**.
+
+### <a name="vouch"></a> Contributor Trust (Vouch System)
+
+To protect the project from low-quality and automated spam contributions, Mainsail uses a
+[vouch-based trust system](https://github.com/mitchellh/vouch) for **pull requests**.
+
+- Pull requests may only be opened by **vouched contributors**. PRs from users who are not on the vouched list are **automatically closed**.
+- Maintainers and collaborators with write access, as well as bots (e.g. Dependabot), are always allowed and do not need to be vouched.
+
+The list of vouched contributors is maintained in
+[`.github/VOUCHED.td`](https://github.com/mainsail-crew/mainsail/blob/develop/.github/VOUCHED.td).
+
+If your PR was closed because you are not yet vouched, this is **not** a rejection of your work. A maintainer can
+vouch for you, after which you can reopen the PR or comment `/recheck` to have it checked again. Becoming an active,
+trusted member of the community, for example through issues is the path to being vouched.
 
 ## <a name="financial"></a> Financial Contribution
 


### PR DESCRIPTION
## Description

Adds the [vouch](https://github.com/mitchellh/vouch) contributor trust system to protect the project from low-quality and automated spam pull requests.

- **PRs** from contributors not on the vouched list are automatically closed (`vouch-check-pr` workflow).
- Maintainers/collaborators with write access and bots are exempt
- Maintainers can vouch or denounce users via issue/PR comments (`vouch-manage-by-issue` workflow), or unvouched authors can comment `/recheck` after being vouched.
- Vouched contributors are maintained in `.github/VOUCHED.td`.
- Documented the system in `CONTRIBUTING.md` and added a hidden/comment notice to the PR template.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

- Merge the PR in the mainsail-crew/docs repo to add the guide into the docs.
    https://github.com/mainsail-crew/docs/pull/54
