### PR TITLE
fix(docker): prevent unprivileged from overwriting latest tag

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
+          tags: &tags |
             type=edge,branch=develop
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -74,13 +74,7 @@ jobs:
           flavor: |
             suffix=-unprivileged
             latest=false
-          tags: |
-            type=edge,branch=develop
-            type=semver,pattern=v{{major}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
-            type=sha
-            type=raw,value=latest-unprivileged,enable=${{ github.event_name == 'release' }}
+          tags: *tags
 
       - name: Build and push unprivileged Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -13,6 +13,7 @@ on:
       - '.docker/**'
       - '.dockerignore'
       - 'Dockerfile'
+      - '.github/workflows/publish_docker.yml'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: &tags |
+          tags: |
             type=edge,branch=develop
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -72,7 +72,14 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-unprivileged
-          tags: *tags
+            latest=false
+          tags: |
+            type=edge,branch=develop
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=sha
+            type=raw,value=latest-unprivileged,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push unprivileged Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,13 +52,13 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for unprivileged Docker
         id: meta-unprivileged
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -83,7 +83,7 @@ jobs:
             type=raw,value=latest-unprivileged,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push unprivileged Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Description

This PR fixes (again) the tags for the mainsail docker. Right now, both images (normal and unprivileged) uses the same tags, which result, that the unprivileged image, overwrite the latest tag. so the unprivileged image will be used with the latest tag, instead of the "normal" one.

I also updated all github actions + added the publish_docker.yml file to the pr trigger files.

## Related Tickets & Documents

- fixes a issue in the docs repo: https://github.com/mainsail-crew/docs/issues/59

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
