### PR TITLE
chore(label-actions): update to dessant/label-actions@v5

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -12,4 +12,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5


### PR DESCRIPTION
## Description

This PR only upgrade the action `dessant/label-actions` from v4 to v5.

## Related Tickets & Documents

- failed workflow because of an outdated token validator: https://github.com/mainsail-crew/mainsail/actions/runs/28334109622

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
