### PR TITLE
refactor(AFC): Updating tooltips in AFC Print Dialog to show more information

### DIFF
--- a/src/components/dialogs/StartPrintDialogAfcTool.vue
+++ b/src/components/dialogs/StartPrintDialogAfcTool.vue
@@ -1,11 +1,18 @@
 <template>
     <v-row :class="{ 'bt-1': borderTop }" class="px-6">
         <v-col class="d-flex align-center shrink pr-0">
-            <v-tooltip v-if="warnings.length" top>
+            <v-tooltip v-if="warnings.length" top max-width="300">
                 <template #activator="{ on, attrs }">
-                    <v-icon color="warning" v-bind="attrs" v-on="on">{{ mdiAlert }}</v-icon>
+                    <span v-bind="attrs" v-on="on">
+                        <v-icon color="warning">{{ mdiAlert }}</v-icon>
+                    </span>
                 </template>
-                <span>{{ warnings.join('\n') }}</span>
+                <div
+                    v-for="(warning, i) in warnings"
+                    :key="i"
+                    :class="{ 'mb-1': i < warnings.length - 1 }">
+                    {{ warning }}
+                </div>
             </v-tooltip>
             <v-icon v-else color="success">{{ mdiCheckCircle }}</v-icon>
         </v-col>
@@ -14,8 +21,52 @@
             <gcodefiles-panel-table-row-file-metadata-filaments-badge :filament="fileFilament" />
         </v-col>
         <v-col class="d-flex align-center pr-0">
-            <span class="mr-3 text-subtitle-1 font-weight-bold text-uppercase">{{ laneName }}</span>
-            <gcodefiles-panel-table-row-file-metadata-filaments-badge :filament="laneFilament" />
+            <v-tooltip
+                v-if="laneInfo"
+                :disabled="!hasLaneTooltipContent"
+                top
+                max-width="280">
+                <template #activator="{ on, attrs }">
+                    <span class="d-flex align-center" v-bind="attrs" v-on="on">
+                        <span
+                            class="mr-2 text-subtitle-1 font-weight-bold text-uppercase"
+                            style="padding-right: 4px;">
+                            {{ laneName }}
+                        </span>
+                        <div class="d-flex flex-column align-center mx-1">
+                            <v-chip
+                                v-if="laneFilamentBadge.color"
+                                x-small
+                                :color="laneFilamentBadge.color"
+                                :style="{ color: laneFilamentBadgeTextColor }">
+                                {{ laneFilamentBadge.weight > 0 ? filamentWeightFormat(laneFilamentBadge.weight) : '' }}
+                            </v-chip>
+                            <small v-if="laneFilamentBadge.type" class="type mt-1">{{ laneFilamentBadge.type }}</small>
+                        </div>
+                    </span>
+                </template>
+                <div v-if="laneInfo.spool">
+                    <div class="font-weight-bold">
+                        #{{ laneInfo.spoolId }} | {{ laneInfo.filamentVendor ?? $t('Dialogs.StartPrint.Afc.Unknown') }}
+                    </div>
+                    <div>{{ laneInfo.filamentName ?? $t('Dialogs.StartPrint.Afc.Unknown') }}</div>
+                    <div v-if="laneInfo.material">{{ laneSpoolMaterialDetails }}</div>
+                    <div v-if="laneWeightsOutput !== undefined">{{ laneWeightsOutput }}</div>
+                </div>
+                <div v-else>
+                    <div v-if="laneInfo.material">{{ laneInfo.material }}</div>
+                    <div v-if="laneInfo.remainingWeight !== undefined">
+                        {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(laneInfo.remainingWeight) }) }}
+                    </div>
+                </div>
+            </v-tooltip>
+            <span
+                v-else
+                class="mr-3 text-subtitle-1 font-weight-bold text-uppercase text--disabled">
+                {{ $t('Dialogs.StartPrint.Afc.NoLane') }}
+            </span>
+
+            <!-- Lane selector dropdown -->
             <v-menu offset-y left>
                 <template #activator="{ on, attrs }">
                     <v-btn v-bind="attrs" icon text ripple class="pr-0" v-on="on">
@@ -24,13 +75,54 @@
                 </template>
                 <v-list>
                     <v-list-item
-                        v-for="lane in afcLanes"
-                        :key="lane"
-                        :disabled="lane === laneName"
-                        @click="changeToolMapping(lane)">
-                        <span class="mr-3 text-subtitle-1 font-weight-bold text-uppercase">{{ lane }}</span>
-                        <gcodefiles-panel-table-row-file-metadata-filaments-badge
-                            :filament="getAfcLaneFilament(lane)" />
+                        v-for="option in laneOptions"
+                        :key="option.lane"
+                        :input-value="option.lane === laneName"
+                        color="primary"
+                        @click="changeToolMapping(option.lane)">
+                        <v-tooltip :disabled="!option.hasContent" top max-width="280">
+                            <template #activator="{ on, attrs }">
+                                <v-list-item-title
+                                    class="d-flex align-center"
+                                    v-bind="attrs"
+                                    v-on="on">
+                                    <span class="mr-2 text-subtitle-1 font-weight-bold text-uppercase">
+                                        {{ option.lane }}
+                                    </span>
+                                    <div class="d-flex flex-column align-center mx-1">
+                                        <v-chip
+                                            v-if="option.badge.color"
+                                            x-small
+                                            :color="option.badge.color"
+                                            :style="{ color: option.badgeTextColor }">
+                                            {{ option.badge.weight > 0 ? filamentWeightFormat(option.badge.weight) : '' }}
+                                        </v-chip>
+                                        <small v-if="option.badge.type" class="type mt-1">{{ option.badge.type }}</small>
+                                    </div>
+                                    <v-icon
+                                        v-if="option.lane === laneName"
+                                        small
+                                        color="primary"
+                                        class="ml-2">
+                                        {{ mdiCheck }}
+                                    </v-icon>
+                                </v-list-item-title>
+                            </template>
+                            <div v-if="option.spoolId">
+                                <div class="font-weight-bold">
+                                    #{{ option.spoolId }} | {{ option.vendorName }}
+                                </div>
+                                <div>{{ option.filamentName }}</div>
+                                <div v-if="option.materialDetails">{{ option.materialDetails }}</div>
+                                <div v-if="option.weightsOutput">{{ option.weightsOutput }}</div>
+                            </div>
+                            <div v-else>
+                                <div v-if="option.material">{{ option.material }}</div>
+                                <div v-if="option.remainingWeight !== undefined">
+                                    {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(option.remainingWeight) }) }}
+                                </div>
+                            </div>
+                        </v-tooltip>
                     </v-list-item>
                 </v-list>
             </v-menu>
