### PR TITLE
fix(webcams): debounce preview to prevent restarts while typing

### DIFF
--- a/src/components/settings/Webcams/WebcamForm.vue
+++ b/src/components/settings/Webcams/WebcamForm.vue
@@ -205,7 +205,7 @@
                     </template>
                 </v-col>
                 <v-col class="col-12 col-sm-6 text-center" align-self="center">
-                    <webcam-wrapper :webcam="webcam" page="settings" />
+                    <webcam-wrapper :webcam="previewWebcam" page="settings" />
                 </v-col>
             </v-row>
         </v-card-text>
@@ -217,7 +217,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import { mdiDelete, mdiPencil, mdiMenuDown } from '@mdi/js'
@@ -240,6 +240,9 @@ export default class WebcamForm extends Mixins(BaseMixin, WebcamMixin) {
     selectIcon = false
     valid = false
     oldWebcamName = ''
+
+    previewWebcam: GuiWebcamStateWebcam = {} as GuiWebcamStateWebcam
+    previewDebounce: ReturnType<typeof setTimeout> | null = null
 
     rules = {
         required: (value: string) => value !== '' || this.$t('Settings.WebcamsTab.Required'),
@@ -453,6 +456,24 @@ export default class WebcamForm extends Mixins(BaseMixin, WebcamMixin) {
 
     mounted() {
         this.oldWebcamName = this.webcam.name
+        this.previewWebcam = this.cloneWebcam(this.webcam)
+    }
+
+    beforeDestroy() {
+        if (this.previewDebounce) clearTimeout(this.previewDebounce)
+    }
+
+    cloneWebcam(webcam: GuiWebcamStateWebcam): GuiWebcamStateWebcam {
+        return JSON.parse(JSON.stringify(webcam))
+    }
+
+    @Watch('webcam', { deep: true })
+    onWebcamChanged() {
+        if (this.previewDebounce) clearTimeout(this.previewDebounce)
+
+        this.previewDebounce = setTimeout(() => {
+            this.previewWebcam = this.cloneWebcam(this.webcam)
+        }, 500)
     }
 
     existsWebcamName(name: string) {


### PR DESCRIPTION
## Description

This PR adds a debounce in the Webcam settings form to prevent too much and fast restarts from the webcam stream while typing the URL.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
