### PR TITLE
fix(webcam): close stream from settings page, when dialog closed

### DIFF
--- a/src/components/settings/Webcams/WebcamForm.vue
+++ b/src/components/settings/Webcams/WebcamForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-form ref="webcamForm" v-model="valid" @submit.prevent="submit">
+    <v-form ref="webcamForm" v-model="valid" v-observe-visibility="visibilityChanged" @submit.prevent="submit">
         <v-card-title>{{ title }}</v-card-title>
         <v-card-text>
             <v-row>
@@ -205,7 +205,7 @@
                     </template>
                 </v-col>
                 <v-col class="col-12 col-sm-6 text-center" align-self="center">
-                    <webcam-wrapper :webcam="webcam" page="settings" />
+                    <webcam-wrapper v-if="showWebcamPreview" :webcam="webcam" page="settings" />
                 </v-col>
             </v-row>
         </v-card-text>
@@ -240,6 +240,8 @@ export default class WebcamForm extends Mixins(BaseMixin, WebcamMixin) {
     selectIcon = false
     valid = false
     oldWebcamName = ''
+
+    showWebcamPreview = false
 
     rules = {
         required: (value: string) => value !== '' || this.$t('Settings.WebcamsTab.Required'),
@@ -466,6 +468,10 @@ export default class WebcamForm extends Mixins(BaseMixin, WebcamMixin) {
 
         // If we are editing a webcam, we want to check if the name only exists once (the one we are editing)
         return count >= 1
+    }
+
+    visibilityChanged(newVal: boolean) {
+        this.showWebcamPreview = newVal
     }
 
     submit() {


### PR DESCRIPTION
## Description

This PR fix an issues with the webcam settings page. If you open/close the form and the preview is loaded, the stream will be continued in the background. With this PR, the webcam component will be unmounted and the stream will be closed with that.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