@@ -42,15 +134,31 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile } from '@/store/files/types'
-import AfcMixin from '@/components/mixins/afc'
-import { mdiAlert, mdiCheckCircle, mdiChevronDown } from '@mdi/js'
-import { convertStringToArray, filamentWeightFormat } from '@/plugins/helpers'
+import AfcMixin, { AfcSpoolLaneInfo } from '@/components/mixins/afc'
+import { mdiAlert, mdiCheck, mdiCheckCircle, mdiChevronDown } from '@mdi/js'
+import { convertStringToArray, filamentTextColor, filamentWeightFormat } from '@/plugins/helpers'
+
+interface LaneOption {
+    lane: string
+    spoolId: number | null
+    badge: { color: string; name: string; type: string; weight: number }
+    badgeTextColor: string
+    material: string
+    vendorName: string
+    filamentName: string
+    materialDetails: string
+    weightsOutput: string | undefined
+    remainingWeight: number | undefined
+    hasContent: boolean
+}
 
 @Component
-export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
+export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin) {
     mdiAlert = mdiAlert
+    mdiCheck = mdiCheck
     mdiCheckCircle = mdiCheckCircle
     mdiChevronDown = mdiChevronDown
+    filamentWeightFormat = filamentWeightFormat
 
     @Prop({ required: true }) declare readonly file: FileStateGcodefile
     @Prop({ required: true }) declare readonly toolIndex: number
@@ -70,41 +178,118 @@ export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
             color: fileColors[this.toolIndex] ?? '#000000',
             name: fileNames[this.toolIndex] ?? '--',
             type: fileTypes[this.toolIndex] ?? '--',
-            weight: fileWeights[this.toolIndex],
+            weight: fileWeights[this.toolIndex] ?? 0,
         }
     }
 
