### PR TITLE
chore(vite): remove Vue chunking and deduplication configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,11 +115,6 @@ export default defineConfig({
             output: {
                 manualChunks: (id: string) => {
                     if (id.includes('node_modules')) {
-                        // keep Vue in a single chunk
-                        if (id.includes('/node_modules/vue/') || id.includes('/node_modules/@vue/')) {
-                            return 'vue'
-                        }
-
                         // split codemirror into its own chunk
                         if (id.includes('/codemirror/') || id.includes('/@codemirror/')) {
                             return 'codemirror'
@@ -143,14 +138,7 @@ export default defineConfig({
 
     envPrefix: 'VUE_',
     resolve: {
-        dedupe: ['vue'],
         alias: {
-            // Ensure every importer exact same Vue build
-            vue: 'vue/dist/vue.runtime.esm.js',
-            'vue/dist/vue.runtime.common.js': 'vue/dist/vue.runtime.esm.js',
-            'vue/dist/vue.runtime.common.dev.js': 'vue/dist/vue.runtime.esm.js',
-            'vue/dist/vue.runtime.common.prod.js': 'vue/dist/vue.runtime.esm.js',
-            'vue/dist/vue.common.js': 'vue/dist/vue.runtime.esm.js',
             '@': path.resolve(__dirname, './src'),
             stream: 'stream-browserify',
             events: 'events',


### PR DESCRIPTION
## Description

This PR removes a deprecated Vite setting (https://github.com/mainsail-crew/mainsail/pull/2547), because it is after the Vite8/Rolldown (https://github.com/mainsail-crew/mainsail/pull/2571) upgrade not necessary anymore.

@pedrolamas thx for the hint!

## Related Tickets & Documents

- PR to chunking the Vue package to deduplicate it: https://github.com/mainsail-crew/mainsail/pull/2547
- PR for the Vite upgrade: https://github.com/mainsail-crew/mainsail/pull/2571

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
