### PR TITLE
fix(webcam): resolve relative go2rtc stream URLs

### DIFF
--- a/src/components/mixins/webcam.ts
+++ b/src/components/mixins/webcam.ts
@@ -23,7 +23,7 @@ export default class WebcamMixin extends Mixins(BaseMixin) {
         // overwrite url to baseUrl, if it is an absolute URL
         if (baseUrl.startsWith('http') || baseUrl.startsWith('://')) url = new URL(baseUrl)
 
-        if (baseUrl.startsWith('/webcam')) {
+        if (baseUrl.startsWith('/')) {
             const ports = [80]
             ports.push(this.$store.state.server.config?.config?.server?.port ?? 7125)
             ports.push(this.$store.state.server.config?.config?.server?.ssl_port ?? 7130)

--- a/src/components/webcams/streamers/WebrtcGo2rtc.vue
+++ b/src/components/webcams/streamers/WebrtcGo2rtc.vue
@@ -65,15 +65,16 @@ export default class WebrtcGo2rtc extends Mixins(BaseMixin, WebcamMixin) {
     }
 
     get url() {
-        // eslint-disable-next-line no-useless-assignment -- urlSearch is used inside try after reassignment
-        let urlSearch = ''
-        let url = new URL(location.href)
+        // parse against a dummy base, so relative stream URLs can be manipulated with the URL API.
+        const url = new URL(this.camSettings.stream_url, 'http://dummy')
 
-        try {
-            urlSearch = new URL(this.camSettings.stream_url).search.toString()
-            url = new URL('api/ws' + urlSearch, this.camSettings.stream_url)
-        } catch {
-            this.log('invalid url', this.camSettings.stream_url)
+        // if the urls is /api/webrtc, it has to be changed to /api/ws
+        if (url.pathname.endsWith('/api/webrtc')) {
+            url.pathname = url.pathname.slice(0, -'webrtc'.length) + 'ws'
+        }
+        // fallback if the "stream url" is used (like http://<host>/stream.html?src=<source>
+        else if (!url.pathname.endsWith('/api/ws')) {
+            url.pathname = url.pathname.replace(/[^/]*$/, '') + 'api/ws'
         }
 
         // create media types array
@@ -81,15 +82,20 @@ export default class WebrtcGo2rtc extends Mixins(BaseMixin, WebcamMixin) {
         if (this.enableAudio) media.push('audio')
 
         url.searchParams.set('media', media.join('+'))
-        // change protocol to ws
-        url.protocol = this.$store.state.socket.protocol + ':'
 
         // output a warning, if no src is set in the url
         if (!url.searchParams.has('src')) {
             this.log('no src set in url')
         }
 
-        return this.convertUrl(url.toString(), this.printerUrl)
+        // keep user-entered absolute URLs, otherwise stay relative so convertUrl can resolve the host
+        const isAbsolute = /^https?:\/\//i.test(this.camSettings.stream_url)
+        const outputUrl = isAbsolute ? url.toString() : url.pathname + url.search
+
+        const wsUrl = new URL(this.convertUrl(outputUrl, this.printerUrl))
+        wsUrl.protocol = this.$store.state.socket.protocol + ':'
+
+        return wsUrl.toString()
     }
 
     get enableAudio() {

--- a/src/components/webcams/streamers/WebrtcGo2rtc.vue
+++ b/src/components/webcams/streamers/WebrtcGo2rtc.vue
@@ -89,7 +89,8 @@ export default class WebrtcGo2rtc extends Mixins(BaseMixin, WebcamMixin) {
         }
 
         // keep user-entered absolute URLs, otherwise stay relative so convertUrl can resolve the host
-        const isAbsolute = /^https?:\/\//i.test(this.camSettings.stream_url)
+        const lower = this.camSettings.stream_url.toLowerCase()
+        const isAbsolute = lower.startsWith('http://') || lower.startsWith('https://')
         const outputUrl = isAbsolute ? url.toString() : url.pathname + url.search
 
         const wsUrl = new URL(this.convertUrl(outputUrl, this.printerUrl))


### PR DESCRIPTION
## Description

This PR fixes issues with the Webcam WebRTC (go2rtc) client with the URL parsing. The "old" solution was only working with absolute paths + when the URL was the "stream" URL (http://<host + port>/stream.html?src=webcam). The new solution works with the following URLs:

- http://<host + port>/stream.html?src=webcam
- http://<host + port>/location/stream.html?src=webcam
- http://<host + port>/api/webrtc?src=webcam
- http://<host + port>/location/api/webrtc?src=webcam
- http://<host + port>/api/ws?src=webcam
- http://<host + port>/location/api/ws?src=webcam

## Related Tickets & Documents

- fixes #2576 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
