### PR TITLE
feat: add custom panel plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ package-lock.json
 *.local
 .env
 .vscode
-
+public/plugins
 cypress/screenshots/
 cypress/videos/
 components.d.ts

--- a/plugins/ExamplePanelPlugin/README.md
+++ b/plugins/ExamplePanelPlugin/README.md
@@ -1,0 +1,29 @@
+Add this to your mainsail config to enable the plugin
+```json
+{
+  ...
+  "customPanels": [
+    {
+      "id": "example-panel-plugin",
+      "title": "Example panel plugin",
+      "icon": "",
+      "entryUrl": "http://localhost:8080/plugins/example-panel-plugin.mjs",
+      "collapsible": true
+    }
+  ],
+  ...
+}
+```
+
+For plugin to be usable **entryUrl** should be either hosted on the same server OR it 
+should come from server with CORS configuration that allows connection coming from 
+mainsail server domain
+
+Icons can be supplied using svg for example heres a bootstrap icon, you might need to add some style tags tough
+```json
+{
+    ...
+    "icon": "<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-heart' viewBox='0 0 16 16'><path d='m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143q.09.083.176.171a3 3 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15'/></svg>",
+    ...
+}     
+```

--- a/plugins/ExamplePanelPlugin/package.json
+++ b/plugins/ExamplePanelPlugin/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "example-panel-plugin",
+    "version": "1.0.0",
+    "description": "An example of mainsail panel plugin",
+    "type": "module",
+    "main": "./dist/example-panel-plugin.mjs",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "serve": "vite preview"
+    },
+    "peerDependencies": {
+        "vue": "^2.7.0",
+        "vue-class-component": "^7.2.0",
+        "vue-property-decorator": "^9.1.2"
+    },
+    "devDependencies": {
+        "@vitejs/plugin-vue2": "^2.3.1",
+        "typescript": "^5.0.0",
+        "vite": "^5.0.0",
+        "vue": "^2.7.16",
+        "vue-class-component": "^7.2.3",
+        "vue-property-decorator": "^9.1.2",
+        "vue-template-compiler": "^2.7.16"
+    }
+}

--- a/plugins/ExamplePanelPlugin/src/ExamplePanelPlugin.vue
+++ b/plugins/ExamplePanelPlugin/src/ExamplePanelPlugin.vue
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({})
+export default class ExamplePanelPlugin extends Vue {
+    @Prop({ type: Object }) panelConfig
+    @Prop({ type: Object }) panelStore
+    @Prop({ type: Object }) panelSocket
+
+    created() {
+        const $store = this.$parent.$store;
+        const macros = $store.getters['printer/getMacros']
+        console.log($store, macros, this.panelStore, this.panelSocket);
+
+
+    }
+
+    postStatus() {
+        const gcode = "STATUS"
+        this.panelStore.dispatch('server/addEvent', {
+            message: gcode,
+            type: 'command',
+        })
+        this.panelSocket.emit('printer.gcode.script', { script: gcode }, { loading: 'macro_' + gcode })
+    }
+}
+</script>
+
+<template>
+    <div>
+        <p>Hello world!</p>
+        <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--dark v-size--small" @click="postStatus">Klipper status</button>
+    </div>
+</template>
+
+<style scoped></style>

--- a/plugins/ExamplePanelPlugin/src/main.ts
+++ b/plugins/ExamplePanelPlugin/src/main.ts
@@ -1,0 +1,3 @@
+import ExamplePanelPlugin from './ExamplePanelPlugin.vue';
+
+export default ExamplePanelPlugin;

--- a/plugins/ExamplePanelPlugin/vite.config.ts
+++ b/plugins/ExamplePanelPlugin/vite.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue2';
+import { resolve } from 'path';
+export default defineConfig({
+    plugins: [vue()],
+    define: {
+        'process.env.NODE_ENV': JSON.stringify('production')
+    },
+    build: {
+        // Output directly to public/plugins then you can use <hostname>/plugins/plugin.mjs as remote url
+        outDir: resolve(__dirname, '../../public/plugins'),
+        emptyOutDir: false,
+        lib: {
+            entry: 'src/main.ts',
+            name: 'ExamplePanelPlugin',
+            formats: ['es'],
+            fileName: () => `example-panel-plugin.mjs`
+        },
+        rolldownOptions: {
+            external: ['vue', 'vue-property-decorator', 'vue-class-component'],
+            output: {
+                globals: {
+                    vue: 'Vue',
+                    process: 'process'
+                }
+            }
+        }
+    },
+    preview: {
+        port: 8081,
+        cors: { origin: 'http://localhost:8080' }
+    }
+});

