### PR TITLE
fix(macros): stop marking existing macros as deleted in the settings

### DIFF
--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -353,7 +353,7 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
 
     private boolFormEdit = false
     private editGroupId: string | null = ''
-    private searchMacros: string = ''
+    private searchMacros: string | null = ''
 
     get groupColors() {
         return [
@@ -397,18 +397,23 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
         return colors
     }
 
-    get allMacros() {
-        const macros = this.$store.getters['printer/getMacros'] ?? []
-        return macros.filter((macro: PrinterStateMacro) => {
+    get allMacros(): PrinterStateMacro[] {
+        return this.$store.getters['printer/getMacros'] ?? []
+    }
+
+    get filteredMacros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
+
+        return this.allMacros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }
 
     get availableMacros() {
-        return this.allMacros.filter((m: GuiMacrosStateMacrogroupMacro) => !this.editGroupUsedMacros.includes(m.name))
+        return this.filteredMacros.filter((m: PrinterStateMacro) => !this.editGroupUsedMacros.includes(m.name))
     }
 
     get groups() {
@@ -512,17 +517,26 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
         })
     }
 
+    get macroListLoaded() {
+        return this.klipperReadyForGui && this.allMacros.length > 0
+    }
+
+    findMacro(macroname: string) {
+        return this.allMacros.find((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase())
+    }
+
     existsMacro(macroname: string) {
-        return (
-            this.allMacros.findIndex((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase()) !== -1
-        )
+        if (!this.macroListLoaded) return true
+
+        return this.findMacro(macroname) !== undefined
     }
 
     getMacroDescription(macroname: string) {
-        const macro = this.allMacros.find((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase())
-        if (!macro) return this.$t('Settings.MacrosTab.DeletedMacro')
+        const macro = this.findMacro(macroname)
+        if (macro) return macro.description ?? null
+        if (!this.macroListLoaded) return null
 
-        return macro?.description ?? null
+        return this.$t('Settings.MacrosTab.DeletedMacro')
     }
 
     updateMacrogroupOption(option: string, newVal: boolean | string) {

--- a/src/components/settings/SettingsMacrosTabSimple.vue
+++ b/src/components/settings/SettingsMacrosTabSimple.vue
@@ -52,14 +52,16 @@ import { PrinterStateMacro } from '@/store/printer/types'
 })
 export default class SettingsMacrosTabSimple extends Mixins(BaseMixin) {
     mdiMagnify = mdiMagnify
-    searchMacros: string = ''
+    searchMacros: string | null = ''
 
     get macros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
         const macros = this.$store.getters['printer/getMacros'] ?? []
+
         return macros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -144,7 +144,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
     getMacros: (state) => {
         const array: PrinterStateMacro[] = []
-        const settings = state.configfile?.settings ?? null
+        const settings = state.configfile?.settings ?? {}
         const printerGcodes = state.gcode?.commands ?? {}
 
         const prefix = 'gcode_macro '

--- a/tests/components/settings/settingsMacrosTabExpert.spec.ts
+++ b/tests/components/settings/settingsMacrosTabExpert.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import SettingsMacrosTabExpert from '@/components/settings/SettingsMacrosTabExpert.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+import type { GuiMacrosStateMacrogroup } from '@/store/gui/macros/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    group?: Partial<GuiMacrosStateMacrogroup>
+    search?: string | null
+    klipperReady?: boolean
+}
+
+interface MacrosTabExpert {
+    searchMacros: string | null
+    editGroupId: string | null
+    allMacros: PrinterStateMacro[]
+    filteredMacros: PrinterStateMacro[]
+    availableMacros: PrinterStateMacro[]
+    macroListLoaded: boolean
+    existsMacro(macroname: string): boolean
+    getMacroDescription(macroname: string): string | null
+}
+
+const MacrosTabExpertClass = SettingsMacrosTabExpert as unknown as new () => MacrosTabExpert
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const klipperReady = options.klipperReady ?? true
+
+    const component = new MacrosTabExpertClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            state: {
+                socket: { isConnected: klipperReady },
+                server: {
+                    klippy_connected: klipperReady,
+                    klippy_state: klipperReady ? 'ready' : 'shutdown',
+                },
+            },
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+                'gui/macros/getMacrogroup': () => options.group,
+            },
+        },
+    })
+
+    Object.defineProperty(component, '$t', { value: (key: string) => key })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+    component.editGroupId = 'group-1'
+
+    return component
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabExpert', () => {
+    describe('the search field only filters the available macros', () => {
+        it('keeps a group macro recognized while the search hides it', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'START',
+            })
+
+            expect(component.existsMacro('END_PRINT')).toBe(true)
+        })
+
+        it('keeps returning the real description of a macro hidden by the search', () => {
+            const component = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'START',
+            })
+
+            expect(component.getMacroDescription('END_PRINT')).toBe('Parks the toolhead')
+        })
+
+        it('still narrows the available macros list by name', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('still narrows the available macros list by description', () => {
+            const component = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('excludes macros already used in the edited group', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                group: { macros: [{ name: 'START_PRINT', pos: 1 }] as GuiMacrosStateMacrogroup['macros'] },
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+    })
+
+    describe('a cleared search field', () => {
+        it('does not throw when the search is null', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(macroNames(component.availableMacros)).toStrictEqual(['START_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(component.availableMacros).toStrictEqual([])
+        })
+    })
+
+    describe('deleted macro detection', () => {
+        it('reports a macro that is no longer in the config as deleted', () => {
+            const component = createComponent({ macros: [{ name: 'START_PRINT' }] })
+
+            expect(component.existsMacro('REMOVED_MACRO')).toBe(false)
+            expect(component.getMacroDescription('REMOVED_MACRO')).toBe('Settings.MacrosTab.DeletedMacro')
+        })
+
+        it('matches macro names case-insensitively', () => {
+            const component = createComponent({ macros: [{ name: 'Start_Print' }] })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.existsMacro('start_print')).toBe(true)
+        })
+
+        it('returns null instead of a description when the macro has no help text', () => {
+            const component = createComponent({ macros: [{ name: 'START_PRINT' }] })
+
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+        })
+
+        it('does not report macros as deleted while klipper is not ready', () => {
+            const component = createComponent({ macros: [], klipperReady: false })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+        })
+
+        it('does not report macros as deleted while the macro list is still empty', () => {
+            const component = createComponent({ macros: [], klipperReady: true })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+        })
+    })
+})

