### PR TITLE
fix(afc): fix get laneName getter in StartPrintDialog

### DIFF
--- a/src/components/dialogs/StartPrintDialogAfcTool.vue
+++ b/src/components/dialogs/StartPrintDialogAfcTool.vue
@@ -76,12 +76,21 @@ export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
 
     get laneName() {
         const lanes = this.afc?.lanes ?? []
+        const toolNameLower = this.toolName.toLowerCase()
 
         return lanes.find((lane: string) => {
             const laneObject = this.getAfcLaneObject(lane)
-            const mappedTool = laneObject?.map?.toLowerCase()
+            const mappedTool = laneObject?.map ?? ''
 
-            return mappedTool === this.toolName.toLowerCase()
+            if (Array.isArray(mappedTool)) {
+                return mappedTool.some((t: string) => t.toLowerCase() === toolNameLower)
+            }
+
+            if (typeof mappedTool === 'string') {
+                return mappedTool.toLowerCase() === toolNameLower
+            }
+
+            return false
         })
     }
 


### PR DESCRIPTION
## Description

This is just a part from the combined PR #2598 . It fixes the laneName getter in the StartPrintDialog. The new AFC-dev branch use an array instead of the string for laneObject.map.

## Related Tickets & Documents

- This PR is a part of #2598  

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
