### PR TITLE
chore(release): update release body text to add contributors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
         with:
           config: ./cliff-release.toml
           args: ${{ steps.latest_tag.outputs.TAG_NAME }}..HEAD
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release and upload build
         uses: softprops/action-gh-release@v2

--- a/cliff-release.toml
+++ b/cliff-release.toml
@@ -14,6 +14,7 @@ body = """
     | filter(attribute="scope")
     | sort(attribute="scope") %}
         - **{{commit.scope}}**: {{ commit.message | upper_first | trim }}\
+        {%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}\
         {%- if commit.breaking %}
         {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
         {%- endif -%}
@@ -24,6 +25,7 @@ body = """
         {% else -%}
         {% raw %}\n{% endraw %}\
         - {{ commit.message | upper_first | trim }}\
+        {%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}\
         {%- if commit.breaking %}
         {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
         {%- endif -%}
@@ -44,6 +46,10 @@ postprocessors = [
     { pattern = '<REPO>', replace = "https://github.com/mainsail-crew/mainsail" }, # replace repository URL
 ]
 
+
+[remote.github]
+owner = "mainsail-crew"
+repo = "mainsail"
 
 [git]
 # allow only conventional commits


### PR DESCRIPTION
## Description

This PR will add the contributor list again in the Release notes from GitHub.

Like this here from v2.2.1:
<img width="442" height="154" alt="Bildschirmfoto 2026-06-28 um 16 37 12" src="https://github.com/user-attachments/assets/997967fc-fbb7-4a88-a24e-7b9923b1cd0b" />


## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
