### PR TITLE
fix(VueLoadImage): handle default export for VueLoadImage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ Vue.config.productionTip = false
 
 Vue.directive('observe-visibility', ObserveVisibility)
 
-Vue.component('VueLoadImage', VueLoadImage)
+Vue.component('VueLoadImage', VueLoadImage.default ?? VueLoadImage)
 
 Vue.use(VueToast, {
     duration: 3000,

--- a/src/types/vue-load-image.d.ts
+++ b/src/types/vue-load-image.d.ts
@@ -1,6 +1,7 @@
 declare module 'vue-load-image' {
     import { DefineComponent } from 'vue'
 
-    const VueLoadImage: DefineComponent<Record<string, never>, Record<string, never>, unknown>
+    type VueLoadImageComponent = DefineComponent<Record<string, never>, Record<string, never>, unknown>
+    const VueLoadImage: VueLoadImageComponent & { default?: VueLoadImageComponent }
     export default VueLoadImage
 }


### PR DESCRIPTION
## Description

This PR fix an Issue with loading the VueLoadImage component, which is used for Thumbnails for example. This issue happens after the Vite8/Rolldown upgrade.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
