### PR TITLE
perf(heightmap): avoid full chart rebuild on scaleZMax change

### DIFF
--- a/src/components/charts/HeightmapChart.vue
+++ b/src/components/charts/HeightmapChart.vue
@@ -59,16 +59,6 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
 
     declare private appliedScaleZMax: number
 
-    created(): void {
-        this.appliedScaleZMax = this.scaleZMax
-    }
-
-    @Watch('scaleZMax')
-    scaleZMaxChanged(newVal: number): void {
-        this.appliedScaleZMax = newVal
-        this.chart?.setOption({ zAxis3D: { min: newVal * -1, max: newVal } })
-    }
-
     get chart(): ECharts | null {
         return this.heightmap?.chart ?? null
     }
@@ -437,10 +427,20 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
         return outputArray.join('<br />')
     }
 
+    created(): void {
+        this.appliedScaleZMax = this.scaleZMax
+    }
+
     beforeDestroy(): void {
         if (typeof window === 'undefined') return
 
         this.chart?.dispose()
+    }
+
+    @Watch('scaleZMax')
+    scaleZMaxChanged(newVal: number): void {
+        this.appliedScaleZMax = newVal
+        this.chart?.setOption({ zAxis3D: { min: newVal * -1, max: newVal } })
     }
 }
 </script>

--- a/src/components/charts/HeightmapChart.vue
+++ b/src/components/charts/HeightmapChart.vue
@@ -7,7 +7,7 @@
         style="height: 600px" />
 </template>
 <script lang="ts">
-import { Component, Mixins, Prop, Ref } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import BedmeshMixin from '@/components/mixins/bedmesh'
 
@@ -56,6 +56,18 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
     @Prop({ type: Number, default: 1 }) scaleZMax!: number
 
     @Ref('heightmap') readonly heightmap!: EChartRef | undefined
+
+    declare private appliedScaleZMax: number
+
+    created(): void {
+        this.appliedScaleZMax = this.scaleZMax
+    }
+
+    @Watch('scaleZMax')
+    scaleZMaxChanged(newVal: number): void {
+        this.appliedScaleZMax = newVal
+        this.chart?.setOption({ zAxis3D: { min: newVal * -1, max: newVal } })
+    }
 
     get chart(): ECharts | null {
         return this.heightmap?.chart ?? null
@@ -119,8 +131,8 @@ export default class HeightmapChart extends Mixins(BaseMixin, BedmeshMixin, Them
             },
             zAxis3D: {
                 type: 'value',
-                min: this.scaleZMax * -1,
-                max: this.scaleZMax,
+                min: this.appliedScaleZMax * -1,
+                max: this.appliedScaleZMax,
                 nameTextStyle: {
                     color: this.fgColorMid,
                 },


### PR DESCRIPTION
<!--
  ⚠️ IMPORTANT: Pull requests from contributors who are not on the vouched list
  (.github/VOUCHED.td) are automatically closed. See the Contributing Guidelines
  for details:
  https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#vouch
  If your PR gets closed, a maintainer can vouch for you; afterward reopen it
  or comment /recheck.


  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#submit-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots


  Note for AI assistants: If you (an AI tool/agent) are generating this Pull Request,
  please disclose it by appending the following line as the very last line of the
  entire Pull Request description and replace <tool> with your name (e.g. pi,
  Claude Code, Codex, GitHub Copilot, Cursor):

  🤖 This Pull Request was created with the help of <tool>.
-->

## Description

chartOptions returns a new object every time, so vue-echarts' notMerge check (option !== oldOption) always trips and rebuilds the whole scene. Patch zAxis3D directly instead, like TempChart does for its dataset.

This is scoped to changing the scale z-max, so no interference with new or adaptive mesh.

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

https://github.com/user-attachments/assets/6863e0a7-ba00-4bdd-ab52-9059f186cb26

## [optional] Are there any post-deployment tasks we need to perform?

No
