### PR TITLE
fix(JobQueue): enhance thumbnail handling for job queue items

### DIFF
--- a/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
@@ -59,22 +59,33 @@ export default class GcodefilesThumbnail extends Mixins(BaseMixin) {
     }
 
     get fileTimestamp() {
-        return typeof this.item.modified?.getTime === 'function' ? this.item.modified?.getTime() : 0
+        if ('modified' in this.item && typeof this.item.modified?.getTime === 'function') {
+            return this.item.modified.getTime()
+        }
+
+        if ('metadata' in this.item && typeof this.item.metadata?.modified?.getTime === 'function') {
+            return this.item.metadata.modified.getTime()
+        }
+
+        return 0
     }
 
-    get thumbnails() {
-        return this.item.thumbnails ?? this.item.metadata?.thumbnails ?? []
+    get thumbnails(): FileStateGcodefile['thumbnails'] {
+        if ('thumbnails' in this.item) return this.item.thumbnails
+
+        return this.item.metadata?.thumbnails ?? []
     }
 
     get subdirectory() {
-        const full_filename = this.item.full_filename ?? this.item.filename
+        let full_filename = this.item.filename
+        if ('full_filename' in this.item) full_filename = this.item.full_filename
         if (!full_filename.includes('/')) return null
 
         return escapePath(full_filename.substring(0, full_filename.lastIndexOf('/')))
     }
 
     get smallThumbnail() {
-        return this.thumbnails.find(
+        return this.thumbnails?.find(
             (thumbnail) =>
                 thumbnail.width >= thumbnailSmallMin &&
                 thumbnail.width <= thumbnailSmallMax &&
@@ -90,7 +101,7 @@ export default class GcodefilesThumbnail extends Mixins(BaseMixin) {
     }
 
     get bigThumbnail() {
-        return this.thumbnails.find((thumbnail) => thumbnail.width >= thumbnailBigMin)
+        return this.thumbnails?.find((thumbnail) => thumbnail.width >= thumbnailBigMin)
     }
 
     get bigThumbnailUrl() {

--- a/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
@@ -37,13 +37,14 @@ import { FileStateGcodefile } from '@/store/files/types'
 import { mdiFile, mdiFolder } from '@mdi/js'
 import { defaultBigThumbnailBackground, thumbnailBigMin, thumbnailSmallMax, thumbnailSmallMin } from '@/store/variables'
 import { escapePath } from '@/plugins/helpers'
+import { ServerJobQueueStateJob } from '@/store/server/jobQueue/types'
 
 @Component
 export default class GcodefilesThumbnail extends Mixins(BaseMixin) {
     mdiFile = mdiFile
     mdiFolder = mdiFolder
 
-    @Prop({ type: Object }) declare readonly item: FileStateGcodefile
+    @Prop({ type: Object }) declare readonly item: FileStateGcodefile | ServerJobQueueStateJob
 
     get bigThumbnailBackground() {
         return this.$store.state.gui.uiSettings.bigThumbnailBackground ?? defaultBigThumbnailBackground
@@ -58,17 +59,18 @@ export default class GcodefilesThumbnail extends Mixins(BaseMixin) {
     }
 
     get fileTimestamp() {
-        return typeof this.item.modified.getTime === 'function' ? this.item.modified.getTime() : 0
+        return typeof this.item.modified?.getTime === 'function' ? this.item.modified?.getTime() : 0
     }
 
     get thumbnails() {
-        return this.item.thumbnails ?? []
+        return this.item.thumbnails ?? this.item.metadata?.thumbnails ?? []
     }
 
     get subdirectory() {
-        if (!this.item.full_filename.includes('/')) return null
+        const full_filename = this.item.full_filename ?? this.item.filename
+        if (!full_filename.includes('/')) return null
 
-        return escapePath(this.item.full_filename.substring(0, this.item.full_filename.lastIndexOf('/')))
+        return escapePath(full_filename.substring(0, full_filename.lastIndexOf('/')))
     }
 
     get smallThumbnail() {

--- a/src/components/panels/Status/JobqueueEntry.vue
+++ b/src/components/panels/Status/JobqueueEntry.vue
@@ -49,8 +49,7 @@ import { Mixins, Prop } from 'vue-property-decorator'
 import type { LongpressEvent } from '@/directives/longpress'
 import BaseMixin from '@/components/mixins/base'
 import { ServerJobQueueStateJob } from '@/store/server/jobQueue/types'
-import { mdiCloseThick, mdiCounter, mdiDragVertical, mdiFile, mdiPlay, mdiPlaylistRemove } from '@mdi/js'
-import { defaultBigThumbnailBackground } from '@/store/variables'
+import { mdiCloseThick, mdiCounter, mdiDragVertical, mdiPlay, mdiPlaylistRemove } from '@mdi/js'
 import GcodefilesThumbnail from '@/components/panels/Gcodefiles/GcodefilesThumbnail.vue'
 import { CLOSE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
 
@@ -61,7 +60,6 @@ export default class StatusPanelJobqueueEntry extends Mixins(BaseMixin) {
     mdiCloseThick = mdiCloseThick
     mdiCounter = mdiCounter
     mdiDragVertical = mdiDragVertical
-    mdiFile = mdiFile
     mdiPlay = mdiPlay
     mdiPlaylistRemove = mdiPlaylistRemove
 
@@ -74,14 +72,6 @@ export default class StatusPanelJobqueueEntry extends Mixins(BaseMixin) {
     contextMenuY = 0
 
     showChangeCountDialog = false
-
-    get smallThumbnail() {
-        return this.$store.getters['server/jobQueue/getSmallThumbnail'](this.job)
-    }
-
-    get bigThumbnail() {
-        return this.$store.getters['server/jobQueue/getBigThumbnail'](this.job)
-    }
 
     get description() {
         if (!this.job?.metadata?.metadataPulled) return false
@@ -144,18 +134,6 @@ export default class StatusPanelJobqueueEntry extends Mixins(BaseMixin) {
         if (seconds) output.push(seconds.toFixed(0) + 's')
 
         return output.join(' ')
-    }
-
-    get bigThumbnailBackground() {
-        return this.$store.state.gui.uiSettings.bigThumbnailBackground ?? defaultBigThumbnailBackground
-    }
-
-    get bigThumbnailTooltipColor() {
-        if (defaultBigThumbnailBackground.toLowerCase() === this.bigThumbnailBackground.toLowerCase()) {
-            return undefined
-        }
-
-        return this.bigThumbnailBackground
     }
 
     openContextMenu(e: MouseEvent | LongpressEvent) {


### PR DESCRIPTION
## Description

This PR fix the thumbnails in the JobQueue list. The Input data is ServerJobQueueStateJob instead of FileStateGcodefile so the path to the thumbnails object is a little bit different. I also removed some unused/deprecated code in the JobqueueEntry.vue file.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
<img width="413" height="229" alt="Bildschirmfoto 2026-06-16 um 17 39 52" src="https://github.com/user-attachments/assets/8d127413-48f4-4cd1-98bd-a1d9ea560b99" />

after:
<img width="419" height="226" alt="Bildschirmfoto 2026-06-16 um 17 40 10" src="https://github.com/user-attachments/assets/1f9e6cfa-231c-4023-a73b-961f7fcab8aa" />

## [optional] Are there any post-deployment tasks we need to perform?

none