-    get laneName() {
-        const lanes = this.afc?.lanes ?? []
+    get laneName(): string | undefined {
+        return this.afcLanes.find((lane: string) => {
+            const laneObj = this.getAfcLaneObject(lane)
+            const mappedTool = laneObj?.map
 
-        return lanes.find((lane: string) => {
-            const laneObject = this.getAfcLaneObject(lane)
-            const mappedTool = laneObject?.map?.toLowerCase()
+            if (Array.isArray(mappedTool)) {
+                return mappedTool.some((t: string) => t.toLowerCase() === this.toolName.toLowerCase())
+            }
 
-            return mappedTool === this.toolName.toLowerCase()
+            return mappedTool?.toLowerCase() === this.toolName.toLowerCase()
         })
     }
 
-    get laneFilament() {
-        return this.getAfcLaneFilament(this.laneName ?? '')
+    get laneInfo(): AfcSpoolLaneInfo | undefined {
+        if (!this.laneName) return undefined
+
+        return this.getAfcLaneInfo(this.laneName)
     }
 
-    get isFilamentTypeValid() {
-        return this.fileFilament?.type?.toLowerCase() === this.laneFilament?.type?.toLowerCase()
+    get laneFilamentBadge() {
+        if (!this.laneInfo) return { color: '', name: '--', type: '--', weight: 0 }
+
+        return {
+            color: this.laneInfo.color,
+            name: this.laneInfo.filamentName ?? '--',
+            type: this.laneInfo.material || '--',
+            weight: this.laneInfo.remainingWeight ?? 0,
+        }
     }
 
-    get isFilamentWeightValid() {
-        return this.fileFilament.weight < this.laneFilament.weight
+    get laneFilamentBadgeTextColor(): string {
+        return this.laneFilamentBadge.color ? filamentTextColor(this.laneFilamentBadge.color) : ''
     }
 
-    get warnings() {
+    get hasLaneTooltipContent(): boolean {
+        if (!this.laneInfo) return false
+        if (this.laneInfo.spool) return true
+
+        return !!this.laneInfo.material || this.laneInfo.remainingWeight !== undefined
+    }
+
+    get laneSpoolMaterialDetails(): string {
+        if (!this.laneInfo) return '--'
+
+        const parts = [this.laneInfo.material || '--']
+        if (this.laneInfo.extruderTemp !== undefined) parts.push(`${this.laneInfo.extruderTemp}°C`)
+        if (this.laneInfo.bedTemp !== undefined) parts.push(`${this.laneInfo.bedTemp}°C`)
+
+        return parts.join(' | ')
+    }
+
+    get laneWeightsOutput(): string | undefined {
+        if (!this.laneInfo || this.laneInfo.remainingWeight === undefined) return undefined
+
+        const parts = [
+            this.$t('Panels.AfcPanel.WeightRemaining', {
+                weight: Math.round(this.laneInfo.remainingWeight),
+            }).toString(),
+        ]
+
+        if (this.laneInfo.usedWeight !== undefined) {
+            parts.push(
+                this.$t('Panels.AfcPanel.WeightUsed', {
+                    weight: Math.round(this.laneInfo.usedWeight),
+                }).toString()
+            )
+        }
+
+        return parts.join(' | ')
+    }
+
+    get isFilamentTypeValid(): boolean {
+        if (!this.laneInfo) return false
+        const fileType = this.fileFilament.type.toLowerCase()
+        const laneType = (this.laneInfo.material || '--').toLowerCase()
+
+        if (fileType === '--' || laneType === '--') return true
+
+        return laneType.includes(fileType)
+    }
+
+    get isFilamentWeightValid(): boolean {
+        if (!this.laneInfo) return false
+        const fileWeight = this.fileFilament.weight ?? 0
+        const laneWeight = this.laneInfo.remainingWeight ?? 0
+
+        if (fileWeight === 0 || laneWeight === 0) return true
+
+        return fileWeight < laneWeight
+    }
+
+    get warnings(): string[] {
         const warnings: string[] = []
+
+        if (!this.laneName) {
+            warnings.push(
+                this.$t('Dialogs.StartPrint.Afc.NoLaneMapped', {
+                    tool: this.toolName,
+                }) as string
+            )
+            return warnings
+        }
 
         if (!this.isFilamentTypeValid) {
             warnings.push(
                 this.$t('Dialogs.StartPrint.Afc.FilamentTypeMismatch', {
                     file: this.fileFilament?.type ?? '--',
-                    lane: this.laneFilament?.type ?? '--',
+                    lane: this.laneInfo?.material || '--',
                 }) as string
             )
         }
@@ -114,7 +299,7 @@ export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
                 this.$t('Dialogs.StartPrint.Afc.FilamentWeightNotEnough', {
                     lane: this.laneName ?? '--',
                     required: filamentWeightFormat(this.fileFilament?.weight ?? 0),
-                    available: filamentWeightFormat(this.laneFilament?.weight ?? 0),
+                    available: filamentWeightFormat(this.laneInfo?.remainingWeight ?? 0),
                 }) as string
             )
         }
@@ -122,11 +307,68 @@ export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
         return warnings
     }
 
-    changeToolMapping(lane: string) {
-        const gcode = `SET_MAP LANE=${lane} MAP=${this.toolName}`
+    get laneOptions(): LaneOption[] {
+        return this.afcLanes.map((lane: string) => {
+            const info = this.getAfcLaneInfo(lane)
+            const material = info.material || ''
+            const remainingWeight = info.remainingWeight
+            const hasContent = info.spool != null || !!material || remainingWeight !== undefined
+            const badgeColor = info.color
 
+            const materialParts = [material || '--']
+            if (info.extruderTemp !== undefined) materialParts.push(`${info.extruderTemp}°C`)
+            if (info.bedTemp !== undefined) materialParts.push(`${info.bedTemp}°C`)
+
+            const weightParts: string[] = []
+            if (remainingWeight !== undefined) {
+                weightParts.push(
+                    this.$t('Panels.AfcPanel.WeightRemaining', {
+                        weight: Math.round(remainingWeight),
+                    }).toString()
+                )
+            }
+            if (info.usedWeight !== undefined) {
+                weightParts.push(
+                    this.$t('Panels.AfcPanel.WeightUsed', {
+                        weight: Math.round(info.usedWeight),
+                    }).toString()
+                )
+            }
+
+            return {
+                lane,
+                spoolId: info.spoolId ?? null,
+                badge: {
+                    color: badgeColor,
+                    name: info.filamentName ?? '--',
+                    type: material || '--',
+                    weight: remainingWeight ?? 0,
+                },
+                badgeTextColor: badgeColor ? filamentTextColor(badgeColor) : '',
+                material,
+                vendorName: info.filamentVendor ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
+                filamentName: info.filamentName ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
+                materialDetails: info.spool ? materialParts.join(' | ') : '',
+                weightsOutput: weightParts.length > 0 ? weightParts.join(' | ') : undefined,
+                remainingWeight,
+                hasContent,
+            }
+        })
+    }
+
+    changeToolMapping(lane: string) {
+        if (lane === this.laneName) return
+
+        const gcode = `SET_MAP LANE=${lane} MAP=${this.toolName}`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode })
     }
 }
 </script>
+
+<style scoped>
+.type {
+    font-size: 0.7rem;
+    line-height: 1;
+}
+</style>

--- a/src/components/dialogs/StartPrintDialogAfcTool.vue
+++ b/src/components/dialogs/StartPrintDialogAfcTool.vue
@@ -7,10 +7,7 @@
                         <v-icon color="warning">{{ mdiAlert }}</v-icon>
                     </span>
                 </template>
-                <div
-                    v-for="(warning, i) in warnings"
-                    :key="i"
-                    :class="{ 'mb-1': i < warnings.length - 1 }">
+                <div v-for="(warning, i) in warnings" :key="i" :class="{ 'mb-1': i < warnings.length - 1 }">
                     {{ warning }}
                 </div>
             </v-tooltip>
@@ -21,16 +18,10 @@
             <gcodefiles-panel-table-row-file-metadata-filaments-badge :filament="fileFilament" />
         </v-col>
         <v-col class="d-flex align-center pr-0">
-            <v-tooltip
-                v-if="laneInfo"
-                :disabled="!hasLaneTooltipContent"
-                top
-                max-width="280">
+            <v-tooltip v-if="laneInfo" :disabled="!hasLaneTooltipContent" top max-width="280">
                 <template #activator="{ on, attrs }">
                     <span class="d-flex align-center" v-bind="attrs" v-on="on">
-                        <span
-                            class="mr-2 text-subtitle-1 font-weight-bold text-uppercase"
-                            style="padding-right: 4px;">
+                        <span class="mr-2 text-subtitle-1 font-weight-bold text-uppercase" style="padding-right: 4px">
                             {{ laneName }}
                         </span>
                         <div class="d-flex flex-column align-center mx-1">
@@ -60,9 +51,7 @@
                     </div>
                 </div>
             </v-tooltip>
-            <span
-                v-else
-                class="mr-3 text-subtitle-1 font-weight-bold text-uppercase text--disabled">
+            <span v-else class="mr-3 text-subtitle-1 font-weight-bold text-uppercase text--disabled">
                 {{ $t('Dialogs.StartPrint.Afc.NoLane') }}
             </span>
 
@@ -82,10 +71,7 @@
                         @click="changeToolMapping(option.lane)">
                         <v-tooltip :disabled="!option.hasContent" top max-width="280">
                             <template #activator="{ on, attrs }">
-                                <v-list-item-title
-                                    class="d-flex align-center"
-                                    v-bind="attrs"
-                                    v-on="on">
+                                <v-list-item-title class="d-flex align-center" v-bind="attrs" v-on="on">
                                     <span class="mr-2 text-subtitle-1 font-weight-bold text-uppercase">
                                         {{ option.lane }}
                                     </span>
@@ -95,23 +81,21 @@
                                             x-small
                                             :color="option.badge.color"
                                             :style="{ color: option.badgeTextColor }">
-                                            {{ option.badge.weight > 0 ? filamentWeightFormat(option.badge.weight) : '' }}
+                                            {{
+                                                option.badge.weight > 0 ? filamentWeightFormat(option.badge.weight) : ''
+                                            }}
                                         </v-chip>
-                                        <small v-if="option.badge.type" class="type mt-1">{{ option.badge.type }}</small>
+                                        <small v-if="option.badge.type" class="type mt-1">
+                                            {{ option.badge.type }}
+                                        </small>
                                     </div>
-                                    <v-icon
-                                        v-if="option.lane === laneName"
-                                        small
-                                        color="primary"
-                                        class="ml-2">
+                                    <v-icon v-if="option.lane === laneName" small color="primary" class="ml-2">
                                         {{ mdiCheck }}
                                     </v-icon>
                                 </v-list-item-title>
                             </template>
                             <div v-if="option.spoolId">
-                                <div class="font-weight-bold">
-                                    #{{ option.spoolId }} | {{ option.vendorName }}
-                                </div>
+                                <div class="font-weight-bold">#{{ option.spoolId }} | {{ option.vendorName }}</div>
                                 <div>{{ option.filamentName }}</div>
                                 <div v-if="option.materialDetails">{{ option.materialDetails }}</div>
                                 <div v-if="option.weightsOutput">{{ option.weightsOutput }}</div>
@@ -119,7 +103,11 @@
                             <div v-else>
                                 <div v-if="option.material">{{ option.material }}</div>
                                 <div v-if="option.remainingWeight !== undefined">
-                                    {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(option.remainingWeight) }) }}
+                                    {{
+                                        $t('Panels.AfcPanel.WeightRemaining', {
+                                            weight: Math.round(option.remainingWeight),
+                                        })
+                                    }}
                                 </div>
                             </div>
                         </v-tooltip>

--- a/src/components/dialogs/StartPrintDialogAfcTool.vue
+++ b/src/components/dialogs/StartPrintDialogAfcTool.vue
@@ -1,15 +1,11 @@
 <template>
     <v-row :class="{ 'bt-1': borderTop }" class="px-6">
         <v-col class="d-flex align-center shrink pr-0">
-            <v-tooltip v-if="warnings.length" top max-width="300">
+            <v-tooltip v-if="warnings.length" top>
                 <template #activator="{ on, attrs }">
