### PR TITLE
fix(StartPrintDialog): pull gcode metadata to display thumbnails

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -96,10 +96,7 @@ export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
         if (!newVal || !this.file || this.file.metadataPulled || this.file.metadataRequested) return
 
         const fullPath = ['gcodes']
-        if (this.currentPath !== '') {
-            if (this.currentPath.startsWith('/')) fullPath.push(this.currentPath.substr(1))
-            else fullPath.push(this.currentPath)
-        }
+        if (this.currentPath) fullPath.push(this.currentPath.replace(/^\/+/, ''))
         fullPath.push(this.file.filename)
         this.$store.dispatch('files/requestMetadata', [{ filename: fullPath.join('/') }])
     }

--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
+import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile } from '@/store/files/types'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
@@ -89,6 +89,19 @@ export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
 
     closeDialog() {
         this.showDialog = false
+    }
+
+    @Watch('showDialog')
+    onShowDialogChanged(newVal: boolean) {
+        if (!newVal || !this.file || this.file.metadataPulled || this.file.metadataRequested) return
+
+        const fullPath = ['gcodes']
+        if (this.currentPath !== '') {
+            if (this.currentPath.startsWith('/')) fullPath.push(this.currentPath.substr(1))
+            else fullPath.push(this.currentPath)
+        }
+        fullPath.push(this.file.filename)
+        this.$store.dispatch('files/requestMetadata', [{ filename: fullPath.join('/') }])
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR fixes an issue, when you open the StartPrintDialog in the History Page for example from a Gcode file, which not pulled the metadata until now. When opening the StartPrintDialog, it checks if the metadata are pulled, if not, it sends the request for this file.

## Related Tickets & Documents

fixes #2558 

## Mobile & Desktop Screenshots/Recordings

before:
<img width="571" height="470" alt="Bildschirmfoto 2026-06-29 um 13 19 24" src="https://github.com/user-attachments/assets/0207f031-31b4-4b91-a42e-fba6b6f01531" />

after: 
<img width="552" height="847" alt="Bildschirmfoto 2026-06-29 um 13 19 48" src="https://github.com/user-attachments/assets/bf384894-76c4-404a-a133-28b3d145ad50" />

## [optional] Are there any post-deployment tasks we need to perform?

none
