### PR TITLE
chore(vouch): add step to reopen and unlabel vouched PRs

### DIFF
--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -42,3 +42,13 @@ jobs:
           PR: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           gh pr edit "$PR" --repo "$REPO" --add-label "unvouched"
+
+      - name: Reopen and unlabel vouched PR
+        if: steps.vouch.outputs.status == 'vouched' || steps.vouch.outputs.status == 'allowed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          gh pr reopen "$PR" --repo "$REPO" || true
+          gh pr edit "$PR" --repo "$REPO" --remove-label "unvouched" || true


### PR DESCRIPTION
## Description

This PR adds the missing path to `/recheck` issue_comment check to revalidate and reopen a PR, when the user is vouched. 

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