--- a/tests/components/settings/settingsMacrosTabSimple.spec.ts
+++ b/tests/components/settings/settingsMacrosTabSimple.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import SettingsMacrosTabSimple from '@/components/settings/SettingsMacrosTabSimple.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    hiddenMacros?: string[]
+    search?: string | null
+}
+
+interface MacrosTabSimple {
+    searchMacros: string | null
+    macros: PrinterStateMacro[]
+    hiddenMacros: string[]
+    getMacroStatus(name: string): boolean
+    changeMacroStatus(name: string): void
+}
+
+const MacrosTabSimpleClass = SettingsMacrosTabSimple as unknown as new () => MacrosTabSimple
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const dispatch = vi.fn()
+    const component = new MacrosTabSimpleClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            state: {
+                gui: { macros: { hiddenMacros: options.hiddenMacros ?? [] } },
+            },
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+            },
+            dispatch,
+        },
+    })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+
+    return { component, dispatch }
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabSimple', () => {
+    describe('search', () => {
+        it('filters by macro name', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('filters by macro description', () => {
+            const { component } = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('does not throw and lists every macro when the search is null', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(macroNames(component.macros)).toStrictEqual(['START_PRINT', 'END_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(component.macros).toStrictEqual([])
+        })
+    })
+
+    describe('hiding macros', () => {
+        it('reports a macro as enabled when it is not hidden', () => {
+            const { component } = createComponent({ hiddenMacros: ['END_PRINT'] })
+
+            expect(component.getMacroStatus('START_PRINT')).toBe(true)
+            expect(component.getMacroStatus('END_PRINT')).toBe(false)
+        })
+
+        it('hides a visible macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: [] })
+
+            component.changeMacroStatus('Start_Print')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['START_PRINT'],
+            })
+        })
+
+        it('unhides an already hidden macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: ['START_PRINT', 'END_PRINT'] })
+
+            component.changeMacroStatus('START_PRINT')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['END_PRINT'],
+            })
+        })
+    })
+})

