### PR TITLE
chore(release): update GitHub Actions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,10 @@ jobs:
 
       - name: git add & commit & push
         if: steps.package-version.outputs.current-version != github.event.inputs.version
-        uses: EndBug/add-and-commit@v9
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          add: 'package.json package-lock.json'
-          default_author: github_actions
-          message: 'chore: push version number to v${{ github.event.inputs.version }}'
-          push: true
+          commit_message: 'chore: push version number to v${{ github.event.inputs.version }}'
+          file_pattern: 'package.json package-lock.json'
 
   update-master-branch:
     needs: ['push-version-number']
@@ -103,7 +101,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release and upload build
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         id: create-release
         with:
           token: ${{ secrets.PAT }}
@@ -117,7 +115,7 @@ jobs:
         run: cp ./remote/* ./dist/
 
       - name: Upload to remote server
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.REMOTEHOST }}
           username: ${{ secrets.REMOTEUSER }}
@@ -156,6 +154,7 @@ jobs:
       - name: Show CHANGELOG
         run: |
           cat CHANGELOG.md
+
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'docs(changelog): update changelog'


### PR DESCRIPTION
## Description

This PR just upgrade all release workflow actions + change `EndBug/add-and-commit` to `stefanzweifel/git-auto-commit-action`. Just to use the same action for both "commit & push" steps.

## Related Tickets & Documents

I saw this warnings with deprecated node versions in the v2.18.1 release workflow run:
<img width="1795" height="727" alt="grafik" src="https://github.com/user-attachments/assets/15ac3c80-8c0b-452e-a3b5-1455cbba5ed4" />

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
