### PR TITLE
fix(vite): optimize Vue chunking and deduplication in Vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,11 @@ export default defineConfig({
             output: {
                 manualChunks: (id: string) => {
                     if (id.includes('node_modules')) {
+                        // keep Vue in a single chunk
+                        if (id.includes('/node_modules/vue/') || id.includes('/node_modules/@vue/')) {
+                            return 'vue'
+                        }
+
                         // split codemirror into its own chunk
                         if (id.includes('/codemirror/') || id.includes('/@codemirror/')) {
                             return 'codemirror'
@@ -138,7 +143,14 @@ export default defineConfig({
 
     envPrefix: 'VUE_',
     resolve: {
+        dedupe: ['vue'],
         alias: {
+            // Ensure every importer exact same Vue build
+            vue: 'vue/dist/vue.runtime.esm.js',
+            'vue/dist/vue.runtime.common.js': 'vue/dist/vue.runtime.esm.js',
+            'vue/dist/vue.runtime.common.dev.js': 'vue/dist/vue.runtime.esm.js',
+            'vue/dist/vue.runtime.common.prod.js': 'vue/dist/vue.runtime.esm.js',
+            'vue/dist/vue.common.js': 'vue/dist/vue.runtime.esm.js',
             '@': path.resolve(__dirname, './src'),
             stream: 'stream-browserify',
             events: 'events',


### PR DESCRIPTION
## Description

This PR fix an issue with multiple vue chunks in the build, because `@vitejs/plugin-vue2` try to load `vue/dist/vue.runtime.esm.js` and `vue-demu` & `vue-echarts` try to load `vue/dist/vue.runtime.common.js`.

## Related Tickets & Documents

Screenshot from the error message in v2.18.0:
<img width="616" height="67" alt="grafik" src="https://github.com/user-attachments/assets/731ccdcc-c66f-4d1f-9dd6-c2e4705dd71b" />

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
