### PR TITLE
fix(logfiles): fix button with in Safari browser

### DIFF
--- a/src/components/panels/Machine/LogfilesPanel.vue
+++ b/src/components/panels/Machine/LogfilesPanel.vue
@@ -1,35 +1,33 @@
 <template>
-    <div>
-        <panel
-            :title="$t('Machine.LogfilesPanel.Logfiles')"
-            :icon="mdiFileDocumentEdit"
-            card-class="machine-logfiles-panel"
-            :collapsible="true">
-            <template #buttons>
-                <v-tooltip top>
-                    <template #activator="{ on, attrs }">
-                        <v-btn
-                            icon
-                            tile
-                            color="primary"
-                            :ripple="true"
-                            :loading="loadings.includes('loadingBtnRolloverLogs')"
-                            :disabled="['printing', 'paused'].includes(printer_state)"
-                            v-bind="attrs"
-                            v-on="on"
-                            @click="showRolloverDialog = true">
-                            <v-icon>{{ mdiFileSyncOutline }}</v-icon>
-                        </v-btn>
-                    </template>
-                    <span>{{ $t('Machine.LogfilesPanel.Rollover') }}</span>
-                </v-tooltip>
-            </template>
-            <v-card-text class="logfiles-grid pa-3">
-                <logfiles-panel-generic-log v-for="logfile in logfiles" :key="logfile" :name="logfile" />
-            </v-card-text>
-        </panel>
+    <panel
+        :title="$t('Machine.LogfilesPanel.Logfiles')"
+        :icon="mdiFileDocumentEdit"
+        card-class="machine-logfiles-panel"
+        :collapsible="true">
+        <template #buttons>
+            <v-tooltip top>
+                <template #activator="{ on, attrs }">
+                    <v-btn
+                        icon
+                        tile
+                        color="primary"
+                        :ripple="true"
+                        :loading="loadings.includes('loadingBtnRolloverLogs')"
+                        :disabled="['printing', 'paused'].includes(printer_state)"
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="showRolloverDialog = true">
+                        <v-icon>{{ mdiFileSyncOutline }}</v-icon>
+                    </v-btn>
+                </template>
+                <span>{{ $t('Machine.LogfilesPanel.Rollover') }}</span>
+            </v-tooltip>
+        </template>
+        <v-card-text class="logfiles-grid pa-3">
+            <logfiles-panel-generic-log v-for="logfile in logfiles" :key="logfile" :name="logfile" />
+        </v-card-text>
         <logfiles-panel-rollover-dialog v-model="showRolloverDialog" />
-    </div>
+    </panel>
 </template>
 
 <script lang="ts">

--- a/src/components/panels/Machine/LogfilesPanel/LogfilesPanelGenericLog.vue
+++ b/src/components/panels/Machine/LogfilesPanel/LogfilesPanelGenericLog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-btn :href="href" block class="primary--text" @click="downloadLog">
+    <v-btn :href="href" class="primary--text logfile-btn" @click="downloadLog">
         <v-icon class="mr-2">{{ mdiDownload }}</v-icon>
         {{ name }}
     </v-btn>
@@ -36,3 +36,10 @@ export default class LogfilesPanel extends Mixins(BaseMixin) {
     }
 }
 </script>
+
+<style scoped>
+.logfile-btn {
+    width: 100%;
+    min-width: 0 !important;
+}
+</style>


### PR DESCRIPTION
## Description

This PR fix a display issue from the logfile buttons when the button should be displayed full with. Safari interpretate "min-width: 100%" different then chome/firefox from the block attribute.

I also removed the wrapper div in the LogfilesPanel. This is not really part of the fix, I just want to refactor this also. I will merge this PR with rebase & merge to have both commit messages in the log.

## Related Tickets & Documents

fixes #2644 

## Mobile & Desktop Screenshots/Recordings

after this fix in Safari:
<img width="451" height="207" alt="Bildschirmfoto 2026-09-02 um 11 15 37" src="https://github.com/user-attachments/assets/8cc9d93a-8bb0-4e31-8bb5-ab8670091505" />

## [optional] Are there any post-deployment tasks we need to perform?

none