--- a/tests/store/printer/getMacros.spec.ts
+++ b/tests/store/printer/getMacros.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { getters } from '@/store/printer/getters'
+import type { PrinterState, PrinterStateMacro } from '@/store/printer/types'
+import type { RootState } from '@/store/types'
+
+const runGetter = (state: Record<string, unknown>): PrinterStateMacro[] => {
+    return getters.getMacros(state as unknown as PrinterState, {}, {} as RootState, {})
+}
+
+describe('printer/getMacros', () => {
+    it('returns the gcode_macro objects with their help text as description', () => {
+        const macros = runGetter({
+            configfile: { settings: { 'gcode_macro start_print': { gcode: 'G28' } } },
+            gcode: { commands: { START_PRINT: { help: 'Heats up and homes' } } },
+            'gcode_macro START_PRINT': { bed_temp: 60 },
+        })
+
+        expect(macros).toHaveLength(1)
+        expect(macros[0].name).toBe('START_PRINT')
+        expect(macros[0].description).toBe('Heats up and homes')
+        expect(macros[0].variables).toStrictEqual({ bed_temp: 60 })
+    })
+
+    it('sorts the macros case-insensitively', () => {
+        const macros = runGetter({
+            configfile: { settings: {} },
+            'gcode_macro zzz_macro': {},
+            'gcode_macro Alpha': {},
+            'gcode_macro beta': {},
+        })
+
+        expect(macros.map((macro) => macro.name)).toStrictEqual(['Alpha', 'beta', 'zzz_macro'])
+    })
+
+    it('hides macros starting with an underscore', () => {
+        const macros = runGetter({
+            configfile: { settings: {} },
+            'gcode_macro _INTERNAL': {},
+            'gcode_macro START_PRINT': {},
+        })
+
+        expect(macros.map((macro) => macro.name)).toStrictEqual(['START_PRINT'])
+    })
+
+    it('hides macros that override an existing command via rename_existing', () => {
+        const macros = runGetter({
+            configfile: {
+                settings: {
+                    'gcode_macro pause': { rename_existing: 'BASE_PAUSE' },
+                },
+            },
+            'gcode_macro PAUSE': {},
+            'gcode_macro START_PRINT': {},
+        })
+
+        expect(macros.map((macro) => macro.name)).toStrictEqual(['START_PRINT'])
+    })
+
+    it('sets the description to null when the macro has no help text', () => {
+        const macros = runGetter({
+            configfile: { settings: {} },
+            gcode: { commands: {} },
+            'gcode_macro START_PRINT': {},
+        })
+
+        expect(macros[0].description).toBeNull()
+    })
+
+    it('does not throw when configfile is missing', () => {
+        expect(() => runGetter({ 'gcode_macro START_PRINT': {} })).not.toThrow()
+        expect(runGetter({ 'gcode_macro START_PRINT': {} }).map((macro) => macro.name)).toStrictEqual(['START_PRINT'])
+    })
+
+    it('does not throw when configfile.settings is missing', () => {
+        expect(() => runGetter({ configfile: {}, 'gcode_macro START_PRINT': {} })).not.toThrow()
+    })
+
+    it('returns an empty list when no printer objects are loaded', () => {
+        expect(runGetter({})).toStrictEqual([])
+    })
+})


### PR DESCRIPTION
## Description

This PR fixes two bugs in the macros settings, plus a TypeError in `printer/getMacros`.

### 1. The search field labels group macros as deleted

`allMacros` in `SettingsMacrosTabExpert` returned the search-filtered macro list, and `existsMacro()` and `getMacroDescription()` used that same list to decide whether a macro still exists in the printer config.

Type anything into the Available Macros search box, and every macro in the edited group that does not match the search picks up the `Deleted macro` subtitle. Its color and visibility buttons vanish too, since `v-if="existsMacro(macro.name)"` turns false. The macros themselves are intact. The lookup was wrong.

Fix: `allMacros` now returns the unfiltered list. A new `filteredMacros` getter applies the search, and only `availableMacros` reads it.

### 2. Clearing the search field breaks both tabs

Both tabs pass `clearable` to their `v-text-field`. Vuetify resets the model to `null` when you click the clear icon, `searchMacros.toLowerCase()` throws, the computed fails, and the macro list stops rendering until you navigate away.

Fix: both tabs type `searchMacros` as `string | null` and coerce it before lowercasing.

### 3. TypeError in printer/getMacros when configfile is missing

`getMacros` defaulted `settings` to `null` when `state.configfile?.settings` was absent, then indexed it on the next line, so any state carrying `gcode_macro` objects without a populated configfile throws `Cannot read properties of null`. It now defaults to `{}`, the same shape as the fix in #2580 on this file.

I left the second `?? null` in `existsZtilt` alone. The `if (settings)` check right below it depends on the null.

## Related Tickets & Documents

No existing issue. I searched open and closed issues for `macro` and `deleted macro` and found nothing that matches.

## Mobile & Desktop Screenshots/Recordings

I have no Moonraker instance to serve a build against, so I cannot supply before and after screenshots. Happy to add them if a maintainer wants them before merge.

Issue 1 reproduces in a few seconds:

1. Settings > Macros, set Management to Expert
2. Create a group and add two or more macros to it
3. Type part of one macro name into the Available Macros search box
4. On develop, every group macro that does not match shows `Deleted macro` and loses its color and visibility buttons. On this branch the group list stays put.

Unit tests cover all three fixes. Every regression test in them fails against develop and passes here:

- `tests/store/printer/getMacros.spec.ts` (8 tests)
- `tests/components/settings/settingsMacrosTabExpert.spec.ts` (10 tests)
- `tests/components/settings/settingsMacrosTabSimple.spec.ts` (7 tests)

`npx vitest run` reports 47 passing across 6 files. `npx vite build` and `eslint src` come back clean.

## [optional] Are there any post-deployment tasks we need to perform?

None.

🤖 This Pull Request was created with the help of Claude Code.
