### PR TITLE
fix(macros): keep the macro settings usable after clearing the search

### DIFF
--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -353,7 +353,7 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
 
     private boolFormEdit = false
     private editGroupId: string | null = ''
-    private searchMacros: string = ''
+    private searchMacros: string | null = ''
 
     get groupColors() {
         return [
@@ -398,11 +398,13 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
     }
 
     get allMacros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
         const macros = this.$store.getters['printer/getMacros'] ?? []
+
         return macros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }

--- a/src/components/settings/SettingsMacrosTabSimple.vue
+++ b/src/components/settings/SettingsMacrosTabSimple.vue
@@ -52,14 +52,16 @@ import { PrinterStateMacro } from '@/store/printer/types'
 })
 export default class SettingsMacrosTabSimple extends Mixins(BaseMixin) {
     mdiMagnify = mdiMagnify
-    searchMacros: string = ''
+    searchMacros: string | null = ''
 
     get macros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
         const macros = this.$store.getters['printer/getMacros'] ?? []
+
         return macros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }

--- a/tests/components/settings/settingsMacrosTabExpert.spec.ts
+++ b/tests/components/settings/settingsMacrosTabExpert.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import SettingsMacrosTabExpert from '@/components/settings/SettingsMacrosTabExpert.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+import type { GuiMacrosStateMacrogroup } from '@/store/gui/macros/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    group?: Partial<GuiMacrosStateMacrogroup>
+    search?: string | null
+}
+
+interface MacrosTabExpert {
+    searchMacros: string | null
+    editGroupId: string | null
+    allMacros: PrinterStateMacro[]
+    availableMacros: PrinterStateMacro[]
+}
+
+const MacrosTabExpertClass = SettingsMacrosTabExpert as unknown as new () => MacrosTabExpert
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const component = new MacrosTabExpertClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+                'gui/macros/getMacrogroup': () => options.group,
+            },
+        },
+    })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+    component.editGroupId = 'group-1'
+
+    return component
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabExpert', () => {
+    describe('search', () => {
+        it('filters by macro name', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('filters by macro description', () => {
+            const component = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('excludes macros already used in the edited group', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                group: { macros: [{ name: 'START_PRINT', pos: 1 }] as GuiMacrosStateMacrogroup['macros'] },
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+    })
+
+    describe('a cleared search field', () => {
+        it('does not throw when the search is null', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(macroNames(component.availableMacros)).toStrictEqual(['START_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(component.availableMacros).toStrictEqual([])
+        })
+    })
+})

--- a/tests/components/settings/settingsMacrosTabSimple.spec.ts
+++ b/tests/components/settings/settingsMacrosTabSimple.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import SettingsMacrosTabSimple from '@/components/settings/SettingsMacrosTabSimple.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    hiddenMacros?: string[]
+    search?: string | null
+}
+
+interface MacrosTabSimple {
+    searchMacros: string | null
+    macros: PrinterStateMacro[]
+    hiddenMacros: string[]
+    getMacroStatus(name: string): boolean
+    changeMacroStatus(name: string): void
+}
+
+const MacrosTabSimpleClass = SettingsMacrosTabSimple as unknown as new () => MacrosTabSimple
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const dispatch = vi.fn()
+    const component = new MacrosTabSimpleClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            state: {
+                gui: { macros: { hiddenMacros: options.hiddenMacros ?? [] } },
+            },
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+            },
+            dispatch,
+        },
+    })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+
+    return { component, dispatch }
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabSimple', () => {
+    describe('search', () => {
+        it('filters by macro name', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('filters by macro description', () => {
+            const { component } = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('does not throw and lists every macro when the search is null', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(macroNames(component.macros)).toStrictEqual(['START_PRINT', 'END_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(component.macros).toStrictEqual([])
+        })
+    })
+
+    describe('hiding macros', () => {
+        it('reports a macro as enabled when it is not hidden', () => {
+            const { component } = createComponent({ hiddenMacros: ['END_PRINT'] })
+
+            expect(component.getMacroStatus('START_PRINT')).toBe(true)
+            expect(component.getMacroStatus('END_PRINT')).toBe(false)
+        })
+
+        it('hides a visible macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: [] })
+
+            component.changeMacroStatus('Start_Print')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['START_PRINT'],
+            })
+        })
+
+        it('unhides an already hidden macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: ['START_PRINT', 'END_PRINT'] })
+
+            component.changeMacroStatus('START_PRINT')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['END_PRINT'],
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Description

Both macro settings tabs have `clearable` on the search field, and Vuetify sets the model to `null` when you hit the ✕. `searchMacros.toLowerCase()` then throws, the computed list dies, and the macro list stays empty until you close and reopen the settings.

Fix: type `searchMacros` as `string | null` in both tabs and fall back to `''` before lowercasing. Added `?? false` on the description half of the filter so it stays a boolean.

Repro on develop:

1. Settings > Macros (either mode)
2. Type something in the search box
3. Click the ✕
4. List is gone, console says `Cannot read properties of null (reading 'toLowerCase')`

Added tests for both tabs. The two null-search ones fail on develop.

## Related Tickets & Documents

No issue. Split out of #2613. Independent of #2617. The third one (`Deleted macro` label showing while searching) touches the same getter in the expert tab, so I'll open it on top of this branch.

## Mobile & Desktop Screenshots/Recordings

No Moonraker instance here, so no before/after. Nothing visual changes anyway — it just stops the exception that emptied the list. Repro steps above.

## [optional] Are there any post-deployment tasks we need to perform?

No.