-                    <span v-bind="attrs" v-on="on">
-                        <v-icon color="warning">{{ mdiAlert }}</v-icon>
-                    </span>
+                    <v-icon color="warning" v-bind="attrs" v-on="on">{{ mdiAlert }}</v-icon>
                 </template>
-                <div v-for="(warning, i) in warnings" :key="i" :class="{ 'mb-1': i < warnings.length - 1 }">
-                    {{ warning }}
-                </div>
+                <span>{{ warnings.join('\n') }}</span>
             </v-tooltip>
             <v-icon v-else color="success">{{ mdiCheckCircle }}</v-icon>
         </v-col>
@@ -18,39 +14,12 @@
             <gcodefiles-panel-table-row-file-metadata-filaments-badge :filament="fileFilament" />
         </v-col>
         <v-col class="d-flex align-center pr-0">
-            <v-tooltip v-if="laneInfo" :disabled="!hasLaneTooltipContent" top max-width="280">
-                <template #activator="{ on, attrs }">
-                    <span class="d-flex align-center" v-bind="attrs" v-on="on">
-                        <span class="mr-2 text-subtitle-1 font-weight-bold text-uppercase" style="padding-right: 4px">
-                            {{ laneName }}
-                        </span>
-                        <div class="d-flex flex-column align-center mx-1">
-                            <v-chip
-                                v-if="laneFilamentBadge.color"
-                                x-small
-                                :color="laneFilamentBadge.color"
-                                :style="{ color: laneFilamentBadgeTextColor }">
-                                {{ laneFilamentBadge.weight > 0 ? filamentWeightFormat(laneFilamentBadge.weight) : '' }}
-                            </v-chip>
-                            <small v-if="laneFilamentBadge.type" class="type mt-1">{{ laneFilamentBadge.type }}</small>
-                        </div>
-                    </span>
-                </template>
-                <div v-if="laneInfo.spool">
-                    <div class="font-weight-bold">
-                        #{{ laneInfo.spoolId }} | {{ laneInfo.filamentVendor ?? $t('Dialogs.StartPrint.Afc.Unknown') }}
-                    </div>
-                    <div>{{ laneInfo.filamentName ?? $t('Dialogs.StartPrint.Afc.Unknown') }}</div>
-                    <div v-if="laneInfo.material">{{ laneSpoolMaterialDetails }}</div>
-                    <div v-if="laneWeightsOutput !== undefined">{{ laneWeightsOutput }}</div>
-                </div>
-                <div v-else>
-                    <div v-if="laneInfo.material">{{ laneInfo.material }}</div>
-                    <div v-if="laneInfo.remainingWeight !== undefined">
-                        {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(laneInfo.remainingWeight) }) }}
-                    </div>
-                </div>
-            </v-tooltip>
+            <gcodefiles-panel-table-row-file-metadata-filaments-badge
+                v-if="laneInfo"
+                :filament="laneFilamentBadge"
+                :details="laneDetails"
+                :label="laneName"
+                hide-zero-weight />
             <span v-else class="mr-3 text-subtitle-1 font-weight-bold text-uppercase text--disabled">
                 {{ $t('Dialogs.StartPrint.Afc.NoLane') }}
             </span>
@@ -69,48 +38,19 @@
                         :input-value="option.lane === laneName"
                         color="primary"
                         @click="changeToolMapping(option.lane)">
-                        <v-tooltip :disabled="!option.hasContent" top max-width="280">
-                            <template #activator="{ on, attrs }">
-                                <v-list-item-title class="d-flex align-center" v-bind="attrs" v-on="on">
-                                    <span class="mr-2 text-subtitle-1 font-weight-bold text-uppercase">
-                                        {{ option.lane }}
-                                    </span>
-                                    <div class="d-flex flex-column align-center mx-1">
-                                        <v-chip
-                                            v-if="option.badge.color"
-                                            x-small
-                                            :color="option.badge.color"
-                                            :style="{ color: option.badgeTextColor }">
-                                            {{
-                                                option.badge.weight > 0 ? filamentWeightFormat(option.badge.weight) : ''
-                                            }}
-                                        </v-chip>
-                                        <small v-if="option.badge.type" class="type mt-1">
-                                            {{ option.badge.type }}
-                                        </small>
-                                    </div>
+                        <v-list-item-title>
+                            <gcodefiles-panel-table-row-file-metadata-filaments-badge
+                                :filament="option.badge"
+                                :details="option.details"
+                                :label="option.lane"
+                                hide-zero-weight>
+                                <template #append>
                                     <v-icon v-if="option.lane === laneName" small color="primary" class="ml-2">
                                         {{ mdiCheck }}
                                     </v-icon>
-                                </v-list-item-title>
-                            </template>
-                            <div v-if="option.spoolId">
-                                <div class="font-weight-bold">#{{ option.spoolId }} | {{ option.vendorName }}</div>
-                                <div>{{ option.filamentName }}</div>
-                                <div v-if="option.materialDetails">{{ option.materialDetails }}</div>
-                                <div v-if="option.weightsOutput">{{ option.weightsOutput }}</div>
-                            </div>
-                            <div v-else>
-                                <div v-if="option.material">{{ option.material }}</div>
-                                <div v-if="option.remainingWeight !== undefined">
-                                    {{
-                                        $t('Panels.AfcPanel.WeightRemaining', {
-                                            weight: Math.round(option.remainingWeight),
-                                        })
-                                    }}
-                                </div>
-                            </div>
-                        </v-tooltip>
+                                </template>
+                            </gcodefiles-panel-table-row-file-metadata-filaments-badge>
+                        </v-list-item-title>
                     </v-list-item>
                 </v-list>
             </v-menu>
@@ -121,23 +61,15 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { FileStateGcodefile } from '@/store/files/types'
+import { FilamentBadgeDetails, FileStateGcodefile } from '@/store/files/types'
 import AfcMixin, { AfcSpoolLaneInfo } from '@/components/mixins/afc'
 import { mdiAlert, mdiCheck, mdiCheckCircle, mdiChevronDown } from '@mdi/js'
-import { convertStringToArray, filamentTextColor, filamentWeightFormat } from '@/plugins/helpers'
+import { convertStringToArray, filamentWeightFormat } from '@/plugins/helpers'
 
 interface LaneOption {
     lane: string
-    spoolId: number | null
     badge: { color: string; name: string; type: string; weight: number }
-    badgeTextColor: string
-    material: string
-    vendorName: string
-    filamentName: string
-    materialDetails: string
-    weightsOutput: string | undefined
-    remainingWeight: number | undefined
-    hasContent: boolean
+    details: FilamentBadgeDetails
 }
 
 @Component
@@ -146,7 +78,6 @@ export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin)
     mdiCheck = mdiCheck
     mdiCheckCircle = mdiCheckCircle
     mdiChevronDown = mdiChevronDown
