### PR TITLE
feat(afc): gate lane eject on mounted tool

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnitLaneActions.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneActions.vue
@@ -33,7 +33,7 @@
                 <v-tooltip top>
                     <template #activator="{ on, attrs }">
                         <v-btn
-                            :disabled="toolLoaded || (!laneRunout && toolLoaded)"
+                            :disabled="ejectDisabled"
                             dense
                             class="flex-grow-1 px-0 last-btn"
                             v-bind="attrs"
@@ -79,6 +79,12 @@ export default class AfcPanelUnitLaneActions extends Mixins(BaseMixin, AfcMixin,
 
     get toolLoaded() {
         return this.lane.tool_loaded ?? false
+    }
+
+    get ejectDisabled() {
+        const mounted = this.lane.mounted
+        if (mounted !== undefined) return !mounted
+        return this.toolLoaded || (!this.laneRunout && this.toolLoaded)
     }
 
     loadLane() {


### PR DESCRIPTION
## Description

AFC Eject button's `disabled` state now also considers an optional
`lane.mounted` flag. When a backend reports it, Eject enables only for the lane
whose tool is currently on the carrier.

On a toolchanger the previous expression (`toolLoaded || (!laneRunout && toolLoaded)`)
greys Eject out exactly when a lane's tool is mounted and loaded, the very moment
you'd actually want to use it.

## Related Tickets & Documents

None.

## Mobile & Desktop Screenshots/Recordings

None, no layout or visual change.
