### PR TITLE
feat(docker): add /healthz endpoint in docker image

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -8,5 +8,11 @@ server {
     try_files $uri $uri/ /index.html =404;
   }
 
+  location = /healthz {
+    access_log off;
+    default_type text/plain;
+    return 200 "ok\n";
+  }
+
   include /etc/nginx/extra-conf.d/*.conf;
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY --link --from=builder /app/.docker/nginx.conf.unprivileged  /etc/nginx/conf
 COPY --link --from=builder /app/dist/ /usr/share/nginx/html/
 USER nginx
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/healthz >/dev/null || exit 1
+
 #
 # Runner stage, runs the application in nginx
 #
@@ -37,3 +40,6 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /app/.docker/nginx.conf  /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist/ /usr/share/nginx/html/
 COPY --chmod=755 --from=builder /app/.docker/00-remove-ipv6-if-unavailable.sh /docker-entrypoint.d/
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/healthz >/dev/null || exit 1


### PR DESCRIPTION
## Description

This PR adds a /healthz endpoint in the docker image and a built-in HEALTHCHECK.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

- PR for the docs: https://github.com/mainsail-crew/docs/pull/60