-    filamentWeightFormat = filamentWeightFormat
 
     @Prop({ required: true }) declare readonly file: FileStateGcodefile
     @Prop({ required: true }) declare readonly toolIndex: number
@@ -200,45 +131,22 @@ export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin)
         }
     }
 
-    get laneFilamentBadgeTextColor(): string {
-        return this.laneFilamentBadge.color ? filamentTextColor(this.laneFilamentBadge.color) : ''
+    get laneDetails(): FilamentBadgeDetails | undefined {
+        if (!this.laneInfo) return undefined
+
+        return this.buildLaneDetails(this.laneInfo)
     }
 
-    get hasLaneTooltipContent(): boolean {
-        if (!this.laneInfo) return false
-        if (this.laneInfo.spool) return true
-
-        return !!this.laneInfo.material || this.laneInfo.remainingWeight !== undefined
-    }
-
-    get laneSpoolMaterialDetails(): string {
-        if (!this.laneInfo) return '--'
-
-        const parts = [this.laneInfo.material || '--']
-        if (this.laneInfo.extruderTemp !== undefined) parts.push(`${this.laneInfo.extruderTemp}°C`)
-        if (this.laneInfo.bedTemp !== undefined) parts.push(`${this.laneInfo.bedTemp}°C`)
-
-        return parts.join(' | ')
-    }
-
-    get laneWeightsOutput(): string | undefined {
-        if (!this.laneInfo || this.laneInfo.remainingWeight === undefined) return undefined
-
-        const parts = [
-            this.$t('Panels.AfcPanel.WeightRemaining', {
-                weight: Math.round(this.laneInfo.remainingWeight),
-            }).toString(),
-        ]
-
-        if (this.laneInfo.usedWeight !== undefined) {
-            parts.push(
-                this.$t('Panels.AfcPanel.WeightUsed', {
-                    weight: Math.round(this.laneInfo.usedWeight),
-                }).toString()
-            )
+    buildLaneDetails(info: AfcSpoolLaneInfo): FilamentBadgeDetails {
+        return {
+            spoolId: info.spool ? info.spoolId : undefined,
+            vendorName: info.filamentVendor ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
+            filamentName: info.filamentName ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
+            materialDetails: info.spool ? this.buildAfcMaterialDetails(info) : undefined,
+            weightsOutput: this.buildAfcWeightsOutput(info),
+            material: info.material || undefined,
+            remainingWeight: info.remainingWeight,
         }
-
-        return parts.join(' | ')
     }
 
     get isFilamentTypeValid(): boolean {
@@ -273,6 +181,15 @@ export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin)
             return warnings
         }
 
+        if (!this.laneInfo?.filamentLoaded) {
+            warnings.push(
+                this.$t('Dialogs.StartPrint.Afc.LaneNotLoaded', {
+                    lane: this.laneName,
+                }) as string
+            )
+            return warnings
+        }
+
         if (!this.isFilamentTypeValid) {
             warnings.push(
                 this.$t('Dialogs.StartPrint.Afc.FilamentTypeMismatch', {
@@ -298,48 +215,16 @@ export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin)
     get laneOptions(): LaneOption[] {
         return this.afcLanes.map((lane: string) => {
             const info = this.getAfcLaneInfo(lane)
-            const material = info.material || ''
-            const remainingWeight = info.remainingWeight
-            const hasContent = info.spool != null || !!material || remainingWeight !== undefined
-            const badgeColor = info.color
-
-            const materialParts = [material || '--']
-            if (info.extruderTemp !== undefined) materialParts.push(`${info.extruderTemp}°C`)
-            if (info.bedTemp !== undefined) materialParts.push(`${info.bedTemp}°C`)
-
-            const weightParts: string[] = []
-            if (remainingWeight !== undefined) {
-                weightParts.push(
-                    this.$t('Panels.AfcPanel.WeightRemaining', {
-                        weight: Math.round(remainingWeight),
-                    }).toString()
-                )
-            }
-            if (info.usedWeight !== undefined) {
-                weightParts.push(
-                    this.$t('Panels.AfcPanel.WeightUsed', {
-                        weight: Math.round(info.usedWeight),
-                    }).toString()
-                )
-            }
 
             return {
                 lane,
-                spoolId: info.spoolId ?? null,
                 badge: {
-                    color: badgeColor,
+                    color: info.color,
                     name: info.filamentName ?? '--',
-                    type: material || '--',
-                    weight: remainingWeight ?? 0,
+                    type: info.material || '--',
+                    weight: info.remainingWeight ?? 0,
                 },
-                badgeTextColor: badgeColor ? filamentTextColor(badgeColor) : '',
-                material,
-                vendorName: info.filamentVendor ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
-                filamentName: info.filamentName ?? (this.$t('Dialogs.StartPrint.Afc.Unknown') as string),
-                materialDetails: info.spool ? materialParts.join(' | ') : '',
-                weightsOutput: weightParts.length > 0 ? weightParts.join(' | ') : undefined,
-                remainingWeight,
-                hasContent,
+                details: this.buildLaneDetails(info),
             }
         })
     }
@@ -353,10 +238,3 @@ export default class StartPrintDialogAfcTool extends Mixins(BaseMixin, AfcMixin)
     }
 }
 </script>
-
-<style scoped>
-.type {
-    font-size: 0.7rem;
-    line-height: 1;
-}
-</style>

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -2,6 +2,22 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 
+export interface AfcSpoolLaneInfo {
+    spoolId: number | undefined
+    spool: ServerSpoolmanStateSpool | null
+    color: string
+    material: string
+    filamentVendor: string | undefined
+    filamentName: string | undefined
+    remainingWeight: number | undefined
+    fullWeight: number | undefined
+    spoolPercent: number
+    usedWeight: number | undefined
+    extruderTemp: number | undefined
+    bedTemp: number | undefined
+    spoolUrl: string | undefined
+}
+
 @Component
 export default class AfcMixin extends Vue {
     get afcExists() {
@@ -146,6 +162,61 @@ export default class AfcMixin extends Vue {
             name: spool?.filament?.name ?? '--',
             type: lane?.material ?? '--',
             weight: lane?.weight ?? 0,
+        }
+    }
+
+    getAfcLaneInfo(laneName: string): AfcSpoolLaneInfo {
+        const lane = this.getAfcLaneObject(laneName)
+        const spoolId: number | undefined = lane?.spool_id ?? undefined
+        const spools: ServerSpoolmanStateSpool[] = this.$store.state.server.spoolman?.spools || []
+        const spool = spoolId
+            ? spools.find((s: ServerSpoolmanStateSpool) => s.id === spoolId) ?? null
+            : null
+
+        // Color: td1_color (when enabled) → spoolman color_hex → lane color
+        let color: string
+        const afcShowTd1Color: boolean = this.$store.state.gui.view.afc?.showTd1Color ?? false
+        if (this.afc?.td1_present && lane?.td1_color && afcShowTd1Color) {
+            color = `#${lane.td1_color}`
+        } else if (spool?.filament?.color_hex) {
+            color = `#${spool.filament.color_hex.replace(/^#/, '')}`
+        } else {
+            color = lane?.color || ''
+        }
+
+        const material = spool?.filament?.material || lane?.material || ''
+        const remainingWeight: number | undefined = spool?.remaining_weight ?? lane?.weight
+        const fullWeight: number | undefined = spool?.initial_weight ?? lane?.initial_weight
+
+        let spoolPercent = 100
+        if (remainingWeight != null && fullWeight != null && fullWeight > 0) {
+            // Clamping to 100 just in case remainingWeight is greater than fillWeight
+            // as this could exceed 100
+            spoolPercent = Math.min(100, Math.round((remainingWeight / fullWeight) * 100))
+        }
+
+        // Use base mixin's spoolManagerUrl if available, otherwise build from store
+        const spoolmanBase: string | undefined =
+            this.$store.state.server.config.config?.spoolman?.server ?? undefined
+        const spoolUrl =
+            spoolmanBase && spoolId
+                ? `${spoolmanBase.replace(/\/$/, '')}/spool/show/${spoolId}`
+                : undefined
+
+        return {
+            spoolId,
+            spool,
+            color,
+            material,
+            filamentVendor: spool?.filament?.vendor?.name,
+            filamentName: spool?.filament?.name || lane?.filament_name || undefined,
+            remainingWeight,
+            fullWeight,
+            spoolPercent,
+            usedWeight: spool?.used_weight,
+            extruderTemp: spool?.filament?.settings_extruder_temp,
+            bedTemp: spool?.filament?.settings_bed_temp,
+            spoolUrl,
         }
     }
 

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -169,9 +169,7 @@ export default class AfcMixin extends Vue {
         const lane = this.getAfcLaneObject(laneName)
         const spoolId: number | undefined = lane?.spool_id ?? undefined
         const spools: ServerSpoolmanStateSpool[] = this.$store.state.server.spoolman?.spools || []
-        const spool = spoolId
-            ? spools.find((s: ServerSpoolmanStateSpool) => s.id === spoolId) ?? null
-            : null
+        const spool = spoolId ? (spools.find((s: ServerSpoolmanStateSpool) => s.id === spoolId) ?? null) : null
 
         // Color: td1_color (when enabled) → spoolman color_hex → lane color
         let color: string
@@ -196,12 +194,9 @@ export default class AfcMixin extends Vue {
         }
 
         // Use base mixin's spoolManagerUrl if available, otherwise build from store
-        const spoolmanBase: string | undefined =
-            this.$store.state.server.config.config?.spoolman?.server ?? undefined
+        const spoolmanBase: string | undefined = this.$store.state.server.config.config?.spoolman?.server ?? undefined
         const spoolUrl =
-            spoolmanBase && spoolId
-                ? `${spoolmanBase.replace(/\/$/, '')}/spool/show/${spoolId}`
-                : undefined
+            spoolmanBase && spoolId ? `${spoolmanBase.replace(/\/$/, '')}/spool/show/${spoolId}` : undefined
 
         return {
             spoolId,

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -9,6 +9,7 @@ export interface AfcSpoolLaneInfo {
     material: string
     filamentVendor: string | undefined
     filamentName: string | undefined
+    filamentLoaded: boolean
     remainingWeight: number | undefined
     fullWeight: number | undefined
     spoolPercent: number
@@ -17,6 +18,9 @@ export interface AfcSpoolLaneInfo {
     bedTemp: number | undefined
     spoolUrl: string | undefined
 }
+
+// AFC's default full-spool weight (g) when no initial_weight is tracked (e.g. no Spoolman spool)
+const AFC_DEFAULT_SPOOL_WEIGHT = 1000
 
 @Component
 export default class AfcMixin extends Vue {
@@ -184,7 +188,8 @@ export default class AfcMixin extends Vue {
 
         const material = spool?.filament?.material || lane?.material || ''
         const remainingWeight: number | undefined = spool?.remaining_weight ?? lane?.weight
-        const fullWeight: number | undefined = spool?.initial_weight ?? lane?.initial_weight
+
+        const fullWeight: number = spool?.initial_weight ?? lane?.initial_weight ?? AFC_DEFAULT_SPOOL_WEIGHT
 
         let spoolPercent = 100
         if (remainingWeight != null && fullWeight != null && fullWeight > 0) {
@@ -205,6 +210,7 @@ export default class AfcMixin extends Vue {
             material,
             filamentVendor: spool?.filament?.vendor?.name,
             filamentName: spool?.filament?.name || lane?.filament_name || undefined,
+            filamentLoaded: lane?.load && lane?.prep,
             remainingWeight,
             fullWeight,
             spoolPercent,
@@ -233,5 +239,33 @@ export default class AfcMixin extends Vue {
     getAfcHubObject(hub: string) {
         const key = `AFC_hub ${hub}`
         return this.getPrinterObject(key) ?? {}
+    }
+
+    buildAfcMaterialDetails(info: AfcSpoolLaneInfo): string {
+        const parts = [info.material || '--']
+        if (info.extruderTemp !== undefined) parts.push(`${info.extruderTemp}°C`)
+        if (info.bedTemp !== undefined) parts.push(`${info.bedTemp}°C`)
+
+        return parts.join(' | ')
+    }
+
+    buildAfcWeightsOutput(info: AfcSpoolLaneInfo): string | undefined {
+        if (info.remainingWeight === undefined) return undefined
+
+        const parts = [
+            this.$t('Panels.AfcPanel.WeightRemaining', {
+                weight: Math.round(info.remainingWeight),
+            }).toString(),
+        ]
+
+        if (info.usedWeight !== undefined) {
+            parts.push(
+                this.$t('Panels.AfcPanel.WeightUsed', {
+                    weight: Math.round(info.usedWeight),
+                }).toString()
+            )
+        }
+
+        return parts.join(' | ')
     }
 }

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -128,23 +128,7 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolWeightsOutput(): string | undefined {
-        if (this.spoolRemainingWeight === undefined) return undefined
-
-        const array = [
-            this.$t('Panels.AfcPanel.WeightRemaining', {
-                weight: Math.round(this.spoolRemainingWeight ?? 0),
-            }).toString(),
-        ]
-
-        if (this.laneInfo.usedWeight !== undefined) {
-            array.push(
-                this.$t('Panels.AfcPanel.WeightUsed', {
-                    weight: Math.round(this.laneInfo.usedWeight ?? 0),
-                }).toString()
-            )
-        }
-
-        return array.join(' | ')
+        return this.buildAfcWeightsOutput(this.laneInfo)
     }
 
     get spoolPercent() {
@@ -160,11 +144,7 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolMaterialDetails(): string {
-        const array = [this.spoolMaterialOutput]
-        if (this.laneInfo.extruderTemp !== undefined) array.push(`${this.laneInfo.extruderTemp}°C`)
-        if (this.laneInfo.bedTemp !== undefined) array.push(`${this.laneInfo.bedTemp}°C`)
-
-        return array.join(' | ')
+        return this.buildAfcMaterialDetails(this.laneInfo)
     }
 
     get spoolFilamentVendor(): string | undefined {

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -62,8 +62,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import AfcMixin from '@/components/mixins/afc'
-import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+import AfcMixin, { AfcSpoolLaneInfo } from '@/components/mixins/afc'
 import { afcIconInfintiy } from '@/plugins/afcIcons'
 import AfcUnitLaneInfiniteDialog from '@/components/dialogs/AfcUnitLaneInfiniteDialog.vue'
 import AfcUnitLaneFilamentDialog from '@/components/dialogs/AfcUnitLaneFilamentDialog.vue'
@@ -91,33 +90,31 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
         return this.lane.runout_lane ?? 'NONE'
     }
 
-    get spoolId(): number {
-        return Number(this.lane.spool_id || '0')
+    get laneInfo(): AfcSpoolLaneInfo {
+        return this.getAfcLaneInfo(this.name)
     }
 
-    get spool(): ServerSpoolmanStateSpool | null {
-        if (this.spoolId === 0) return null
+    get spoolId(): number {
+        return Number(this.laneInfo.spoolId || '0')
+    }
 
-        const spools = this.$store.state.server.spoolman?.spools || []
-
-        return spools.find((spool: ServerSpoolmanStateSpool) => spool.id === this.spoolId) || null
+    get spool() {
+        return this.laneInfo.spool
     }
 
     get spoolFilamentHeadline(): string {
         const array = [`#${this.spoolId}`]
-        if (this.spoolFilamentVendor) array.push(this.spoolFilamentVendor)
+        if (this.laneInfo.filamentVendor) array.push(this.laneInfo.filamentVendor)
 
         return array.join(' | ')
     }
 
     get spoolColor() {
-        if (this.hasTd && this.showTd1Color) return `#${this.tdColor}`
-
-        return this.lane.color || '#000000'
+        return this.laneInfo.color
     }
 
     get spoolRemainingWeight(): number | undefined {
-        return this.spool?.remaining_weight ?? this.lane.weight ?? undefined
+        return this.laneInfo.remainingWeight
     }
 
     get spoolRemainingWeightOutput(): string {
@@ -127,7 +124,7 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolFullWeight(): number | undefined {
-        return this.spool?.initial_weight ?? this.lane.initial_weight ?? undefined
+        return this.laneInfo.fullWeight
     }
 
     get spoolWeightsOutput(): string | undefined {
@@ -139,9 +136,11 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
             }).toString(),
         ]
 
-        if (this.spoolUsedWeight !== undefined) {
+        if (this.laneInfo.usedWeight !== undefined) {
             array.push(
-                this.$t('Panels.AfcPanel.WeightUsed', { weight: Math.round(this.spoolUsedWeight ?? 0) }).toString()
+                this.$t('Panels.AfcPanel.WeightUsed', {
+                    weight: Math.round(this.laneInfo.usedWeight ?? 0),
+                }).toString()
             )
         }
 
@@ -149,14 +148,11 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolPercent() {
-        if (this.spoolRemainingWeight === undefined || this.spoolFullWeight === undefined) return 100
-        if (this.spoolFullWeight === 0) return 100
-
-        return Math.round((this.spoolRemainingWeight / this.spoolFullWeight) * 100)
+        return this.laneInfo.spoolPercent
     }
 
     get spoolMaterial(): string {
-        return this.spool?.filament?.material ?? this.lane.material ?? ''
+        return this.laneInfo.material
     }
 
     get spoolMaterialOutput(): string {
@@ -165,40 +161,34 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
 
     get spoolMaterialDetails(): string {
         const array = [this.spoolMaterialOutput]
-        if (this.spoolExtruderTemp !== undefined) array.push(`${this.spoolExtruderTemp}°C`)
-        if (this.spoolBedTemp !== undefined) array.push(`${this.spoolBedTemp}°C`)
+        if (this.laneInfo.extruderTemp !== undefined) array.push(`${this.laneInfo.extruderTemp}°C`)
+        if (this.laneInfo.bedTemp !== undefined) array.push(`${this.laneInfo.bedTemp}°C`)
 
         return array.join(' | ')
     }
 
     get spoolFilamentVendor(): string | undefined {
-        return this.spool?.filament?.vendor?.name
+        return this.laneInfo.filamentVendor
     }
 
     get spoolFilamentName(): string {
-        return this.spool?.filament?.name || this.lane.filament_name || 'Unknown'
+        return this.laneInfo.filamentName ?? 'Unknown'
     }
 
     get spoolUrl(): string | undefined {
-        if (!this.spoolManagerUrl || !this.spoolId) return undefined
-
-        return `${this.spoolManagerUrl.replace(/\/$/, '')}/spool/show/${this.spoolId}`
+        return this.laneInfo.spoolUrl
     }
 
     get spoolExtruderTemp(): number | undefined {
-        return this.spool?.filament?.settings_extruder_temp
+        return this.laneInfo.extruderTemp
     }
 
     get spoolBedTemp(): number | undefined {
-        return this.spool?.filament?.settings_bed_temp
+        return this.laneInfo.bedTemp
     }
 
     get spoolUsedWeight(): number | undefined {
-        return this.spool?.used_weight
-    }
-
-    get showTd1Color(): boolean {
-        return this.$store.state.gui.view.afc?.showTd1Color ?? true
+        return this.laneInfo.usedWeight
     }
 
     get hasTd() {

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -2,7 +2,7 @@
     <div>
         <v-row class="my-3">
             <v-col class="pl-6 pr-0 pt-0 pb-0 d-flex flex-column">
-                <v-tooltip top>
+                <v-tooltip :disabled="tooltipDisabled" top>
                     <template #activator="{ on, attr }">
                         <span class="d-flex align-center justify-center" v-bind="attr" v-on="on">
                             <afc-filament-reel
@@ -97,6 +97,9 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     get spoolId(): number {
         return Number(this.laneInfo.spoolId || '0')
     }
+    get tooltipDisabled(): boolean {
+        return this.spoolId === 0
+    }
 
     get spool() {
         return this.laneInfo.spool
@@ -152,7 +155,7 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolFilamentName(): string {
-        return this.laneInfo.filamentName ?? 'Unknown'
+        return this.laneInfo.filamentName ?? ''
     }
 
     get spoolUrl(): string | undefined {

--- a/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFileMetadataFilamentsBadge.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFileMetadataFilamentsBadge.vue
@@ -1,26 +1,57 @@
 <template>
-    <v-tooltip top>
+    <v-tooltip :disabled="tooltipDisabled" top>
         <template #activator="{ on, attrs }">
-            <div class="d-flex flex-column align-center mx-1" v-bind="attrs" v-on="on">
-                <v-chip :color="filament.color" x-small :style="chipStyle" class="chip">{{ weight }}</v-chip>
-                <small class="type mt-1">{{ filament.type }}</small>
+            <span class="d-flex align-center mx-1" v-bind="attrs" v-on="on">
+                <span
+                    v-if="label"
+                    class="mr-2 text-subtitle-1 font-weight-bold text-uppercase"
+                    style="padding-right: 4px">
+                    {{ label }}
+                </span>
+                <div class="d-flex flex-column align-center">
+                    <v-chip v-if="filament.color" :color="filament.color" x-small :style="chipStyle" class="chip">
+                        {{ weightText }}
+                    </v-chip>
+                    <small v-if="filament.type" class="type mt-1">{{ filament.type }}</small>
+                </div>
+                <slot name="append" />
+            </span>
+        </template>
+        <template v-if="details">
+            <div v-if="details.spoolId">
+                <div class="font-weight-bold">#{{ details.spoolId }} | {{ details.vendorName ?? '--' }}</div>
+                <div>{{ details.filamentName ?? '--' }}</div>
+                <div v-if="details.materialDetails">{{ details.materialDetails }}</div>
+                <div v-if="details.weightsOutput">{{ details.weightsOutput }}</div>
+            </div>
+            <div v-else>
+                <div v-if="details.material">{{ details.material }}</div>
+                <div v-if="details.remainingWeight !== undefined">
+                    {{ $t('Panels.AfcPanel.WeightRemaining', { weight: Math.round(details.remainingWeight) }) }}
+                </div>
             </div>
         </template>
-        <span>{{ filament.name }}</span>
+        <span v-else>{{ filament.name }}</span>
     </v-tooltip>
 </template>
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { FileStateGcodefileFilament } from '@/store/files/types'
+import { FilamentBadgeDetails, FileStateGcodefileFilament } from '@/store/files/types'
 import { filamentTextColor, filamentWeightFormat } from '@/plugins/helpers'
 
 @Component
 export default class GcodefilesPanelTableRowFileMetadataFilaments extends Mixins(BaseMixin) {
     @Prop({ type: Object, required: true }) readonly filament!: FileStateGcodefileFilament
+    @Prop({ type: Object, required: false, default: undefined }) readonly details?: FilamentBadgeDetails
+    @Prop({ type: String, required: false, default: undefined }) readonly label?: string
+    @Prop({ type: Boolean, required: false, default: false }) readonly hideZeroWeight!: boolean
 
-    get weight() {
-        return filamentWeightFormat(this.filament.weight ?? 0)
+    get weightText() {
+        const weight = this.filament.weight ?? 0
+        if (this.hideZeroWeight && weight <= 0) return ''
+
+        return filamentWeightFormat(weight)
     }
 
     get fontColor() {
@@ -32,6 +63,13 @@ export default class GcodefilesPanelTableRowFileMetadataFilaments extends Mixins
             color: this.fontColor,
         }
     }
+
+    get tooltipDisabled(): boolean {
+        if (!this.details) return false
+        if (this.details.spoolId) return false
+
+        return !this.details.material && this.details.remainingWeight === undefined
+    }
 }
 </script>
 
@@ -42,6 +80,7 @@ export default class GcodefilesPanelTableRowFileMetadataFilaments extends Mixins
 }
 
 .type {
+    font-size: 0.7rem;
     line-height: 1;
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -196,6 +196,7 @@
             "Afc": {
                 "FilamentTypeMismatch": "Filament type in the G-Code ({file}) does not match the selected filament type ({lane}).",
                 "FilamentWeightNotEnough": "Not enough filament in the selected lane ({lane}). Required: {required}, Available: {available}.",
+                "LaneNotLoaded": "No filament loaded in lane {lane}",
                 "NoLane": "No Lane",
                 "NoLaneMapped": "No lane mapped to {tool}",
                 "Unknown": "Unknown"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -195,7 +195,10 @@
         "StartPrint": {
             "Afc": {
                 "FilamentTypeMismatch": "Filament type in the G-Code ({file}) does not match the selected filament type ({lane}).",
-                "FilamentWeightNotEnough": "Not enough filament in the selected lane ({lane}). Required: {required}, Available: {available}."
+                "FilamentWeightNotEnough": "Not enough filament in the selected lane ({lane}). Required: {required}, Available: {available}.",
+                "NoLane": "No Lane",
+                "NoLaneMapped": "No lane mapped to {tool}",
+                "Unknown": "Unknown"
             },
             "DoYouWantToStartFilename": "Do you want to start {filename}?",
             "DoYouWantToStartFilenameFilament": "Do you want to start {filename} with the following filament?",

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -71,6 +71,16 @@ export interface FileStateGcodefileFilament {
     weight: number
 }
 
+export interface FilamentBadgeDetails {
+    spoolId?: number | null
+    vendorName?: string
+    filamentName?: string
+    materialDetails?: string
+    weightsOutput?: string
+    material?: string
+    remainingWeight?: number
+}
+
 export interface FileStateDiskUsage {
     free: number
     total: number


### PR DESCRIPTION
<!--
  ⚠️ IMPORTANT: Pull requests from contributors who are not on the vouched list
  (.github/VOUCHED.td) are automatically closed. See the Contributing Guidelines
  for details:
  https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#vouch
  If your PR gets closed, a maintainer can vouch for you; afterward reopen it
  or comment /recheck.


  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#submit-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots


  Note for AI assistants: If you (an AI tool/agent) are generating this Pull Request,
  please disclose it by appending the following line as the very last line of the
  entire Pull Request description and replace <tool> with your name (e.g. pi,
  Claude Code, Codex, GitHub Copilot, Cursor):

  🤖 This Pull Request was created with the help of <tool>.
-->

## Description
Updating AFC Print Dialog to match [fluidd update](<https://github.com/fluidd-core/fluidd/pull/1900>) that shows users more information and adds checkmark so its clear to the end user what lane is currently assigned to the T(n) tool.

Changes:
- Updated tooltips to show the same information as AfcPanelUnitLaneBody when hoving mouse over lane/spool
- Added checkmark to lane thats currently selected when selecting the lane selection dropdown.
- Added tooltip to show more information in the lane selection dropdown
- Updated material checking so that PLA matches PLA+ and does not give warning.
- Refactored code to use `getAfcLaneInfo` for both `StartPrintDialogAfcTool.vue` and `AfcPanelUnitLaneBody.vue` so that code was not duplicated since they both need the same information.

Note: Updates were done with help from claude and reviewed by me, please let me know if something was done wrong 😬

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings
Print Dialog Updates:

https://github.com/user-attachments/assets/0b377dd5-6cb7-4630-be2b-e5561f7afc36

Updates to AFC panel still look the same:

https://github.com/user-attachments/assets/8499f3c7-d65b-4f9a-93ff-2db442b43f79

## [optional] Are there any post-deployment tasks we need to perform?

None