--- a/public/config.json
+++ b/public/config.json
@@ -6,5 +6,6 @@
     "port": null,
     "path": null,
     "instancesDB": "moonraker",
-    "instances": []
+    "instances": [],
+    "customPanels": []
 }

--- a/remote/config.json
+++ b/remote/config.json
@@ -4,5 +4,6 @@
     "hostname": null,
     "port": null,
     "instancesDB": "browser",
-    "instances": []
+    "instances": [],
+    "customPanels": []
 }

--- a/src/components/mixins/dashboard.ts
+++ b/src/components/mixins/dashboard.ts
@@ -29,7 +29,11 @@ export default class DashboardMixin extends BaseMixin {
         return this.$store.getters['gui/webcams/getWebcams'] ?? []
     }
 
-    getPanelName(name: string) {
+    getPanelName(name: string, config: { [key: string]: unknown }): string {
+        if (name === 'custom') {
+            return config['title'] ?? 'Custom panel'
+        }
+
         if (name.startsWith('macrogroup_')) {
             const groupId = name.split('_')[1] ?? ''
             const group = this.macrogroups.find((group: GuiMacrosStateMacrogroup) => group.id === groupId)

--- a/src/components/panels/CustomPanel.vue
+++ b/src/components/panels/CustomPanel.vue
@@ -1,0 +1,48 @@
+<template>
+    <panel
+        v-if="klipperReadyForGui"
+        :icon="config.icon"
+        :title="config.title"
+        :collapsible="config.collapsible"
+        :loading="!loadedComponent"
+        card-class="custom-panel">
+        <component
+            :is="loadedComponent"
+            v-if="loadedComponent"
+            :panel-config="config"
+            :panel-store="$store"
+            :panel-socket="$socket"
+        />
+    </panel>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import Panel from '@/components/ui/Panel.vue'
+import BaseMixin from '@/components/mixins/base'
+import { ConfigJsonCustomPanel } from '@/store/types'
+@Component({
+    components: { Panel },
+})
+export default class CustomPanel extends Mixins(BaseMixin) {
+    @Prop({ required: true, type: Object })
+    readonly config: ConfigJsonCustomPanel;
+
+    loadedComponent: null|object = null;
+    async created() {
+        await this.resolvePlugin();
+    }
+
+    private async resolvePlugin() {
+        try {
+            if (this.config.entryUrl) {
+                // Fetch the external ESM package at runtime
+                const module = await import(/* @vite-ignore */ this.config.entryUrl);
+                this.loadedComponent = module.default;
+            }
+        } catch (error) {
+            window.console.error(`Failed to load custom panel: ${this.config.title}`, error);
+        }
+    }
+}
+</script>

--- a/src/components/settings/Dashboard/Sortable.vue
+++ b/src/components/settings/Dashboard/Sortable.vue
@@ -26,6 +26,7 @@
                         v-for="element in layout"
                         :key="`item-${element.name}`"
                         :name="element.name"
+                        :panel-config="element.config"
                         :visible="element.visible"
                         @change-visible="changeVisible" />
                 </transition-group>

--- a/src/components/settings/Dashboard/SortableItem.vue
+++ b/src/components/settings/Dashboard/SortableItem.vue
@@ -37,9 +37,10 @@ export default class SettingsDashboardSortableItem extends Mixins(DashboardMixin
 
     @Prop({ type: String, required: true }) declare readonly name: string
     @Prop({ type: Boolean, required: true }) declare readonly visible: boolean
+    @Prop({ type: Object, required: false }) declare readonly panelConfig: { [key: string]: unknown }
 
     get panelname() {
-        return this.getPanelName(this.name)
+        return this.getPanelName(this.name, this.panelConfig)
     }
 
     get icon() {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -7,6 +7,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-mobileLayout-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -18,6 +19,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-tabletLayout1-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -26,6 +28,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-tabletLayout2-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -37,6 +40,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-desktopLayout1-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -45,6 +49,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-desktopLayout2-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -56,6 +61,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-desktopLayout1-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -64,6 +70,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-desktopLayout2-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -72,6 +79,7 @@
                     <component
                         :is="extractPanelName(component.name)"
                         :key="'dashboard-desktopLayout3-' + component.name"
+                        :config="component.config"
                         :panel-id="extractPanelId(component.name)"></component>
                 </template>
             </v-col>
@@ -99,6 +107,7 @@ import StatusPanel from '@/components/panels/StatusPanel.vue'
 import ToolheadControlPanel from '@/components/panels/ToolheadControlPanel.vue'
 import TemperaturePanel from '@/components/panels/TemperaturePanel.vue'
 import WebcamPanel from '@/components/panels/WebcamPanel.vue'
+import CustomPanel from '@/components/panels/CustomPanel.vue'
 
 @Component({
     components: {
@@ -118,6 +127,7 @@ import WebcamPanel from '@/components/panels/WebcamPanel.vue'
         ToolheadControlPanel,
         TemperaturePanel,
         WebcamPanel,
+        CustomPanel,
     },
 })
 export default class PageDashboard extends Mixins(DashboardMixin) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -54,5 +54,6 @@ export const actions: ActionTree<RootState, RootState> = {
         if (payload.hostname) commit('socket/setData', { hostname: payload.hostname })
         if (payload.port) commit('socket/setData', { port: parseInt(payload.port.toString()) })
         if (payload.path) commit('socket/setData', { route_prefix: payload.path })
+        if (payload.customPanels) commit('gui/setCustomPanels', { customPanels: payload.customPanels })
     },
 }

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -473,24 +473,6 @@ export const actions: ActionTree<GuiState, RootState> = {
         })
     },
 
-    addDefaultCustomPanels({ dispatch, state }, name: GuiStateDashboardLayoutKey) {
-        if (state.view.customPanels) {
-            const panels = state.dashboard[name].filter(panel => panel.name !== 'custom');
-            state.view.customPanels.forEach((panelConfig) => {
-                panels.push({
-                    name: 'custom',
-                    visible: true,
-                    config: panelConfig as Record<string, unknown>,
-                });
-            });
-
-            dispatch('saveSetting', {
-                name: 'dashboard.' + name,
-                value: panels,
-            });
-        }
-    },
-
     updateGcodeviewerCache({ dispatch, state }, payload) {
         const klipperCache = state.gcodeViewer.klipperCache as Record<string, unknown>
         const payloadCache = payload as Record<string, unknown>

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -111,7 +111,35 @@ export const actions: ActionTree<GuiState, RootState> = {
         }
 
         await commit('setData', payload.value)
+        await dispatch('initCustomPanels')
         await dispatch('socket/removeInitModule', 'gui/init', { root: true })
+    },
+
+    async initCustomPanels({ commit, rootGetters, rootState }) {
+        const customPanels = rootState.gui?.view?.customPanels ?? [];
+        const viewports = {
+            'mobile': 'mobileLayout',
+            'tablet': 'tabletLayout2',
+            'desktop': 'desktopLayout2',
+            'widescreen': 'widescreenLayout3',
+        };
+
+        for (const [viewport, defaultLayout] of Object.entries(viewports)) {
+            const panels = rootGetters['gui/getAllPanelsFromViewport'](viewport);
+            for (const customPanel of customPanels) {
+                if (panels.some((panel: GuiStateLayoutoption) => panel.config?.id === customPanel.id)) {
+                    continue;
+                }
+                await commit('addPanel', {
+                    viewport: defaultLayout,
+                    panel: {
+                        name: 'custom',
+                        visible: true,
+                        config: customPanel,
+                    }
+                });
+            }
+        }
     },
 
     /*
@@ -443,6 +471,24 @@ export const actions: ActionTree<GuiState, RootState> = {
             name: 'dashboard.' + name,
             value: newVal,
         })
+    },
+
+    addDefaultCustomPanels({ dispatch, state }, name: GuiStateDashboardLayoutKey) {
+        if (state.view.customPanels) {
+            const panels = state.dashboard[name].filter(panel => panel.name !== 'custom');
+            state.view.customPanels.forEach((panelConfig) => {
+                panels.push({
+                    name: 'custom',
+                    visible: true,
+                    config: panelConfig as Record<string, unknown>,
+                });
+            });
+
+            dispatch('saveSetting', {
+                name: 'dashboard.' + name,
+                value: panels,
+            });
+        }
     },
 
     updateGcodeviewerCache({ dispatch, state }, payload) {

--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -106,6 +106,10 @@ export const getters: GetterTree<GuiState, RootState> = {
             allPanels = allPanels.filter((name) => name !== 'led-effects')
         }
 
+        if (state.view.customPanels.length > 0) {
+            allPanels.push('custom');
+        }
+
         return allPanels
     },
 
@@ -191,5 +195,9 @@ export const getters: GetterTree<GuiState, RootState> = {
         }
 
         return false
+    },
+
+    getCustomPanels: (state) => {
+        return state.view.customPanels;
     },
 }

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -316,6 +316,7 @@ export const getDefaultState = (): GuiState => {
                     page: 'all',
                 },
             },
+            customPanels: []
         },
     }
 }

--- a/src/store/gui/mutations.ts
+++ b/src/store/gui/mutations.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { getDefaultState } from './index'
 import { MutationTree } from 'vuex'
-import { GuiState, GuiStateDashboard, GuiStateLayoutoption } from '@/store/gui/types'
+import { GuiState, GuiStateDashboard, GuiStateDashboardLayoutKey, GuiStateLayoutoption } from '@/store/gui/types'
 import { setDataDeep } from '@/plugins/helpers'
 
 export const mutations: MutationTree<GuiState> = {
@@ -120,5 +120,18 @@ export const mutations: MutationTree<GuiState> = {
             payload.dataset,
             payload.value
         )
+    },
+
+    addPanel(state, payload) {
+        const panels = state.dashboard[payload.viewport as GuiStateDashboardLayoutKey];
+        panels.push(payload.panel)
+
+        Vue.set(state.dashboard, payload.viewport, panels)
+    },
+
+    setCustomPanels(state, payload) {
+        if (payload.customPanels) {
+            Vue.set(state.view, 'customPanels', payload.customPanels)
+        }
     },
 }

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -220,7 +220,17 @@ export interface GuiState {
             showClimate: boolean
             showUnavailableSpoolColor: boolean
         }
+        customPanels: GuiStateCustomPanel[]
     }
+}
+
+export interface GuiStateCustomPanel {
+    [index: string]: unknown;
+    id: string;
+    title: string;
+    icon: string;
+    entryUrl: string;
+    collapsible: boolean;
 }
 
 export interface GuiStateDashboard {
@@ -242,6 +252,10 @@ export type GuiStateDashboardLayoutKey = Exclude<keyof GuiStateDashboard, 'nonEx
 export interface GuiStateLayoutoption {
     name: string
     visible: boolean
+    config?: {
+        id?: string;
+        [key: string]: unknown;
+    }
 }
 
 export type GuiStateUiSettingsDashboardFilesFilter = 'new' | 'failed' | 'completed'

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -31,12 +31,21 @@ export interface ConfigJson {
     path?: string | null
     instancesDB?: 'moonraker' | 'browser' | 'json'
     instances?: ConfigJsonInstance[]
+    customPanels?: ConfigJsonCustomPanel[]
 }
 
 export interface ConfigJsonInstance {
     hostname: string
     port?: number
     path?: string
+}
+
+export interface ConfigJsonCustomPanel {
+    id: string;
+    title: string;
+    icon: string;
+    entryUrl: string;
+    collapsible: boolean;
 }
 
 export interface Theme {


### PR DESCRIPTION
## Description

This PR adds ability to extend mainsail dashboard using custom panel plugins.

1. Panel plugins are created as seperate projects (see [ExamplePanelPlugin](https://github.com/mainsail-crew/mainsail/pull/2602/changes/6cbfb6b269d672affedbccfcabb392b7e9bb0d71)) that compile into ***.mjs** file, this way we can use any mainsail distribution method and still extend it using a custom plugin without touching mainsail codebase itself
2. Plugins are configured using [config.json](https://docs.mainsail.xyz/configuration/config-json/) by adding this section:
```json
 "customPanels": [
    {
      "id": "example-panel-plugin",
      "title": "Example panel plugin",
      "icon": "",
      "entryUrl": "http://localhost:8080/plugins/example-panel-plugin.mjs",
      "collapsible": true
    }
  ],
```

- **id** - Plugin Id's MUST be unique (Its how I distinguish between them)
- **title** - Plugin title, displayed in panel header and in configuration menu
- **icon** - An SVG string thats displayed as panel icon, you must either use single quotes (') or escape quotes (\") in the svg
- **entryUrl** - Link to .mjs entry file, it should be an ESM compatible module, when loading module it should either be located in mainsail web root (For example **<web root>/plugins/plugin.mjs**) or it should be a external server that has correct cors configuration, otherwise browser wont load it
- **collapsible** - If panel should be collapsible or not

3. Implementation - Its actually quite simple, custom panels are loaded on gui store init, we iterate through each viewport and if viewport doesnt contain a panel, we add it to last possible viewport layout. When custom panel is added, we import the mjs file and render it from **CustomPanel** component

5. Why? This allows mainsail to become more extensible, that way anybody can add their own custom panels for their own needs.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings
### Here we can see the custom panel
<img width="834" height="626" alt="image" src="https://github.com/user-attachments/assets/be564ed1-0900-40ac-8ad9-ad27d0643320" />

### Here we can see the panel in dashboard configuration, same controls, same everything
<img width="907" height="568" alt="image" src="https://github.com/user-attachments/assets/66d7ea2c-2675-42c2-9169-b818eaef5a86" />

## [optional] Are there any post-deployment tasks we need to perform?

none
