### PR TITLE
fix(gcodefiles): use extruder_colors from PrusaSlicer for colors

### DIFF
--- a/src/components/dialogs/MmuEditTtgMapDialogDetails.vue
+++ b/src/components/dialogs/MmuEditTtgMapDialogDetails.vue
@@ -67,7 +67,7 @@ import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { GATE_UNKNOWN, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
 import { FileStateGcodefile } from '@/store/files/types'
 import Vue from 'vue'
-import { colorsMatch, convertStringToArray } from '@/plugins/helpers'
+import { colorsMatch, convertStringToArray, getFileFilamentColors } from '@/plugins/helpers'
 
 @Component
 export default class MmuEditTtgMapDialogDetails extends Mixins(BaseMixin, MmuMixin) {
@@ -92,10 +92,8 @@ export default class MmuEditTtgMapDialogDetails extends Mixins(BaseMixin, MmuMix
     }
 
     get fileFilamentColor() {
-        let colors = this.file?.extruder_colors ?? []
-        if (['BambuStudio', 'OrcaSlicer'].includes(this.file?.slicer ?? '')) {
-            colors = this.file?.filament_colors ?? []
-        }
+        if (!this.file) return ''
+        const colors = getFileFilamentColors(this.file)
 
         return this.formColorString(colors[this.tool] ?? '')
     }

--- a/src/components/dialogs/StartPrintDialogAfcTool.vue
+++ b/src/components/dialogs/StartPrintDialogAfcTool.vue
@@ -44,7 +44,7 @@ import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile } from '@/store/files/types'
 import AfcMixin from '@/components/mixins/afc'
 import { mdiAlert, mdiCheckCircle, mdiChevronDown } from '@mdi/js'
-import { convertStringToArray, filamentWeightFormat } from '@/plugins/helpers'
+import { convertStringToArray, filamentWeightFormat, getFileFilamentColors } from '@/plugins/helpers'
 
 @Component
 export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
@@ -61,7 +61,7 @@ export default class StartPrintDialogAfc extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get fileFilament() {
-        const fileColors = this.file.filament_colors ?? []
+        const fileColors = getFileFilamentColors(this.file)
         const fileNames = convertStringToArray(this.file.filament_name ?? '')
         const fileTypes = convertStringToArray(this.file.filament_type ?? '')
         const fileWeights = this.file.filament_weights ?? []

--- a/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFileMetadataFilaments.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFileMetadataFilaments.vue
@@ -12,14 +12,14 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile, FileStateGcodefileFilament } from '@/store/files/types'
-import { convertStringToArray } from '@/plugins/helpers'
+import { convertStringToArray, getFileFilamentColors } from '@/plugins/helpers'
 
 @Component
 export default class GcodefilesPanelTableRowFileMetadataFilaments extends Mixins(BaseMixin) {
     @Prop({ type: Object, required: true }) readonly item!: FileStateGcodefile
 
     get filament_colors() {
-        return this.item.filament_colors ?? []
+        return getFileFilamentColors(this.item)
     }
 
     get filament_types() {

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -1,4 +1,4 @@
-import { FileStateFile } from '@/store/files/types'
+import { FileStateFile, FileStateGcodefile } from '@/store/files/types'
 import { PrinterStateMacroParams } from '@/store/printer/types'
 import {
     mdiAlertOutline,
@@ -593,4 +593,25 @@ export function generateTimestamp(date: Date = new Date()): string {
     const timeString = `${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
 
     return `${dateString}-${timeString}`
+}
+
+/**
+ * Returns the filament colors of a G-code file, preferring `extruder_colors` over `filament_colors`.
+ *
+ * Moonraker extracts both arrays from the slicer config block (`extruder_colour` / `filament_colour`),
+ * but their meaning differs between slicers:
+ * - PrusaSlicer (and forks): `extruder_colour` is the per-slot color the user selected in the project,
+ *   `filament_colour` is only the default color of the filament preset. `extruder_colour` is the correct one.
+ * - OrcaSlicer: writes `extruder_colour` with the value of `filament_colour`, so both are identical.
+ * - BambuStudio (and older OrcaSlicer versions): `extruder_colour` is missing or empty,
+ *   `filament_colour` is the only source.
+ *
+ * @param file - The G-code file object containing `filament_colors` and/or `extruder_colors`.
+ * @returns Array of color strings (hex format, e.g. `#FF3232`), one per tool/slot. Empty if none are available.
+ */
+export function getFileFilamentColors(file: FileStateGcodefile): string[] {
+    const extruder = file.extruder_colors ?? []
+    if (extruder.length) return extruder
+
+    return file.filament_colors ?? []
 }


### PR DESCRIPTION
## Description

This PR fixes the filament colors for PrusaSlicer gcode files on all position. I added a helper function and used it in the Gcodefiles (list), AFC + HappyHare start print dialog.

**Context to this helper function:**
Older OrcaSlicer + BambuSlicer didnt use the `extruder_colour` in the gcode metadata. Newer OrcaSlicer copy the `filament_colours` to `filament_colours` and PrusaSlicer use `extruder_colours` for the color you use in the slicing gui and `filament_colours` for the filament preset color.
Another importent info: in the gcode metadata the name `colours` will be used, but Moonraker use `colors`... The topic is not complicated enough /s

## Related Tickets & Documents

fixes #2610 

## Mobile & Desktop Screenshots/Recordings
Before:
<img width="1368" height="671" alt="Bildschirmfoto 2026-09-06 um 16 15 04" src="https://github.com/user-attachments/assets/3a60caf7-2bb0-4d04-88f6-f9f443d44644" />

After:
<img width="1384" height="677" alt="Bildschirmfoto 2026-09-06 um 16 15 31" src="https://github.com/user-attachments/assets/c76eda6f-9f6c-452d-9b37-399f78ef2b7a" />

## [optional] Are there any post-deployment tasks we need to perform?

none
