### PR TITLE
chore(i18n): update i18n-extract script for single lang check

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,13 @@ export default defineConfigWithVueTs(
     },
 
     {
+        files: ['scripts/**/*.js'],
+        languageOptions: {
+            globals: globals.node,
+        },
+    },
+
+    {
         files: ['**/*.vue'],
         rules: {
             'vue/no-v-html': 'off',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint src",
         "lint:fix": "npm run lint -- --fix",
         "build.zip": "cd ./dist && zip -r mainsail.zip ./ -x '**.DS_Store' ./ && cd ..",
-        "i18n-extract": "f() { vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles \"./src/locales/${1:-*}.json\"; }; f",
+        "i18n-extract": "node ./scripts/i18n-extract.js",
         "preview": "vite preview",
         "start": "vite build && vite preview",
         "test": "start-server-and-test preview http://127.0.0.1:4173/ 'cypress run'",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint src",
         "lint:fix": "npm run lint -- --fix",
         "build.zip": "cd ./dist && zip -r mainsail.zip ./ -x '**.DS_Store' ./ && cd ..",
-        "i18n-extract": "vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles './src/locales/*.json'",
+        "i18n-extract": "f() { vue-i18n-extract --vueFiles './src/**/{*.?(js|ts|vue),.i18nignore}' --languageFiles \"./src/locales/${1:-*}.json\"; }; f",
         "preview": "vite preview",
         "start": "vite build && vite preview",
         "test": "start-server-and-test preview http://127.0.0.1:4173/ 'cypress run'",

--- a/scripts/i18n-extract.js
+++ b/scripts/i18n-extract.js
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process'
+
+// optional language arg: `npm run i18n-extract -- de` -> only ./src/locales/de.json
+const lang = process.argv[2] ?? '*'
+
+const { status } = spawnSync(
+    process.execPath,
+    [
+        './node_modules/vue-i18n-extract/bin/vue-i18n-extract.js',
+        '--vueFiles',
+        './src/**/{*.?(js|ts|vue),.i18nignore}',
+        '--languageFiles',
+        `./src/locales/${lang}.json`,
+    ],
+    { stdio: 'inherit' }
+)
+
+process.exit(status ?? 1)


### PR DESCRIPTION
## Description

This PR modify the `i18n-extract` command in the `package.json` to allow the user/contributor to just check one single translation file. The normal `npm run i18n-extract` will work like before and will check all locale files, but `npm run i18n-extract de` will just check the de.json file for example.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
