### PR TITLE
feat: add GPG Signature in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,38 @@ jobs:
         shell: bash
         run: mv ./dist/mainsail.zip ./mainsail.zip
 
+      - name: GPG signature
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY_BASE64: ${{ secrets.GPG_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+      
+          # make temp home dir
+          export GNUPGHOME="$(mktemp -d)"
+          chmod 700 "$GNUPGHOME"
+      
+          # write base64 gpg key to private.key
+          echo "$GPG_PRIVATE_KEY_BASE64" | base64 --decode > "$GNUPGHOME/private.key"
+      
+          # import private.key
+          gpg --batch --import "$GNUPGHOME/private.key"
+      
+          # rm temp key
+          rm -f "$GNUPGHOME/private.key"
+      
+          # use key to sign
+          gpg \
+            --batch \
+            --yes \
+            --armor \
+            --detach-sign \
+            --output mainsail.zip.asc \
+            mainsail.zip
+      
+          # clean temp dir
+          rm -rf "$GNUPGHOME"
+          
       - name: Get latest tag
         id: latest_tag
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,9 @@ jobs:
           token: ${{ secrets.PAT }}
           name: v${{ github.event.inputs.version }}
           tag_name: v${{ github.event.inputs.version }}
-          files: ./mainsail.zip
+          files: |
+            ./mainsail.zip
+            ./mainsail.zip.asc
           body: ${{ steps.generate-changelog.outputs.content }}
 
       - name: Copy remote configs to dist


### PR DESCRIPTION
## Description

It add GPG  Signature after mainsail webui build.

Relate to https://github.com/Arksine/moonraker/pull/1081. Which add support to allow mirror.

This requires adding an additional GPG Signature to verify that the mirror has not been modified.

## Related Tickets & Documents

is relate to issue #2559 
https://github.com/Arksine/moonraker/pull/1081

## What Change?

- it add new env var `${{ secrets.GPG_PRIVATE_KEY_BASE64 }}`.
- release with `mainsail.zip.asc` file

## [optional] Are there any post-deployment tasks we need to perform?

- require GPG Public key to moonraker repo `keychain/mainsail-crew/mainsail.asc`
- require GPG Private key in base64 to `secrets.GPG_PRIVATE_KEY_BASE64`

-Neko.vecter