### PR TITLE
fix(printer): use forEach instead of non-existent foreach in getFans

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -194,7 +194,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
         const controllableFans = ['fan_generic', 'fan']
 
-        objects.foreach((object: PrinterGetterObject) => {
+        objects.forEach((object: PrinterGetterObject) => {
             fans.push({
                 name: object.name,
                 type: object.type,


### PR DESCRIPTION
## Description

The `getFans` getter in `src/store/printer/getters.ts` iterates its objects array with `objects.foreach(...)`:

```ts
objects.foreach((object: PrinterGetterObject) => {
```

Arrays expose `forEach`, not `foreach`, so this line throws `TypeError: objects.foreach is not a function` the moment `getFans` is evaluated.

The getter currently has no callers in the codebase, so the bug is latent today — but any use of `printer/getFans` throws immediately. I ran into it while working with this getter.

## Fix

One-character correction: `foreach` → `forEach`.

## Checklist
- [x] `npx eslint --max-warnings 0` passes
- [x] `npx prettier --check` passes