### PR TITLE
locale(ca): add Catalan translation file

### DIFF
--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -1,0 +1,3 @@
+{
+    "title": "Catalan"
+}


### PR DESCRIPTION
## Description

This PR adds a empty translation file for Catalan to enable this language in Weblate.

## Related Tickets & Documents

- Language request on Weblate

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
