### PR TITLE
fix(StatusPanel): show thumbnail for gcode files in subfolders on dashboard

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -82,7 +82,9 @@ export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
     }
 
     startPrint(filename = '') {
-        filename = (this.currentPath + '/' + filename).substring(1)
+        if (!filename.includes('/')) {
+            filename = (this.currentPath + '/' + filename).substring(1)
+        }
         this.closeDialog()
         this.$socket.emit('printer.print.start', { filename: filename }, { action: 'switchToDashboard' })
     }

--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -83,10 +83,15 @@ export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
 
     startPrint(filename = '') {
         if (!filename.includes('/')) {
-            filename = (this.currentPath + '/' + filename).substring(1)
+            filename = `${this.currentPath}/${filename}`
         }
+
+        if (filename.startsWith('/')) {
+            filename = filename.substring(1)
+        }
+
         this.closeDialog()
-        this.$socket.emit('printer.print.start', { filename: filename }, { action: 'switchToDashboard' })
+        this.$socket.emit('printer.print.start', { filename }, { action: 'switchToDashboard' })
     }
 
     closeDialog() {

--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -41,6 +41,8 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
     }
 
     get currentPathWithoutSlash() {
+        const pos = this.file.filename.lastIndexOf('/')
+        if (pos > 0) return this.file.filename.slice(0, pos)
         if (this.currentPath.startsWith('/')) return this.currentPath.substring(1)
 
         return this.currentPath

--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -44,6 +44,7 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
         // Status/History panel items already carry the full relative path in `filename`.
         const pos = this.file.filename.lastIndexOf('/')
         if (pos > 0) return this.file.filename.slice(0, pos)
+        // Gcodefiles panel items are basename-only; currentPath supplies the folder.
         if (this.currentPath.startsWith('/')) return this.currentPath.substring(1)
 
         return this.currentPath

--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -42,8 +42,9 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
 
     get currentPathWithoutSlash() {
         // Status/History panel items already carry the full relative path in `filename`.
-        const pos = this.file.filename.lastIndexOf('/')
-        if (pos > 0) return this.file.filename.slice(0, pos)
+        const lastSlashPos = this.file.filename.lastIndexOf('/')
+        if (lastSlashPos > 0) return this.file.filename.slice(0, lastSlashPos)
+
         // Gcodefiles panel items are basename-only; currentPath supplies the folder.
         if (this.currentPath.startsWith('/')) return this.currentPath.substring(1)
 

--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -41,6 +41,7 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
     }
 
     get currentPathWithoutSlash() {
+        // Status/History panel items already carry the full relative path in `filename`.
         const pos = this.file.filename.lastIndexOf('/')
         if (pos > 0) return this.file.filename.slice(0, pos)
         if (this.currentPath.startsWith('/')) return this.currentPath.substring(1)

--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -123,8 +123,6 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
     @Prop({ type: Object, required: true }) item!: FileStateGcodefile
     @Prop({ type: Number, required: true }) contentTdWidth!: number
 
-    currentPath = ''
-
     contextMenuShow = false
     contextMenuX = 0
     contextMenuY = 0


### PR DESCRIPTION
## Description

Fixes the missing thumbnail on the dashboard's Start Job dialog for gcode files in subfolders.
Full discussion and reasoning in #2639.

## Related Tickets & Documents

Fixes #2639

## Mobile & Desktop Screenshots/Recordings

Before Fix: 
<img width="744" height="661" alt="mainsail-thumbnail-bug-BEFORE-FIX" src="https://github.com/user-attachments/assets/6208304c-74ea-4d2b-93c8-e38287d26422" />

After Fix:
<img width="748" height="669" alt="mainsail-thumbnail-bug-AFTER-FIX" src="https://github.com/user-attachments/assets/1125649f-0219-4576-8693-12270fbf928b" />


## [optional] Are there any post-deployment tasks we need to perform?

None.

Signed-off-by: Rene Costa <rescosta@yahoo.com.br>

This Pull Request was created with the help of Claude Code.