### PR TITLE
fix(macros): stop marking existing macros as deleted in the settings

### DIFF
--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -397,11 +397,14 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
         return colors
     }
 
-    get allMacros() {
-        const search = (this.searchMacros ?? '').toLowerCase()
-        const macros = this.$store.getters['printer/getMacros'] ?? []
+    get allMacros(): PrinterStateMacro[] {
+        return this.$store.getters['printer/getMacros'] ?? []
+    }
 
-        return macros.filter((macro: PrinterStateMacro) => {
+    get filteredMacros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
+
+        return this.allMacros.filter((macro: PrinterStateMacro) => {
             return (
                 macro.name.toLowerCase().includes(search) ||
                 (macro.description?.toLowerCase().includes(search) ?? false)
@@ -410,7 +413,7 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
     }
 
     get availableMacros() {
-        return this.allMacros.filter((m: GuiMacrosStateMacrogroupMacro) => !this.editGroupUsedMacros.includes(m.name))
+        return this.filteredMacros.filter((m: PrinterStateMacro) => !this.editGroupUsedMacros.includes(m.name))
     }
 
     get groups() {
@@ -514,17 +517,26 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
         })
     }
 
+    get macroListLoaded() {
+        return this.klipperReadyForGui && this.allMacros.length > 0
+    }
+
+    findMacro(macroname: string) {
+        return this.allMacros.find((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase())
+    }
+
     existsMacro(macroname: string) {
-        return (
-            this.allMacros.findIndex((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase()) !== -1
-        )
+        if (!this.macroListLoaded) return true
+
+        return this.findMacro(macroname) !== undefined
     }
 
     getMacroDescription(macroname: string) {
-        const macro = this.allMacros.find((m: PrinterStateMacro) => m.name.toLowerCase() === macroname.toLowerCase())
-        if (!macro) return this.$t('Settings.MacrosTab.DeletedMacro')
+        const macro = this.findMacro(macroname)
+        if (macro) return macro.description ?? null
+        if (!this.macroListLoaded) return null
 
-        return macro?.description ?? null
+        return this.$t('Settings.MacrosTab.DeletedMacro')
     }
 
     updateMacrogroupOption(option: string, newVal: boolean | string) {

--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -518,7 +518,7 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
     }
 
     get macroListLoaded() {
-        return this.klipperReadyForGui && this.allMacros.length > 0
+        return this.klipperReadyForGui
     }
 
     findMacro(macroname: string) {

--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -353,7 +353,7 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
 
     private boolFormEdit = false
     private editGroupId: string | null = ''
-    private searchMacros: string = ''
+    private searchMacros: string | null = ''
 
     get groupColors() {
         return [
@@ -398,11 +398,13 @@ export default class SettingsMacrosTabExpert extends Mixins(BaseMixin, ThemeMixi
     }
 
     get allMacros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
         const macros = this.$store.getters['printer/getMacros'] ?? []
+
         return macros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }

--- a/src/components/settings/SettingsMacrosTabSimple.vue
+++ b/src/components/settings/SettingsMacrosTabSimple.vue
@@ -52,14 +52,16 @@ import { PrinterStateMacro } from '@/store/printer/types'
 })
 export default class SettingsMacrosTabSimple extends Mixins(BaseMixin) {
     mdiMagnify = mdiMagnify
-    searchMacros: string = ''
+    searchMacros: string | null = ''
 
     get macros() {
+        const search = (this.searchMacros ?? '').toLowerCase()
         const macros = this.$store.getters['printer/getMacros'] ?? []
+
         return macros.filter((macro: PrinterStateMacro) => {
             return (
-                macro.name.toLowerCase().includes(this.searchMacros.toLowerCase()) ||
-                macro.description?.toLowerCase().includes(this.searchMacros.toLowerCase())
+                macro.name.toLowerCase().includes(search) ||
+                (macro.description?.toLowerCase().includes(search) ?? false)
             )
         })
     }

--- a/tests/components/settings/settingsMacrosTabExpert.spec.ts
+++ b/tests/components/settings/settingsMacrosTabExpert.spec.ts
@@ -7,28 +7,44 @@ type ComponentOptions = {
     macros?: Partial<PrinterStateMacro>[]
     group?: Partial<GuiMacrosStateMacrogroup>
     search?: string | null
+    klipperReady?: boolean
 }
 
 interface MacrosTabExpert {
     searchMacros: string | null
     editGroupId: string | null
     allMacros: PrinterStateMacro[]
+    filteredMacros: PrinterStateMacro[]
     availableMacros: PrinterStateMacro[]
+    macroListLoaded: boolean
+    existsMacro(macroname: string): boolean
+    getMacroDescription(macroname: string): string | null
 }
 
 const MacrosTabExpertClass = SettingsMacrosTabExpert as unknown as new () => MacrosTabExpert
 
 const createComponent = (options: ComponentOptions = {}) => {
+    const klipperReady = options.klipperReady ?? true
+
     const component = new MacrosTabExpertClass()
 
     Object.defineProperty(component, '$store', {
         value: {
+            state: {
+                socket: { isConnected: klipperReady },
+                server: {
+                    klippy_connected: klipperReady,
+                    klippy_state: klipperReady ? 'ready' : 'shutdown',
+                },
+            },
             getters: {
                 'printer/getMacros': options.macros ?? [],
                 'gui/macros/getMacrogroup': () => options.group,
             },
         },
     })
+
+    Object.defineProperty(component, '$t', { value: (key: string) => key })
 
     component.searchMacros = 'search' in options ? (options.search as string | null) : ''
     component.editGroupId = 'group-1'
@@ -39,8 +55,29 @@ const createComponent = (options: ComponentOptions = {}) => {
 const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
 
 describe('SettingsMacrosTabExpert', () => {
-    describe('search', () => {
-        it('filters by macro name', () => {
+    describe('the search field only filters the available macros', () => {
+        it('keeps a group macro recognized while the search hides it', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'START',
+            })
+
+            expect(component.existsMacro('END_PRINT')).toBe(true)
+        })
+
+        it('keeps returning the real description of a macro hidden by the search', () => {
+            const component = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'START',
+            })
+
+            expect(component.getMacroDescription('END_PRINT')).toBe('Parks the toolhead')
+        })
+
+        it('still narrows the available macros list by name', () => {
             const component = createComponent({
                 macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
                 search: 'end',
@@ -49,7 +86,7 @@ describe('SettingsMacrosTabExpert', () => {
             expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
         })
 
-        it('filters by macro description', () => {
+        it('still narrows the available macros list by description', () => {
             const component = createComponent({
                 macros: [
                     { name: 'START_PRINT', description: 'Heats up and homes' },
@@ -90,6 +127,42 @@ describe('SettingsMacrosTabExpert', () => {
 
             expect(() => component.availableMacros).not.toThrow()
             expect(component.availableMacros).toStrictEqual([])
+        })
+    })
+
+    describe('deleted macro detection', () => {
+        it('reports a macro that is no longer in the config as deleted', () => {
+            const component = createComponent({ macros: [{ name: 'START_PRINT' }] })
+
+            expect(component.existsMacro('REMOVED_MACRO')).toBe(false)
+            expect(component.getMacroDescription('REMOVED_MACRO')).toBe('Settings.MacrosTab.DeletedMacro')
+        })
+
+        it('matches macro names case-insensitively', () => {
+            const component = createComponent({ macros: [{ name: 'Start_Print' }] })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.existsMacro('start_print')).toBe(true)
+        })
+
+        it('returns null instead of a description when the macro has no help text', () => {
+            const component = createComponent({ macros: [{ name: 'START_PRINT' }] })
+
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+        })
+
+        it('does not report macros as deleted while klipper is not ready', () => {
+            const component = createComponent({ macros: [], klipperReady: false })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+        })
+
+        it('does not report macros as deleted while the macro list is still empty', () => {
+            const component = createComponent({ macros: [], klipperReady: true })
+
+            expect(component.existsMacro('START_PRINT')).toBe(true)
+            expect(component.getMacroDescription('START_PRINT')).toBeNull()
         })
     })
 })

--- a/tests/components/settings/settingsMacrosTabExpert.spec.ts
+++ b/tests/components/settings/settingsMacrosTabExpert.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import SettingsMacrosTabExpert from '@/components/settings/SettingsMacrosTabExpert.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+import type { GuiMacrosStateMacrogroup } from '@/store/gui/macros/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    group?: Partial<GuiMacrosStateMacrogroup>
+    search?: string | null
+}
+
+interface MacrosTabExpert {
+    searchMacros: string | null
+    editGroupId: string | null
+    allMacros: PrinterStateMacro[]
+    availableMacros: PrinterStateMacro[]
+}
+
+const MacrosTabExpertClass = SettingsMacrosTabExpert as unknown as new () => MacrosTabExpert
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const component = new MacrosTabExpertClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+                'gui/macros/getMacrogroup': () => options.group,
+            },
+        },
+    })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+    component.editGroupId = 'group-1'
+
+    return component
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabExpert', () => {
+    describe('search', () => {
+        it('filters by macro name', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('filters by macro description', () => {
+            const component = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('excludes macros already used in the edited group', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                group: { macros: [{ name: 'START_PRINT', pos: 1 }] as GuiMacrosStateMacrogroup['macros'] },
+            })
+
+            expect(macroNames(component.availableMacros)).toStrictEqual(['END_PRINT'])
+        })
+    })
+
+    describe('a cleared search field', () => {
+        it('does not throw when the search is null', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(macroNames(component.availableMacros)).toStrictEqual(['START_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const component = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.availableMacros).not.toThrow()
+            expect(component.availableMacros).toStrictEqual([])
+        })
+    })
+})

--- a/tests/components/settings/settingsMacrosTabExpert.spec.ts
+++ b/tests/components/settings/settingsMacrosTabExpert.spec.ts
@@ -158,11 +158,11 @@ describe('SettingsMacrosTabExpert', () => {
             expect(component.getMacroDescription('START_PRINT')).toBeNull()
         })
 
-        it('does not report macros as deleted while the macro list is still empty', () => {
+        it('reports a macro as deleted once klipper is ready with a genuinely empty macro list', () => {
             const component = createComponent({ macros: [], klipperReady: true })
 
-            expect(component.existsMacro('START_PRINT')).toBe(true)
-            expect(component.getMacroDescription('START_PRINT')).toBeNull()
+            expect(component.existsMacro('START_PRINT')).toBe(false)
+            expect(component.getMacroDescription('START_PRINT')).toBe('Settings.MacrosTab.DeletedMacro')
         })
     })
 })

--- a/tests/components/settings/settingsMacrosTabSimple.spec.ts
+++ b/tests/components/settings/settingsMacrosTabSimple.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import SettingsMacrosTabSimple from '@/components/settings/SettingsMacrosTabSimple.vue'
+import type { PrinterStateMacro } from '@/store/printer/types'
+
+type ComponentOptions = {
+    macros?: Partial<PrinterStateMacro>[]
+    hiddenMacros?: string[]
+    search?: string | null
+}
+
+interface MacrosTabSimple {
+    searchMacros: string | null
+    macros: PrinterStateMacro[]
+    hiddenMacros: string[]
+    getMacroStatus(name: string): boolean
+    changeMacroStatus(name: string): void
+}
+
+const MacrosTabSimpleClass = SettingsMacrosTabSimple as unknown as new () => MacrosTabSimple
+
+const createComponent = (options: ComponentOptions = {}) => {
+    const dispatch = vi.fn()
+    const component = new MacrosTabSimpleClass()
+
+    Object.defineProperty(component, '$store', {
+        value: {
+            state: {
+                gui: { macros: { hiddenMacros: options.hiddenMacros ?? [] } },
+            },
+            getters: {
+                'printer/getMacros': options.macros ?? [],
+            },
+            dispatch,
+        },
+    })
+
+    component.searchMacros = 'search' in options ? (options.search as string | null) : ''
+
+    return { component, dispatch }
+}
+
+const macroNames = (macros: PrinterStateMacro[]) => macros.map((macro) => macro.name)
+
+describe('SettingsMacrosTabSimple', () => {
+    describe('search', () => {
+        it('filters by macro name', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: 'end',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('filters by macro description', () => {
+            const { component } = createComponent({
+                macros: [
+                    { name: 'START_PRINT', description: 'Heats up and homes' },
+                    { name: 'END_PRINT', description: 'Parks the toolhead' },
+                ],
+                search: 'parks',
+            })
+
+            expect(macroNames(component.macros)).toStrictEqual(['END_PRINT'])
+        })
+
+        it('does not throw and lists every macro when the search is null', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT' }, { name: 'END_PRINT' }],
+                search: null,
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(macroNames(component.macros)).toStrictEqual(['START_PRINT', 'END_PRINT'])
+        })
+
+        it('does not throw when a macro has no description', () => {
+            const { component } = createComponent({
+                macros: [{ name: 'START_PRINT', description: null }],
+                search: 'nomatch',
+            })
+
+            expect(() => component.macros).not.toThrow()
+            expect(component.macros).toStrictEqual([])
+        })
+    })
+
+    describe('hiding macros', () => {
+        it('reports a macro as enabled when it is not hidden', () => {
+            const { component } = createComponent({ hiddenMacros: ['END_PRINT'] })
+
+            expect(component.getMacroStatus('START_PRINT')).toBe(true)
+            expect(component.getMacroStatus('END_PRINT')).toBe(false)
+        })
+
+        it('hides a visible macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: [] })
+
+            component.changeMacroStatus('Start_Print')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['START_PRINT'],
+            })
+        })
+
+        it('unhides an already hidden macro', () => {
+            const { component, dispatch } = createComponent({ hiddenMacros: ['START_PRINT', 'END_PRINT'] })
+
+            component.changeMacroStatus('START_PRINT')
+
+            expect(dispatch).toHaveBeenCalledWith('gui/macros/saveSetting', {
+                name: 'hiddenMacros',
+                value: ['END_PRINT'],
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Description

The expert tab's `allMacros` returned the search-filtered macro list, and `existsMacro()` / `getMacroDescription()` used that same list to check if a macro still exists. Typing into the search box labelled every non-matching macro in the edited group as "Deleted macro" and hid its color/visibility buttons.

`allMacros` now returns the unfiltered list. A new `filteredMacros` getter applies the search and is only used by `availableMacros`.

Also guards `existsMacro`/`getMacroDescription` against running before the macro list has loaded, so macros aren't reported as deleted while Klipper isn't ready yet.

This is the third of three PRs splitting up #2613.

## Related Tickets & Documents

No existing issue. Split out of #2613 at a maintainer's request.

## Mobile & Desktop Screenshots/Recordings

No Moonraker instance available to screenshot against. Repro:

1. Settings > Macros, Management: Expert
2. Create a group, add two or more macros
3. Type part of one macro name into the Available Macros search box
4. On develop, every non-matching group macro shows "Deleted macro" and loses its buttons. On this branch the group list stays put.

## [optional] Are there any post-deployment tasks we need to perform?

None.

Signed-off-by: Åsmund Collin <aakjaergaard@gmail.com>

🤖 This Pull Request was created with the help of Claude Code.
