### PR TITLE
fix(editor): add a visual divider between editor and sidebar

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -540,7 +540,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     clip-path: inset(0 0 0 -12px);
 }
 
-.theme--light .structure-sidebar {
+html.theme--light .structure-sidebar {
     border-left-color: rgba(0, 0, 0, 0.12);
     box-shadow: -4px 0 8px rgba(0, 0, 0, 0.12);
 }

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -535,7 +535,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     width: 300px;
     overflow-y: auto;
     max-height: calc(100vh - 48px);
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-left: 1px solid #272727;
     box-shadow: -4px 0 8px rgba(0, 0, 0, 0.35);
     clip-path: inset(0 0 0 -12px);
 }

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -537,6 +537,7 @@ export default class TheEditor extends Mixins(BaseMixin) {
     max-height: calc(100vh - 48px);
     border-left: 1px solid rgba(255, 255, 255, 0.12);
     box-shadow: -4px 0 8px rgba(0, 0, 0, 0.35);
+    clip-path: inset(0 0 0 -12px);
 }
 
 .theme--light .structure-sidebar {

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -530,9 +530,18 @@ export default class TheEditor extends Mixins(BaseMixin) {
 }
 
 .structure-sidebar {
+    position: relative;
+    z-index: 1;
     width: 300px;
     overflow-y: auto;
     max-height: calc(100vh - 48px);
+    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: -4px 0 8px rgba(0, 0, 0, 0.35);
+}
+
+.theme--light .structure-sidebar {
+    border-left-color: rgba(0, 0, 0, 0.12);
+    box-shadow: -4px 0 8px rgba(0, 0, 0, 0.12);
 }
 ._structure-sidebar-item {
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description

This PR just fix a visual issue in the editor, when your file is too short and you don't have a scrollbar between editor and sidebar. This PR add here a border line + shadow to the sidebar to fix this visual issue.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
<img width="1182" height="474" alt="Bildschirmfoto 2026-09-02 um 15 22 42" src="https://github.com/user-attachments/assets/f096702c-088a-4cae-b4c8-ded419f151ed" />

after dark mode:
<img width="1181" height="363" alt="Bildschirmfoto 2026-09-02 um 15 22 10" src="https://github.com/user-attachments/assets/4719bec8-9ced-4f8b-98c7-b410cf8c4a54" />

after light mode:
<img width="1179" height="436" alt="Bildschirmfoto 2026-09-02 um 15 21 25" src="https://github.com/user-attachments/assets/abc1d7cb-c9c9-46eb-9516-579ec667bfcc" />


## [optional] Are there any post-deployment tasks we need to perform?

none
