### PR TITLE
fix(store): prevent TypeError when configfile is not yet loaded

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -412,7 +412,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
     },
 
     getPrinterConfigObjects: (state) => (objectNames: string[]) => {
-        const settings = state.configfile.settings
+        const settings = state.configfile?.settings
         if (!settings) return {}
 
         const output: Record<string, unknown> = {}


### PR DESCRIPTION
## Description

This PR fixes a tiny getter issue in the printer getters, when the printer object is not loaded.

## Related Tickets & Documents

Screenshot from the browser error:
<img width="488" height="313" alt="grafik" src="https://github.com/user-attachments/assets/f9fba3b1-7fc5-42fc-a3b1-3283766bc887" />

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
