### PR TITLE
chore(changelog): skip vouch system auto-commits

### DIFF
--- a/cliff-release.toml
+++ b/cliff-release.toml
@@ -57,6 +57,7 @@ commit_parsers = [
     { message = "^docs\\(changelog\\):", group = "Changelog", skip = true}, # Old redundant commits
     { message = "^chore: push version number to", group = "9$Other", skip = true}, # Old redundant commits
     { message = "^chore\\(changelog\\): update changelog", group = "Changelog", skip = true}, # Old redundant commits
+    { message = "^chore\\(vouch\\): update VOUCHED contributors", skip = true}, # vouch system commits
 
     # Commits to parse
     { message = "^feat(\\(.*\\))?:", group = "<!-- 1 -->Features"},

--- a/cliff.toml
+++ b/cliff.toml
@@ -62,6 +62,7 @@ commit_parsers = [
     { message = "^docs\\(changelog\\):", group = "Changelog", skip = true}, # Old redundant commits
     { message = "^chore: push version number to", group = "9$Other", skip = true}, # Old redundant commits
     { message = "^chore\\(changelog\\): update changelog", group = "Changelog", skip = true}, # Old redundant commits
+    { message = "^chore\\(vouch\\): update VOUCHED contributors", skip = true}, # vouch system commits
 
     # Commits to parse
     { message = "^feat(\\(.*\\))?:", group = "<!-- 1 -->Features"},


### PR DESCRIPTION
## Description

This PR will skill all auto-commits from the vouch system from the changelogs (release + CHANGELOG.md).

## Related Tickets & Documents

- This PR is importent after this PR: #2561 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
