### PR TITLE
fix(Gcodefiles): correct file path for multi gcode downloads

### DIFF
--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -104,7 +104,7 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
     }
 
     downloadSelectedFiles() {
-        if (this.selectedFiles.length === 1) {
+        if (this.selectedFiles.length === 1 && !this.selectedFiles[0].isDirectory) {
             const filepath = `${this.currentPath}/${this.selectedFiles[0].filename}`
             const href = `${this.apiUrl}/server/files/gcodes${escapePath(filepath)}`
             window.open(href)

--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -117,7 +117,7 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
 
         const addElementToItems = (absolutPath: string, directory: FileStateFile[]) => {
             for (const file of directory) {
-                const filePath = `${absolutPath}/${escapePath(file.filename)}`
+                const filePath = `${absolutPath}/${file.filename}`
 
                 if (file.isDirectory && file.childrens) {
                     addElementToItems(filePath, file.childrens)
@@ -129,7 +129,8 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
             }
         }
 
-        addElementToItems('gcodes/' + this.currentPath, this.selectedFiles)
+        const absolutePath = this.currentPath ? `gcodes${this.currentPath}` : 'gcodes'
+        addElementToItems(absolutePath, this.selectedFiles)
 
         this.$socket.emit(
             'server.files.zip',

--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -129,8 +129,7 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
             }
         }
 
-        const absolutePath = this.currentPath ? `gcodes${this.currentPath}` : 'gcodes'
-        addElementToItems(absolutePath, this.selectedFiles)
+        addElementToItems(`gcodes${this.currentPath}`, this.selectedFiles)
 
         this.$socket.emit(
             'server.files.zip',

--- a/src/components/panels/Gcodefiles/GcodefilesPanelTableRowDirectory.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelTableRowDirectory.vue
@@ -95,6 +95,9 @@ export default class GcodefilesPanelTableRowDirectory extends Mixins(BaseMixin, 
     }
 
     goToDirectory() {
+        // reset selectedFiles when changing directory to prevent wrong absolute paths
+        this.selectedFiles = []
+
         this.currentPath += '/' + this.item.filename
     }
 


### PR DESCRIPTION
## Description

This PR fixes three issues in the Gcodefiles page.

1. Moonraker needs a not escapted URL to bundle files into a ZIP file for a multi file download.
2. It resets the selctedFiles array to prevent wrong URLs, because if you select files in the parent directory and then switching to a sub directory, it will build the path to all files with the sub directory path.
3. If you only check one directory in the gcodes file list, it will also use the "multi file download" instead of linking to the directory. So it will also download a zip file from this directory.

## Related Tickets & Documents

fixes #2453 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
