### PR TITLE
fix(MiscellaneousSlider): commit fan/output % input on blur instead of discarding it

### DIFF
--- a/src/components/inputs/MiscellaneousSlider.vue
+++ b/src/components/inputs/MiscellaneousSlider.vue
@@ -36,7 +36,7 @@
                             outlined
                             dense
                             class="_slider-input pt-1"
-                            @blur="inputValue = Math.round(parseFloat(sliderValue) * 100)"
+                            @blur="onInputBlur"
                             @focus="$event.target.select()"
                             @keydown="checkInvalidChars" />
                     </form>
@@ -304,6 +304,18 @@ export default class MiscellaneousSlider extends Mixins(BaseMixin) {
         if (this.colorOrder === 'B') return 'BLUE'
 
         return 'WHITE'
+    }
+
+    onInputBlur(): void {
+        // commit the typed value on blur (Tab / click-away), same as Enter -> submitInput.
+        // previously blur reset inputValue to the current value, silently discarding the typed
+        // number -> fan left at its last M106 (e.g. stuck at 0% for many layers mid-print).
+        if (this.errors.length > 0) {
+            this.inputValue = Math.round(this.value * 100)
+            return
+        }
+
+        this.submitInput()
     }
 
     submitInput(): void {


### PR DESCRIPTION
## Problem
The percentage text-input in the Miscellaneous fan/output slider does **not** commit a typed value. On `blur` (Tab or click-away) it resets `inputValue` back to the current value:
```html
@blur="inputValue = Math.round(parseFloat(sliderValue) * 100)"
```
So typing e.g. `85` and tabbing/clicking away silently discards the number and sends nothing. The **slider drag path works** (it commits via `sendCmd`), so the two paths are inconsistent.

For a `[fan]` this is a real print-quality risk: the fan is left at its **last `M106`** (e.g. 0%), and since slicers only emit `M106` on fan-speed *changes*, a stuck value persists for many layers. Operators who type a value (common on tablets/touchscreens) get the fan stuck off.

## Fix
`blur` now commits the typed value through the same `submitInput` path as Enter, reverting to the current value only when the input is invalid/empty. No change to the slider path.

## Repro (before)
1. Open a fan in the Miscellaneous panel.
2. Type a percentage into the box and press Tab / click away (do not drag).
3. Box snaps back to the old value; `fan.speed` unchanged. Dragging the slider works fine.

## Test (after)
Type `45` + Tab → `SET_FAN_SPEED`/`M106` fires and `fan.speed` becomes ~0.45.