### PR TITLE
refactor(logfiles): refactor layout from log files panel

### DIFF
--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -49,7 +49,7 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
 
     showRolloverDialog = false
 
-    get filesInLogRoot() {
+    get filesInLogRoot(): FileStateFile[] {
         return this.$store.getters['files/getDirectory']('logs')?.childrens ?? []
     }
 
@@ -57,7 +57,8 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
         const logfiles = ['klippy', 'moonraker']
 
         genericLogfiles.forEach((logfile: string) => {
-            if (this.filesInLogRoot.findIndex((log: FileStateFile) => log.filename === `${logfile}.log`) === -1) return
+            const existsLogfile = this.filesInLogRoot.some((file) => file.filename === `${logfile}.log`)
+            if (existsLogfile) return
 
             logfiles.push(logfile)
         })

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -24,10 +24,8 @@
                     <span>{{ $t('Machine.LogfilesPanel.Rollover') }}</span>
                 </v-tooltip>
             </template>
-            <v-card-text :class="'text-center text-lg-left'">
-                <v-row class="pt-3">
-                    <logfiles-panel-generic-log v-for="logfile in genericLogfiles" :key="logfile" :name="logfile" />
-                </v-row>
+            <v-card-text class="logfiles-grid pa-3">
+                <logfiles-panel-generic-log v-for="logfile in logfiles" :key="logfile" :name="logfile" />
             </v-card-text>
         </panel>
         <logfiles-panel-rollover-dialog v-model="showRolloverDialog" />
@@ -41,6 +39,7 @@ import Panel from '@/components/ui/Panel.vue'
 import { mdiFileDocumentEdit, mdiFileSyncOutline } from '@mdi/js'
 import { genericLogfiles } from '@/store/variables'
 import LogfilesPanelGenericLog from '@/components/panels/Machine/LogfilesPanel/LogfilesPanelGenericLog.vue'
+import { FileStateFile } from '@/store/files/types'
 @Component({
     components: { LogfilesPanelGenericLog, Panel },
 })
@@ -48,8 +47,30 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
     mdiFileDocumentEdit = mdiFileDocumentEdit
     mdiFileSyncOutline = mdiFileSyncOutline
 
-    genericLogfiles = genericLogfiles
-
     showRolloverDialog = false
+
+    get filesInLogRoot() {
+        return this.$store.getters['files/getDirectory']('logs')?.childrens ?? []
+    }
+
+    get logfiles() {
+        const logfiles = ['klippy', 'moonraker']
+
+        genericLogfiles.forEach((logfile: string) => {
+            if (this.filesInLogRoot.findIndex((log: FileStateFile) => log.filename === `${logfile}.log`) === -1) return
+
+            logfiles.push(logfile)
+        })
+
+        return logfiles
+    }
 }
 </script>
+
+<style scoped>
+.logfiles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+}
+</style>

--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -58,7 +58,7 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
 
         genericLogfiles.forEach((logfile: string) => {
             const existsLogfile = this.filesInLogRoot.some((file) => file.filename === `${logfile}.log`)
-            if (existsLogfile) return
+            if (!existsLogfile) return
 
             logfiles.push(logfile)
         })

--- a/src/components/panels/Machine/LogfilesPanel/LogfilesPanelGenericLog.vue
+++ b/src/components/panels/Machine/LogfilesPanel/LogfilesPanelGenericLog.vue
@@ -1,38 +1,23 @@
 <template>
-    <v-col v-if="exists" :class="classes">
-        <v-btn :href="href" block class="primary--text" @click="downloadLog">
-            <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
-            {{ name }}
-        </v-btn>
-    </v-col>
+    <v-btn :href="href" block class="primary--text" @click="downloadLog">
+        <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
+        {{ name }}
+    </v-btn>
 </template>
 
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import Panel from '@/components/ui/Panel.vue'
-import { FileStateFile } from '@/store/files/types'
 import { mdiDownload } from '@mdi/js'
-@Component({
-    components: { Panel },
-})
+
+@Component
 export default class LogfilesPanel extends Mixins(BaseMixin) {
     mdiDownload = mdiDownload
 
     @Prop({ type: String, required: true }) name!: string
 
-    get logfiles() {
-        return this.$store.getters['files/getDirectory']('logs')?.childrens ?? []
-    }
-
     get filename() {
         return this.name + '.log'
-    }
-
-    get exists(): boolean {
-        if (['klippy', 'moonraker'].includes(this.name)) return true
-
-        return this.logfiles.findIndex((log: FileStateFile) => log.filename === this.filename) !== -1
     }
 
     get href() {
@@ -40,19 +25,6 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
         if (['klippy', 'moonraker'].includes(this.name)) path = '/server/files/'
 
         return this.apiUrl + path + this.filename
-    }
-
-    get classes() {
-        const output = ['col-12', 'pt-0']
-
-        if (this.klipperState !== 'ready') {
-            output.push('col-md-6')
-            output.push('mt-md-3')
-        } else {
-            output.push('col-md-12')
-        }
-
-        return output
     }
 
     downloadLog(event: MouseEvent) {

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -157,7 +157,7 @@ export const hiddenDirectories = ['.git']
 /*
  * List of all downloadable logfiles
  */
-export const genericLogfiles = ['klippy', 'moonraker', 'crowsnest', 'mmu', 'sonar']
+export const genericLogfiles = ['crowsnest', 'mmu', 'sonar']
 
 /*
  * List of all rollover logfiles


### PR DESCRIPTION
## Description

This PR refactor the log files panel and use a grid system to layout the buttons. I also moved the genericLogFiles filter to the parent element (LogfilesPanel.vue) instead of  inside of the LogfilesPanelGenericLog.vue file.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
