### PR TITLE
fix(Editor): fix sidebar font color when switching light/dark

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -546,12 +546,15 @@ export default class TheEditor extends Mixins(BaseMixin) {
 ._structure-sidebar-section {
     color: #4ec9b0;
 }
+
 ._structure-sidebar-key {
     color: #569cd6;
 }
+
 html.theme--light ._structure-sidebar-section {
     color: #267f99;
 }
+
 html.theme--light ._structure-sidebar-key {
     color: #0000ff;
 }

--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -75,7 +75,9 @@
                             <template #label="{ item }">
                                 <div
                                     class="cursor-pointer _structure-sidebar-item"
-                                    :class="item.type == 'item' ? 'ͼp' : 'ͼt'"
+                                    :class="
+                                        item.type == 'item' ? '_structure-sidebar-key' : '_structure-sidebar-section'
+                                    "
                                     @click="activeChangesItemClick">
                                     {{ item.name }}
                                 </div>
@@ -534,10 +536,24 @@ export default class TheEditor extends Mixins(BaseMixin) {
     overflow-y: auto;
     max-height: calc(100vh - 48px);
 }
+
 ._structure-sidebar-item {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+}
+
+._structure-sidebar-section {
+    color: #4ec9b0;
+}
+._structure-sidebar-key {
+    color: #569cd6;
+}
+html.theme--light ._structure-sidebar-section {
+    color: #267f99;
+}
+html.theme--light ._structure-sidebar-key {
+    color: #0000ff;
 }
 
 ::v-deep .v-treeview-node__level + .v-treeview-node__level {


### PR DESCRIPTION
## Description

This PR fix the font from the editor sidebar structure tree, when you switch to light/dark mode with "hardcoded" classes instead of using the codemirror highlighting colors.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
